### PR TITLE
Class recreation without class loader invocation

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -61,7 +61,7 @@ class OopMapBlocksBuilder : public ResourceObj {
   OopMapBlock* last_oop_map() const;
   void initialize_inherited_blocks(OopMapBlock* blocks, unsigned int nof_blocks);
   void add(int offset, int count);
-  void copy(OopMapBlock* dst);
+  void copy(OopMapBlock* dst) const;
   void compact();
   void print_on(outputStream* st) const;
   void print_value_on(outputStream* st) const;
@@ -547,29 +547,16 @@ class ClassFileParser {
 
   void set_klass_to_deallocate(InstanceKlass* klass);
 
-  int static_field_size() const;
-  int total_oop_map_count() const;
-  jint layout_size() const;
-
-  int vtable_size() const { return _vtable_size; }
-  int itable_size() const { return _itable_size; }
-
   u2 this_class_index() const { return _this_class_index; }
 
-  bool is_hidden() const { return _is_hidden; }
-  bool is_interface() const { return _access_flags.is_interface(); }
-
-  ClassLoaderData* loader_data() const { return _loader_data; }
-  const Symbol* class_name() const { return _class_name; }
-  const InstanceKlass* super_klass() const { return _super_klass; }
-
-  ReferenceType super_reference_type() const;
-  bool is_instance_ref_klass() const;
-  bool is_java_lang_ref_Reference_subclass() const;
-
-  AccessFlags access_flags() const { return _access_flags; }
-
   bool is_internal() const { return INTERNAL == _pub_level; }
+
+  static Array<InstanceKlass*>* compute_transitive_interfaces(const InstanceKlass* super,
+                                                              Array<InstanceKlass*>* local_ifs,
+                                                              ClassLoaderData* loader_data,
+                                                              TRAPS);
+  static void check_methods_for_intrinsics(const InstanceKlass* ik);
+  static void check_can_allocate_fast(InstanceKlass* ik);
 
   static bool verify_unqualified_name(const char* name, unsigned int length, int type);
 

--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -206,7 +206,11 @@ void Dictionary::all_entries_do(KlassClosure* closure) {
     return true;
   };
 
-  _table->do_scan(Thread::current(), all_doit);
+  if (SafepointSynchronize::is_at_safepoint()) {
+    _table->do_safepoint_scan(all_doit);
+  } else {
+    _table->do_scan(Thread::current(), all_doit);
+  }
 }
 
 // Used to scan and relocate the classes during CDS archive dump.
@@ -219,6 +223,11 @@ void Dictionary::classes_do(MetaspaceClosure* it) {
     return true;
   };
   _table->do_scan(Thread::current(), push);
+}
+
+int Dictionary::number_of_entries() const {
+  assert_locked_or_safepoint(SystemDictionary_lock);
+  return _number_of_entries;
 }
 
 class DictionaryLookup : StackObj {

--- a/src/hotspot/share/classfile/dictionary.hpp
+++ b/src/hotspot/share/classfile/dictionary.hpp
@@ -73,6 +73,8 @@ public:
   void all_entries_do(KlassClosure* closure);
   void classes_do(MetaspaceClosure* it);
 
+  int number_of_entries() const;
+
   void clean_cached_protection_domains(GrowableArray<ProtectionDomainEntry*>* delete_list);
 
   // Protection domains

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.cpp
@@ -105,7 +105,7 @@ void FieldGroup::sort_by_size() {
   }
 }
 
-FieldLayout::FieldLayout(GrowableArray<FieldInfo>* field_info, ConstantPool* cp) :
+FieldLayout::FieldLayout(GrowableArrayView<FieldInfo>* field_info, ConstantPool* cp) :
   _field_info(field_info),
   _cp(cp),
   _blocks(nullptr),
@@ -499,7 +499,7 @@ void FieldLayout::print(outputStream* output, bool is_static, const InstanceKlas
 }
 
 FieldLayoutBuilder::FieldLayoutBuilder(const Symbol* classname, const InstanceKlass* super_klass, ConstantPool* constant_pool,
-      GrowableArray<FieldInfo>* field_info, bool is_contended, FieldLayoutInfo* info) :
+      GrowableArrayView<FieldInfo>* field_info, bool is_contended, FieldLayoutInfo* info) :
   _classname(classname),
   _super_klass(super_klass),
   _constant_pool(constant_pool),

--- a/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
+++ b/src/hotspot/share/classfile/fieldLayoutBuilder.hpp
@@ -164,14 +164,14 @@ class FieldGroup : public ResourceObj {
 //
 class FieldLayout : public ResourceObj {
  private:
-  GrowableArray<FieldInfo>* _field_info;
+  GrowableArrayView<FieldInfo>* _field_info;
   ConstantPool* _cp;
   LayoutRawBlock* _blocks;  // the layout being computed
   LayoutRawBlock* _start;   // points to the first block where a field can be inserted
   LayoutRawBlock* _last;    // points to the last block of the layout (big empty block)
 
  public:
-  FieldLayout(GrowableArray<FieldInfo>* field_info, ConstantPool* cp);
+  FieldLayout(GrowableArrayView<FieldInfo>* field_info, ConstantPool* cp);
   void initialize_static_layout();
   void initialize_instance_layout(const InstanceKlass* ik);
 
@@ -230,7 +230,7 @@ class FieldLayoutBuilder : public ResourceObj {
   const Symbol* _classname;
   const InstanceKlass* _super_klass;
   ConstantPool* _constant_pool;
-  GrowableArray<FieldInfo>* _field_info;
+  GrowableArrayView<FieldInfo>* _field_info;
   FieldLayoutInfo* _info;
   FieldGroup* _root_group;
   GrowableArray<FieldGroup*> _contended_groups;
@@ -244,7 +244,7 @@ class FieldLayoutBuilder : public ResourceObj {
 
  public:
   FieldLayoutBuilder(const Symbol* classname, const InstanceKlass* super_klass, ConstantPool* constant_pool,
-                     GrowableArray<FieldInfo>* field_info, bool is_contended, FieldLayoutInfo* info);
+                     GrowableArrayView<FieldInfo>* field_info, bool is_contended, FieldLayoutInfo* info);
 
   int get_alignment() {
     assert(_alignment != -1, "Uninitialized");

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -915,7 +915,10 @@ void java_lang_Class::initialize_mirror_fields(Klass* k,
   set_protection_domain(mirror(), protection_domain());
 
   // Initialize static fields
-  InstanceKlass::cast(k)->do_local_static_fields(&initialize_static_field, mirror, CHECK);
+  InstanceKlass* ik = InstanceKlass::cast(k);
+  if (!ik->is_being_restored()) { // No need to initialize if going to be restored
+    ik->do_local_static_fields(&initialize_static_field, mirror, CHECK);
+  }
 
  // Set classData
   set_class_data(mirror(), classData());
@@ -4647,6 +4650,36 @@ oop java_lang_ClassLoader::non_reflection_class_loader(oop loader) {
 oop java_lang_ClassLoader::unnamedModule(oop loader) {
   assert(is_instance(loader), "loader must be oop");
   return loader->obj_field(_unnamedModule_offset);
+}
+
+void java_lang_ClassLoader::set_parent(oop loader, oop value) {
+  assert(is_instance(loader), "loader must be oop");
+  assert(loader->obj_field(_parent_offset) == nullptr, "should not overwrite");
+  loader->obj_field_put(_parent_offset, value);
+}
+
+void java_lang_ClassLoader::set_parallelLockMap(oop loader, oop value) {
+  assert(is_instance(loader), "loader must be oop");
+  assert(loader->obj_field(_parallelCapable_offset) == nullptr, "should not overwrite");
+  loader->obj_field_put(_parallelCapable_offset, value);
+}
+
+void java_lang_ClassLoader::set_name(oop loader, oop value) {
+  assert(is_instance(loader), "loader must be oop");
+  assert(loader->obj_field(_name_offset) == nullptr, "should not overwrite");
+  loader->obj_field_put(_name_offset, value);
+}
+
+void java_lang_ClassLoader::set_nameAndId(oop loader, oop value) {
+  assert(is_instance(loader), "loader must be oop");
+  assert(loader->obj_field(_nameAndId_offset) == nullptr, "should not overwrite");
+  loader->obj_field_put(_nameAndId_offset, value);
+}
+
+void java_lang_ClassLoader::set_unnamedModule(oop loader, oop value) {
+  assert(is_instance(loader), "loader must be oop");
+  assert(loader->obj_field(_unnamedModule_offset) == nullptr, "should not overwrite");
+  loader->obj_field_put(_unnamedModule_offset, value);
 }
 
 // Support for java_lang_System

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1500,6 +1500,15 @@ class java_lang_ClassLoader : AllStatic {
 
   // Debugging
   friend class JavaClasses;
+
+  // Class loader restoration
+  friend class CracHeapRestorer;
+ private:
+  static void set_parent(oop loader, oop value);
+  static void set_parallelLockMap(oop loader, oop value);
+  static void set_name(oop loader, oop value);
+  static void set_nameAndId(oop loader, oop value);
+  static void set_unnamedModule(oop loader, oop value);
 };
 
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -139,6 +139,11 @@ class SystemDictionary : AllStatic {
                                             const ClassLoadInfo& cl_info,
                                             TRAPS);
 
+  // Defines a class being restored using its defining class loader.
+  static void define_recreated_instance_class(InstanceKlass* recreated_class, TRAPS);
+
+  static void record_initiating_loader(InstanceKlass* loaded_class, Handle class_loader, TRAPS);
+
   // Lookup an already loaded class. If not found null is returned.
   static InstanceKlass* find_instance_klass(Thread* current, Symbol* class_name,
                                             Handle class_loader, Handle protection_domain);

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -139,11 +139,6 @@ class SystemDictionary : AllStatic {
                                             const ClassLoadInfo& cl_info,
                                             TRAPS);
 
-  // Defines a class being restored using its defining class loader.
-  static void define_recreated_instance_class(InstanceKlass* recreated_class, TRAPS);
-
-  static void record_initiating_loader(InstanceKlass* loaded_class, Handle class_loader, TRAPS);
-
   // Lookup an already loaded class. If not found null is returned.
   static InstanceKlass* find_instance_klass(Thread* current, Symbol* class_name,
                                             Handle class_loader, Handle protection_domain);
@@ -179,6 +174,14 @@ class SystemDictionary : AllStatic {
   static Klass* find_constrained_instance_or_array_klass(Thread* current,
                                                          Symbol* class_name,
                                                          Handle class_loader);
+
+  // Portable CRaC support: finds a class with the same name and class loader or
+  // defines the provided class. Returns the defined class, deallocating the
+  // provided one if it was not defined.
+  static InstanceKlass* find_or_define_recreated_class(InstanceKlass* k, TRAPS);
+
+  // Records the non-defining class loader as an initiating loader of the class.
+  static void record_initiating_loader(InstanceKlass* loaded_class, Handle class_loader, TRAPS);
 
   static void classes_do(MetaspaceClosure* it);
   // Iterate over all methods in all klasses
@@ -307,10 +310,10 @@ private:
   static Klass* resolve_array_class_or_null(Symbol* class_name,
                                             Handle class_loader,
                                             Handle protection_domain, TRAPS);
-  static void define_instance_class(InstanceKlass* k, Handle class_loader, TRAPS);
+  static void define_instance_class(InstanceKlass* k, Handle class_loader, bool publicize, TRAPS);
   static InstanceKlass* find_or_define_helper(Symbol* class_name,
                                               Handle class_loader,
-                                              InstanceKlass* k, TRAPS);
+                                              InstanceKlass* k, bool restoration, TRAPS);
   static InstanceKlass* load_instance_class_impl(Symbol* class_name, Handle class_loader, TRAPS);
   static InstanceKlass* load_instance_class(Symbol* class_name,
                                             Handle class_loader, TRAPS);

--- a/src/hotspot/share/classfile/systemDictionaryShared.cpp
+++ b/src/hotspot/share/classfile/systemDictionaryShared.cpp
@@ -1447,7 +1447,8 @@ class CleanupDumpTimeLambdaProxyClassTable: StackObj {
   bool do_entry(LambdaProxyClassKey& key, DumpTimeLambdaProxyClassInfo& info) {
     assert_lock_strong(DumpTimeTable_lock);
     InstanceKlass* caller_ik = key.caller_ik();
-    InstanceKlass* nest_host = caller_ik->nest_host_not_null();
+    InstanceKlass* nest_host = caller_ik->nest_host_noresolve();
+    assert(nest_host != nullptr, "must be");
 
     // If the caller class and/or nest_host are excluded, the associated lambda proxy
     // must also be excluded.

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -530,6 +530,9 @@ class SerializeClosure;
   template(jvmti_is_in_VTMS_transition_name,          "jvmti_is_in_VTMS_transition")              \
   template(module_entry_name,                         "module_entry")                             \
   template(resolved_references_name,                  "<resolved_references>")                    \
+  template(internal_name_name,                        "<name>")                                   \
+  template(internal_signature_name,                   "<signature>")                              \
+  template(internal_kind_name,                        "<kind>")                                   \
   template(init_lock_name,                            "<init_lock>")                              \
   template(address_size_name,                         "ADDRESS_SIZE0")                            \
   template(page_size_name,                            "PAGE_SIZE")                                \

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1883,3 +1883,11 @@ void LinkResolver::throw_abstract_method_error(const methodHandle& resolved_meth
 
   THROW_MSG(vmSymbols::java_lang_AbstractMethodError(), ss.as_string());
 }
+
+Method* LinkResolver::resolve_intrinsic_polymorphic_method(Klass *klass, Symbol *name, Symbol *signature, TRAPS) {
+  precond(MethodHandles::is_signature_polymorphic_intrinsic_name(klass, name));
+  const LinkInfo link_info(klass, name, signature);
+  Method* const result = lookup_polymorphic_method(link_info, nullptr, CHECK_NULL);
+  postcond(result != nullptr);
+  return result;
+}

--- a/src/hotspot/share/interpreter/linkResolver.hpp
+++ b/src/hotspot/share/interpreter/linkResolver.hpp
@@ -357,5 +357,10 @@ class LinkResolver: AllStatic {
   static void throw_abstract_method_error(const methodHandle& resolved_method,
                                           const methodHandle& selected_method,
                                           Klass *recv_klass, TRAPS);
+
+  // Portable CRaC support: handle signature polymorphic resolution cases that
+  // does not require calling into Java, omit JFR events
+  static Method* resolve_intrinsic_polymorphic_method(Klass* klass, Symbol* name,
+                                                      Symbol* signature, TRAPS);
 };
 #endif // SHARE_INTERPRETER_LINKRESOLVER_HPP

--- a/src/hotspot/share/logging/logSelectionList.hpp
+++ b/src/hotspot/share/logging/logSelectionList.hpp
@@ -37,7 +37,7 @@ class LogTagSet;
 // Consists of ordered LogSelections, i.e. "tag1+tag2=level1,tag3*=level2".
 class LogSelectionList : public StackObj {
  public:
-  static const size_t MaxSelections = 256;
+  static const size_t MaxSelections = 300;
 
  private:
   friend void LogConfiguration::configure_stdout(LogLevelType, int, ...);

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -92,7 +92,6 @@ class outputStream;
   LOG_TAG(hashtables) \
   LOG_TAG(heap) \
   LOG_TAG(heapdump) \
-  LOG_TAG(heapdumpparsing) \
   NOT_PRODUCT(LOG_TAG(heapsampling)) \
   LOG_TAG(humongous) \
   LOG_TAG(ihop) \
@@ -169,7 +168,6 @@ class outputStream;
   LOG_TAG(reloc) \
   LOG_TAG(remset) \
   LOG_TAG(resolve) \
-  LOG_TAG(restore) \
   LOG_TAG(safepoint) \
   LOG_TAG(sampling) \
   LOG_TAG(scavenge) \
@@ -177,8 +175,6 @@ class outputStream;
   LOG_TAG(setting) \
   LOG_TAG(smr) \
   LOG_TAG(stackbarrier) \
-  LOG_TAG(stackdump) \
-  LOG_TAG(stackdumpparsing) \
   LOG_TAG(stackmap) \
   LOG_TAG(stacktrace) \
   LOG_TAG(stackwalk) \

--- a/src/hotspot/share/oops/constMethod.hpp
+++ b/src/hotspot/share/oops/constMethod.hpp
@@ -230,6 +230,7 @@ public:
   void set_inlined_tables_length(InlineTableSizes* sizes);
 
   // Create getters and setters for the flag values.
+  int flags() const { return _flags.as_int(); }
 #define CM_FLAGS_GET_SET(name, ignore)          \
   bool name() const       { return _flags.name(); } \
   void set_##name()       { _flags.set_##name(); }

--- a/src/hotspot/share/oops/constMethodFlags.hpp
+++ b/src/hotspot/share/oops/constMethodFlags.hpp
@@ -72,6 +72,7 @@ class ConstMethodFlags {
  public:
 
   ConstMethodFlags() : _flags(0) {}
+  explicit ConstMethodFlags(int flags) : _flags(flags) {}
 
   // Create getters and setters for the flag values.
 #define CM_FLAGS_GET_SET(name, ignore)          \

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -82,6 +82,7 @@ class ConstantPool : public Metadata {
   friend class BytecodeInterpreter;  // Directly extracts a klass in the pool for fast instanceof/checkcast
   friend class Universe;             // For null constructor
   friend class ClassPrelinker;       // CDS
+  friend class CracInstanceClassDumpParser;
  private:
   // If you add a new field that points to any metaspace object, you
   // must add this field to ConstantPool::metaspace_pointers_do().

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -278,6 +278,8 @@ class ConstantPool : public Metadata {
 
   // Hidden class support:
   void klass_at_put(int class_index, Klass* k);
+  // Portable CRaC support:
+  Klass* klass_at_put_and_get(int class_index, Klass* k);
 
   void unresolved_klass_at_put(int cp_index, int name_index, int resolved_klass_index) {
     release_tag_at_put(cp_index, JVM_CONSTANT_UnresolvedClass);

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -699,7 +699,7 @@ ConstantPoolCache* ConstantPoolCache::allocate_uninitialized(ClassLoaderData* lo
   // Allocate resolved entry arrays leaving them uninitialized
   Array<ResolvedFieldEntry>* resolved_field_entries = resolved_field_entries_length == 0 ? nullptr
           : MetadataFactory::new_array<ResolvedFieldEntry>(loader_data, resolved_field_entries_length, CHECK_NULL);
-  Array<ResolvedIndyEntry>* resolved_indy_entries = resolved_field_entries_length == 0 ? nullptr
+  Array<ResolvedIndyEntry>* resolved_indy_entries = resolved_indy_entries_length == 0 ? nullptr
           : MetadataFactory::new_array<ResolvedIndyEntry>(loader_data, resolved_indy_entries_length, CHECK_NULL);
 
   return new (loader_data, size, MetaspaceObj::ConstantPoolCacheType, THREAD)

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -689,6 +689,23 @@ void ConstantPoolCache::initialize(const intArray& inverse_index_map,
   }
 }
 
+ConstantPoolCache* ConstantPoolCache::allocate_uninitialized(ClassLoaderData* loader_data,
+                                                             int length,
+                                                             int resolved_indy_entries_length,
+                                                             int resolved_field_entries_length,
+                                                             TRAPS) {
+  const int size = ConstantPoolCache::size(length);
+
+  // Allocate resolved entry arrays leaving them uninitialized
+  Array<ResolvedFieldEntry>* resolved_field_entries = resolved_field_entries_length == 0 ? nullptr
+          : MetadataFactory::new_array<ResolvedFieldEntry>(loader_data, resolved_field_entries_length, CHECK_NULL);
+  Array<ResolvedIndyEntry>* resolved_indy_entries = resolved_field_entries_length == 0 ? nullptr
+          : MetadataFactory::new_array<ResolvedIndyEntry>(loader_data, resolved_indy_entries_length, CHECK_NULL);
+
+  return new (loader_data, size, MetaspaceObj::ConstantPoolCacheType, THREAD)
+              ConstantPoolCache(length, resolved_indy_entries, resolved_field_entries);
+}
+
 // Record the GC marking cycle when redefined vs. when found in the loom stack chunks.
 void ConstantPoolCache::record_gc_epoch() {
   _gc_epoch = CodeCache::gc_epoch();

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -325,6 +325,7 @@ class ConstantPoolCacheEntry {
   // of _f1 must be ordered with the loads performed by
   // cache->main_entry_index().
   bool      is_f1_null() const;  // classifies a CPC entry as unbound
+  intx      f2_ord() const                       { return _f2; }
   int       f2_as_index() const                  { assert(!is_vfinal(), ""); return (int) _f2; }
   Method*   f2_as_vfinal_method() const          { assert(is_vfinal(), ""); return (Method*)_f2; }
   Method*   f2_as_interface_method() const;

--- a/src/hotspot/share/oops/cpCache.hpp
+++ b/src/hotspot/share/oops/cpCache.hpp
@@ -135,6 +135,8 @@ class ConstantPoolCacheEntry {
   friend class VMStructs;
   friend class ConstantPool;
   friend class InterpreterRuntime;
+  friend class CracInstanceClassDumpParser;
+  friend struct CracClassStateRestorer;
 
  private:
   volatile intx     _indices;  // constant pool index & rewrite bytecodes
@@ -421,6 +423,11 @@ class ConstantPoolCache: public MetaspaceObj {
                     const intStack& invokedynamic_references_map,
                     Array<ResolvedIndyEntry>* indy_info,
                     Array<ResolvedFieldEntry>* field_entries);
+  ConstantPoolCache(int length,
+                    Array<ResolvedIndyEntry>* indy_entries,
+                    Array<ResolvedFieldEntry>* field_entries) :
+                    _length(length), _constant_pool(nullptr), _gc_epoch(0),
+                    _resolved_indy_entries(indy_entries), _resolved_field_entries(field_entries) {};
 
   // Initialization
   void initialize(const intArray& inverse_index_map,
@@ -432,6 +439,11 @@ class ConstantPoolCache: public MetaspaceObj {
                                      const GrowableArray<ResolvedIndyEntry> indy_entries,
                                      const GrowableArray<ResolvedFieldEntry> field_entries,
                                      TRAPS);
+  static ConstantPoolCache* allocate_uninitialized(ClassLoaderData* loader_data,
+                                                   int length,
+                                                   int resolved_indy_entries_length,
+                                                   int resolved_field_entries_length,
+                                                   TRAPS);
 
   int length() const                      { return _length; }
   void metaspace_pointers_do(MetaspaceClosure* it);

--- a/src/hotspot/share/oops/cpCache.inline.hpp
+++ b/src/hotspot/share/oops/cpCache.inline.hpp
@@ -115,7 +115,7 @@ inline ResolvedFieldEntry* ConstantPoolCache::resolved_field_entry_at(int field_
 }
 
 inline int ConstantPoolCache::resolved_field_entries_length() const {
-  return _resolved_field_entries->length();
+  return _resolved_field_entries != nullptr ? _resolved_field_entries->length() : 0;
 }
 
 inline ResolvedIndyEntry* ConstantPoolCache::resolved_indy_entry_at(int index) const {
@@ -123,6 +123,6 @@ inline ResolvedIndyEntry* ConstantPoolCache::resolved_indy_entry_at(int index) c
 }
 
 inline int ConstantPoolCache::resolved_indy_entries_length() const {
-  return _resolved_indy_entries->length();
+  return _resolved_indy_entries != nullptr ? _resolved_indy_entries->length() : 0;
 }
 #endif // SHARE_OOPS_CPCACHE_INLINE_HPP

--- a/src/hotspot/share/oops/fieldInfo.cpp
+++ b/src/hotspot/share/oops/fieldInfo.cpp
@@ -48,7 +48,7 @@ void FieldInfo::print_from_growable_array(outputStream* os, GrowableArray<FieldI
   }
 }
 
-Array<u1>* FieldInfoStream::create_FieldInfoStream(GrowableArray<FieldInfo>* fields, int java_fields, int injected_fields,
+Array<u1>* FieldInfoStream::create_FieldInfoStream(GrowableArrayView<FieldInfo>* fields, int java_fields, int injected_fields,
                                                           ClassLoaderData* loader_data, TRAPS) {
   // The stream format described in fieldInfo.hpp is:
   //   FieldInfoStream := j=num_java_fields k=num_injected_fields Field[j+k] End

--- a/src/hotspot/share/oops/fieldInfo.hpp
+++ b/src/hotspot/share/oops/fieldInfo.hpp
@@ -27,6 +27,7 @@
 
 #include "memory/allocation.hpp"
 #include "oops/typeArrayOop.hpp"
+#include "utilities/growableArray.hpp"
 #include "utilities/unsigned5.hpp"
 #include "utilities/vmEnums.hpp"
 
@@ -275,7 +276,7 @@ class FieldInfoStream : AllStatic {
   static int num_injected_java_fields(const Array<u1>* fis);
   static int num_total_fields(const Array<u1>* fis);
 
-  static Array<u1>* create_FieldInfoStream(GrowableArray<FieldInfo>* fields, int java_fields, int injected_fields,
+  static Array<u1>* create_FieldInfoStream(GrowableArrayView<FieldInfo>* fields, int java_fields, int injected_fields,
                                                           ClassLoaderData* loader_data, TRAPS);
   static GrowableArray<FieldInfo>* create_FieldInfoArray(const Array<u1>* fis, int* java_fields_count, int* injected_fields_count);
   static void print_from_fieldinfo_stream(Array<u1>* fis, outputStream* os, ConstantPool* cp);

--- a/src/hotspot/share/oops/instanceClassLoaderKlass.hpp
+++ b/src/hotspot/share/oops/instanceClassLoaderKlass.hpp
@@ -26,9 +26,8 @@
 #define SHARE_OOPS_INSTANCECLASSLOADERKLASS_HPP
 
 #include "oops/instanceKlass.hpp"
+#include "utilities/accessFlags.hpp"
 #include "utilities/macros.hpp"
-
-class ClassFileParser;
 
 // An InstanceClassLoaderKlass is a specialization of the InstanceKlass. It does
 // not add any field.  It is added to walk the dependencies for the class loader
@@ -43,7 +42,8 @@ public:
   static const KlassKind Kind = InstanceClassLoaderKlassKind;
 
 private:
-  InstanceClassLoaderKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
+  InstanceClassLoaderKlass(AccessFlags access_flags, const InstanceKlassSizes& sizes)
+      : InstanceKlass(access_flags, sizes, Kind) {}
 
 public:
   InstanceClassLoaderKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -148,7 +148,7 @@
 bool InstanceKlass::_finalization_enabled = true;
 
 static inline bool is_class_loader(const Symbol* class_name,
-                                   const ClassFileParser& parser) {
+                                   const Klass* super_klass) {
   assert(class_name != nullptr, "invariant");
 
   if (class_name == vmSymbols::java_lang_ClassLoader()) {
@@ -156,7 +156,6 @@ static inline bool is_class_loader(const Symbol* class_name,
   }
 
   if (vmClasses::ClassLoader_klass_loaded()) {
-    const Klass* const super_klass = parser.super_klass();
     if (super_klass != nullptr) {
       if (super_klass->is_subtype_of(vmClasses::ClassLoader_klass())) {
         return true;
@@ -434,35 +433,38 @@ const char* InstanceKlass::nest_host_error() {
   }
 }
 
-InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& parser, TRAPS) {
-  const int size = InstanceKlass::size(parser.vtable_size(),
-                                       parser.itable_size(),
-                                       nonstatic_oop_map_size(parser.total_oop_map_count()),
-                                       parser.is_interface());
-
-  const Symbol* const class_name = parser.class_name();
-  assert(class_name != nullptr, "invariant");
-  ClassLoaderData* loader_data = parser.loader_data();
+InstanceKlass* InstanceKlass::allocate_instance_klass(ClassLoaderData* loader_data,
+                                                      const Symbol* name,
+                                                      const InstanceKlass* super,
+                                                      AccessFlags access_flags,
+                                                      const InstanceKlassSizes& sizes,
+                                                      TRAPS) {
+  const int size = InstanceKlass::size(sizes.vtable_size,
+                                       sizes.itable_size,
+                                       nonstatic_oop_map_size(sizes.total_oop_map_count),
+                                       access_flags.is_interface());
   assert(loader_data != nullptr, "invariant");
+  assert(name != nullptr, "invariant");
 
   InstanceKlass* ik;
 
   // Allocation
-  if (parser.is_instance_ref_klass()) {
+  const ReferenceType reference_type = InstanceRefKlass::determine_reference_type(super, name);
+  if (reference_type != ReferenceType::REF_NONE) {
     // java.lang.ref.Reference
-    ik = new (loader_data, size, THREAD) InstanceRefKlass(parser);
-  } else if (class_name == vmSymbols::java_lang_Class()) {
+    ik = new (loader_data, size, THREAD) InstanceRefKlass(access_flags, sizes, reference_type);
+  } else if (name == vmSymbols::java_lang_Class()) {
     // mirror - java.lang.Class
-    ik = new (loader_data, size, THREAD) InstanceMirrorKlass(parser);
-  } else if (is_stack_chunk_class(class_name, loader_data)) {
+    ik = new (loader_data, size, THREAD) InstanceMirrorKlass(access_flags, sizes);
+  } else if (is_stack_chunk_class(name, loader_data)) {
     // stack chunk
-    ik = new (loader_data, size, THREAD) InstanceStackChunkKlass(parser);
-  } else if (is_class_loader(class_name, parser)) {
+    ik = new (loader_data, size, THREAD) InstanceStackChunkKlass(access_flags, sizes);
+  } else if (is_class_loader(name, super)) {
     // class loader - java.lang.ClassLoader
-    ik = new (loader_data, size, THREAD) InstanceClassLoaderKlass(parser);
+    ik = new (loader_data, size, THREAD) InstanceClassLoaderKlass(access_flags, sizes);
   } else {
     // normal
-    ik = new (loader_data, size, THREAD) InstanceKlass(parser);
+    ik = new (loader_data, size, THREAD) InstanceKlass(access_flags, sizes);
   }
 
   // Check for pending exception before adding to the loader data and incrementing
@@ -500,30 +502,28 @@ static Monitor* create_init_monitor(const char* name) {
   return new Monitor(Mutex::safepoint, name);
 }
 
-InstanceKlass::InstanceKlass(const ClassFileParser& parser, KlassKind kind, ReferenceType reference_type) :
+InstanceKlass::InstanceKlass(AccessFlags access_flags, const InstanceKlassSizes& sizes, KlassKind kind, ReferenceType reference_type) :
   Klass(kind),
   _nest_members(nullptr),
   _nest_host(nullptr),
   _permitted_subclasses(nullptr),
   _record_components(nullptr),
-  _static_field_size(parser.static_field_size()),
-  _nonstatic_oop_map_size(nonstatic_oop_map_size(parser.total_oop_map_count())),
-  _itable_len(parser.itable_size()),
+  _static_field_size(sizes.static_field_size),
+  _nonstatic_oop_map_size(nonstatic_oop_map_size(sizes.total_oop_map_count)),
+  _itable_len(sizes.itable_size),
   _nest_host_index(0),
   _init_state(allocated),
   _reference_type(reference_type),
   _init_monitor(create_init_monitor("InstanceKlassInitMonitor_lock")),
   _init_thread(nullptr)
 {
-  set_vtable_length(parser.vtable_size());
-  set_access_flags(parser.access_flags());
-  if (parser.is_hidden()) set_is_hidden();
-  set_layout_helper(Klass::instance_layout_helper(parser.layout_size(),
-                                                    false));
+  set_vtable_length(sizes.vtable_size);
+  set_access_flags(access_flags);
+  set_layout_helper(Klass::instance_layout_helper(sizes.layout_size, false));
 
   assert(nullptr == _methods, "underlying memory not zeroed?");
   assert(is_instance_klass(), "is layout incorrect?");
-  assert(size_helper() == parser.layout_size(), "incorrect size_helper?");
+  assert(size_helper() == sizes.layout_size, "incorrect size_helper?");
 }
 
 void InstanceKlass::deallocate_methods(ClassLoaderData* loader_data,
@@ -982,6 +982,17 @@ void InstanceKlass::initialize_super_interfaces(TRAPS) {
 using InitializationErrorTable = ResourceHashtable<const InstanceKlass*, OopHandle, 107, AnyObj::C_HEAP, mtClass>;
 static InitializationErrorTable* _initialization_error_table;
 
+void InstanceKlass::put_initializetion_error(JavaThread* current, Handle init_error) {
+  MutexLocker ml(current, ClassInitError_lock);
+  OopHandle elem = OopHandle(Universe::vm_global(), init_error());
+  bool created;
+  if (_initialization_error_table == nullptr) {
+    _initialization_error_table = new (mtClass) InitializationErrorTable();
+  }
+  _initialization_error_table->put_if_absent(this, elem, &created);
+  assert(created, "Initialization is single threaded");
+}
+
 void InstanceKlass::add_initialization_error(JavaThread* current, Handle exception) {
   // Create the same exception with a message indicating the thread name,
   // and the StackTraceElements.
@@ -1004,19 +1015,21 @@ void InstanceKlass::add_initialization_error(JavaThread* current, Handle excepti
     }
   }
 
-  MutexLocker ml(current, ClassInitError_lock);
-  OopHandle elem = OopHandle(Universe::vm_global(), init_error());
-  bool created;
-  if (_initialization_error_table == nullptr) {
-    _initialization_error_table = new (mtClass) InitializationErrorTable();
-  }
-  _initialization_error_table->put_if_absent(this, elem, &created);
-  assert(created, "Initialization is single threaded");
+  put_initializetion_error(current, init_error);
   log_trace(class, init)("Initialization error added for class %s", external_name());
 }
 
 oop InstanceKlass::get_initialization_error(JavaThread* current) {
   MutexLocker ml(current, ClassInitError_lock);
+  if (_initialization_error_table == nullptr) {
+    return nullptr;
+  }
+  OopHandle* h = _initialization_error_table->get(this);
+  return (h != nullptr) ? h->resolve() : nullptr;
+}
+
+oop InstanceKlass::get_initialization_error() {
+  assert_locked_or_safepoint(ClassInitError_lock);
   if (_initialization_error_table == nullptr) {
     return nullptr;
   }
@@ -2880,7 +2893,12 @@ InstanceKlass* InstanceKlass::get_klass_version(int version) {
   return nullptr;
 }
 
-void InstanceKlass::set_source_debug_extension(const char* array, int length) {
+void InstanceKlass::set_source_debug_extension(const char* array) {
+  precond(_source_debug_extension == nullptr);
+  _source_debug_extension = array;
+}
+
+void InstanceKlass::copy_source_debug_extension(const char* array, int length) {
   if (array == nullptr) {
     _source_debug_extension = nullptr;
   } else {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3590,8 +3590,12 @@ static void print_vtable(vtableEntry* start, int len, outputStream* st) {
   return print_vtable(reinterpret_cast<intptr_t*>(start), len, st);
 }
 
+const char* InstanceKlass::state_name(ClassState state) {
+  return state_names[state];
+}
+
 const char* InstanceKlass::init_state_name() const {
-  return state_names[init_state()];
+  return state_name(init_state());
 }
 
 void InstanceKlass::print_on(outputStream* st) const {

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -556,6 +556,7 @@ public:
   void link_class(TRAPS);
   bool link_class_or_fail(TRAPS); // returns false on failure
   void rewrite_class(TRAPS);
+  void finish_linking(bool check_vtable_constraints, TRAPS);
   void link_methods(TRAPS);
   Method* class_initializer() const;
 
@@ -848,6 +849,7 @@ public:
   // initialization
   void call_class_initializer(TRAPS);
   void set_initialization_state_and_notify(ClassState state, JavaThread* current);
+  void set_linked_to_be_initialized_state_and_notify(JavaThread* current);
 
   // OopMapCache support
   OopMapCache* oop_map_cache()               { return _oop_map_cache; }

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -168,6 +168,7 @@ class InstanceKlass: public Klass {
     fully_initialized,                  // initialized (successful final state)
     initialization_error                // error happened during initialization
   };
+  static const char* state_name(ClassState state);
 
   static InstanceKlass* allocate_instance_klass(ClassLoaderData* loader_data,
                                                 const Symbol* class_name,

--- a/src/hotspot/share/oops/instanceKlassFlags.cpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.cpp
@@ -67,6 +67,20 @@ void InstanceKlassFlags::assign_class_loader_type(const ClassLoaderData* cld) {
     set_shared_class_loader_type(ClassLoader::APP_LOADER);
   }
 }
+
+InstanceKlassFlags InstanceKlassFlags::drop_nonportable_flags() const {
+  // - Clear flags dependent on CDS archive dumping -- they need to be set
+  //   when restoring based on the VM options
+  const u2 cds_bits = shared_loader_type_bits() | _misc_shared_loading_failed;
+  return {checked_cast<u2>(_flags & ~cds_bits), _status};
+}
+
+#else // INCLUDE_CDS
+
+InstanceKlassFlags InstanceKlassFlags::drop_nonportable_flags() const {
+  return *this;
+}
+
 #endif // INCLUDE_CDS
 
 #ifdef ASSERT

--- a/src/hotspot/share/oops/instanceKlassFlags.hpp
+++ b/src/hotspot/share/oops/instanceKlassFlags.hpp
@@ -69,6 +69,7 @@ class InstanceKlassFlags {
     status(has_been_redefined                , 1 << 2) /* class has been redefined */ \
     status(is_scratch_class                  , 1 << 3) /* class is the redefined scratch class */ \
     status(is_marked_dependent               , 1 << 4) /* class is the redefined scratch class */ \
+    status(is_being_restored                 , 1 << 5) /* class is being restored by CRaC */ \
     /* end of list */
 
 #define IK_STATUS_ENUM_NAME(name, value)    _misc_##name = value,
@@ -90,8 +91,10 @@ class InstanceKlassFlags {
  public:
 
   InstanceKlassFlags() : _flags(0), _status(0) {}
+  InstanceKlassFlags(u2 flags, u1 status) : _flags(flags), _status(status) {}
 
   // Create getters and setters for the flag values.
+  u2 flags() const { return _flags; }
 #define IK_FLAGS_GET_SET(name, ignore)          \
   bool name() const { return (_flags & _misc_##name) != 0; } \
   void set_##name(bool b) {         \
@@ -104,13 +107,16 @@ class InstanceKlassFlags {
   bool is_shared_unregistered_class() const {
     return (_flags & shared_loader_type_bits()) == 0;
   }
-
   void set_shared_class_loader_type(s2 loader_type);
-
   void assign_class_loader_type(const ClassLoaderData* cld);
+
+  // Returns a copy with VM-options-depended flags cleared.
+  InstanceKlassFlags drop_nonportable_flags() const;
+
   void assert_is_safe(bool set) NOT_DEBUG_RETURN;
 
   // Create getters and setters for the status values.
+  u1 status() const { return _status; }
 #define IK_STATUS_GET_SET(name, ignore)          \
   bool name() const { return (_status & _misc_##name) != 0; } \
   void set_##name(bool b) {         \

--- a/src/hotspot/share/oops/instanceMirrorKlass.hpp
+++ b/src/hotspot/share/oops/instanceMirrorKlass.hpp
@@ -28,9 +28,8 @@
 #include "classfile/vmClasses.hpp"
 #include "oops/instanceKlass.hpp"
 #include "runtime/handles.hpp"
+#include "utilities/accessFlags.hpp"
 #include "utilities/macros.hpp"
-
-class ClassFileParser;
 
 // An InstanceMirrorKlass is a specialized InstanceKlass for
 // java.lang.Class instances.  These instances are special because
@@ -50,7 +49,8 @@ class InstanceMirrorKlass: public InstanceKlass {
  private:
   static int _offset_of_static_fields;
 
-  InstanceMirrorKlass(const ClassFileParser& parser) : InstanceKlass(parser, Kind) {}
+  InstanceMirrorKlass(AccessFlags access_flags, const InstanceKlassSizes& sizes)
+      : InstanceKlass(access_flags, sizes, Kind) {}
 
  public:
   InstanceMirrorKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceRefKlass.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.hpp
@@ -26,9 +26,8 @@
 #define SHARE_OOPS_INSTANCEREFKLASS_HPP
 
 #include "oops/instanceKlass.hpp"
+#include "utilities/accessFlags.hpp"
 #include "utilities/macros.hpp"
-
-class ClassFileParser;
 
 // An InstanceRefKlass is a specialized InstanceKlass for Java
 // classes that are subclasses of java/lang/ref/Reference.
@@ -52,8 +51,11 @@ class InstanceRefKlass: public InstanceKlass {
  public:
   static const KlassKind Kind = InstanceRefKlassKind;
 
+  static ReferenceType determine_reference_type(const InstanceKlass* super_class, const Symbol* class_name);
+
  private:
-  InstanceRefKlass(const ClassFileParser& parser);
+  InstanceRefKlass(AccessFlags access_flags, const InstanceKlassSizes& sizes, ReferenceType reference_type)
+      : InstanceKlass(access_flags, sizes, Kind, reference_type) {};
 
  public:
   InstanceRefKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -51,8 +51,8 @@ void InstanceStackChunkKlass::serialize_offsets(SerializeClosure* f) {
 }
 #endif
 
-InstanceStackChunkKlass::InstanceStackChunkKlass(const ClassFileParser& parser)
-  : InstanceKlass(parser, Kind) {
+InstanceStackChunkKlass::InstanceStackChunkKlass(AccessFlags access_flags, const InstanceKlassSizes& sizes)
+  : InstanceKlass(access_flags, sizes, Kind) {
   // Change the layout_helper to use the slow path because StackChunkOops are
   // variable sized InstanceOops.
   const jint lh = Klass::instance_layout_helper(size_helper(), true);

--- a/src/hotspot/share/oops/instanceStackChunkKlass.hpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.hpp
@@ -27,10 +27,10 @@
 
 #include "oops/instanceKlass.hpp"
 #include "oops/oopsHierarchy.hpp"
+#include "utilities/accessFlags.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/ostream.hpp"
 
-class ClassFileParser;
 class MemRegion;
 
 // An InstanceStackChunkKlass is a specialization of the InstanceKlass.
@@ -110,7 +110,7 @@ public:
 private:
   static int _offset_of_stack;
 
-  InstanceStackChunkKlass(const ClassFileParser& parser);
+  InstanceStackChunkKlass(AccessFlags access_flags, const InstanceKlassSizes& sizes);
 
 public:
   InstanceStackChunkKlass() { assert(DumpSharedSpaces || UseSharedSpaces, "only for CDS"); }

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -668,7 +668,7 @@ protected:
   void set_has_finalizer()              { _access_flags.set_has_finalizer(); }
   bool is_hidden() const                { return access_flags().is_hidden_class(); }
   void set_is_hidden()                  { _access_flags.set_is_hidden_class(); }
-  bool is_value_based()                 { return _access_flags.is_value_based_class(); }
+  bool is_value_based() const           { return _access_flags.is_value_based_class(); }
   void set_is_value_based()             { _access_flags.set_is_value_based_class(); }
 
   inline bool is_non_strong_hidden() const;

--- a/src/hotspot/share/oops/klassVtable.cpp
+++ b/src/hotspot/share/oops/klassVtable.cpp
@@ -68,7 +68,7 @@ void klassVtable::compute_vtable_size_and_num_mirandas(
     int* vtable_length_ret, int* num_new_mirandas,
     GrowableArray<Method*>* all_mirandas, const Klass* super,
     Array<Method*>* methods, AccessFlags class_flags, u2 major_version,
-    Handle classloader, Symbol* classname, Array<InstanceKlass*>* local_interfaces) {
+    Handle classloader, const Symbol* classname, Array<InstanceKlass*>* local_interfaces) {
   NoSafepointVerifier nsv;
 
   // set up default result values
@@ -277,7 +277,7 @@ void klassVtable::initialize_vtable(GrowableArray<InstanceKlass*>* supers) {
 // See JLS 8.4.8.1
 // Assumes name-signature match
 // Note that the InstanceKlass of the method in the targetclassname has not always been created yet
-static bool can_be_overridden(Method* super_method, Handle targetclassloader, Symbol* targetclassname) {
+static bool can_be_overridden(Method* super_method, Handle targetclassloader, const Symbol* targetclassname) {
    // Private methods can not be overridden
    assert(!super_method->is_private(), "shouldn't call with a private method");
 
@@ -634,7 +634,7 @@ void klassVtable::initialize_vtable_and_check_constraints(TRAPS) {
 bool klassVtable::needs_new_vtable_entry(Method* target_method,
                                          const Klass* super,
                                          Handle classloader,
-                                         Symbol* classname,
+                                         const Symbol* classname,
                                          AccessFlags class_flags,
                                          u2 major_version) {
   if (class_flags.is_interface()) {

--- a/src/hotspot/share/oops/klassVtable.hpp
+++ b/src/hotspot/share/oops/klassVtable.hpp
@@ -79,7 +79,7 @@ class klassVtable {
                                                    AccessFlags class_flags,
                                                    u2 major_version,
                                                    Handle classloader,
-                                                   Symbol* classname,
+                                                   const Symbol* classname,
                                                    Array<InstanceKlass*>* local_interfaces);
 
 #if INCLUDE_JVMTI
@@ -115,7 +115,7 @@ class klassVtable {
   static bool needs_new_vtable_entry(Method* m,
                                      const Klass* super,
                                      Handle classloader,
-                                     Symbol* classname,
+                                     const Symbol* classname,
                                      AccessFlags access_flags,
                                      u2 major_version);
 

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -585,6 +585,8 @@ public:
   bool can_omit_stack_trace();
 
   // Flags getting and setting.
+  const MethodFlags &statuses() const  { return _flags; }
+  void set_statuses(MethodFlags flags) { _flags = flags; }
 #define M_STATUS_GET_SET(name, ignore)          \
   bool name() const { return _flags.name(); }   \
   void set_##name(bool x) { _flags.set_##name(x); } \

--- a/src/hotspot/share/oops/methodFlags.hpp
+++ b/src/hotspot/share/oops/methodFlags.hpp
@@ -72,6 +72,7 @@ class MethodFlags {
  public:
 
   MethodFlags() : _status(0) {}
+  explicit MethodFlags(jint status) : _status(status) {}
 
   // Create getters and setters for the status values.
 #define M_STATUS_GET_SET(name, ignore)          \

--- a/src/hotspot/share/oops/resolvedFieldEntry.hpp
+++ b/src/hotspot/share/oops/resolvedFieldEntry.hpp
@@ -132,10 +132,11 @@ public:
   }
 
   // CRaC
-  void fill_in_partial(u2 index, u1 tos_state, u1 flags, u1 b1, u1 b2) {
+  void fill_in_portable(u2 index, u1 tos_state, u1 flags, u1 b1, u1 b2) {
     assert(_cpool_index > 0, "uninitialized");
     assert(tos_state < TosState::number_of_states, "not a ToS state");
 
+    _field_index = index;
     _tos_state = tos_state;
     _flags = flags;
     _get_code = b1;
@@ -145,12 +146,13 @@ public:
     postcond(b1 == 0 || is_resolved(Bytecodes::cast(b1)));
     postcond(b2 == 0 || is_resolved(Bytecodes::cast(b2)));
   }
-  void fill_in_holder(InstanceKlass* klass) {
+  void fill_in_unportable(InstanceKlass* klass) {
     precond(klass != nullptr);
     assert(_cpool_index > 0, "uninitialized");
     assert(_get_code > 0 || _put_code > 0, "unresolved");
-    assert(_field_holder == nullptr, "holder already set");
+    assert(_field_holder == nullptr, "already filled in");
     _field_holder = klass;
+    _field_offset = klass->field_offset(_field_index);
   }
 
   // CDS

--- a/src/hotspot/share/oops/resolvedIndyEntry.hpp
+++ b/src/hotspot/share/oops/resolvedIndyEntry.hpp
@@ -71,6 +71,7 @@ public:
   // Note: Only two flags exists at the moment but more could be added
   enum {
       has_appendix_shift        = 1,
+      num_flags
   };
 
   // Getters
@@ -79,6 +80,7 @@ public:
   u2 constant_pool_index()       const { return _cpool_index;                   }
   u2 num_parameters()            const { return _number_of_parameters;          }
   u1 return_type()               const { return _return_type;                   }
+  u1 flags()                     const { return _flags;                         }
   bool is_resolved()             const { return method() != nullptr;            }
   bool has_appendix()            const { return (_flags & (1 << has_appendix_shift)) != 0; }
   bool resolution_failed()       const { return (_flags & 1) != 0; }
@@ -127,6 +129,15 @@ public:
 
   void adjust_method_entry(Method* new_method) { _method = new_method; }
   bool check_no_old_or_obsolete_entry();
+
+  // CRaC
+  void fill_in_partial(u2 num_params, u1 return_type, bool has_appendix) {
+    assert(_cpool_index > 0, "uninitialized");
+    assert(!is_resolved(), "already resolved");
+    _number_of_parameters = num_params;
+    _return_type = return_type;
+    set_flags(has_appendix);
+  }
 
   // CDS
   void remove_unshareable_info();

--- a/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiRedefineClasses.cpp
@@ -4386,7 +4386,7 @@ void VM_RedefineClasses::redefine_single_class(Thread* current, jclass the_jclas
   // Leave arrays of jmethodIDs and itable index cache unchanged
 
   // Copy the "source debug extension" attribute from new class version
-  the_class->set_source_debug_extension(
+  the_class->copy_source_debug_extension(
     scratch_class->source_debug_extension(),
     scratch_class->source_debug_extension() == nullptr ? 0 :
     (int)strlen(scratch_class->source_debug_extension()));

--- a/src/hotspot/share/prims/methodHandles.hpp
+++ b/src/hotspot/share/prims/methodHandles.hpp
@@ -143,6 +143,10 @@ class MethodHandles: AllStatic {
     return signature_polymorphic_name_id(klass, name) != vmIntrinsics::_none;
   }
   static bool is_signature_polymorphic_public_name(Klass* klass, Symbol* name);
+  static bool is_signature_polymorphic_intrinsic_name(Klass* klass, Symbol* name) {
+    const vmIntrinsics::ID iid = MethodHandles::signature_polymorphic_name_id(klass, name);
+    return iid != vmIntrinsics::_none && is_signature_polymorphic_intrinsic(iid);
+  }
 
   static Bytecodes::Code signature_polymorphic_intrinsic_bytecode(vmIntrinsics::ID id);
 

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -209,7 +209,7 @@ static VM_Crac::Outcome checkpoint_portable() {
                        CRaCCheckpointTo, os::file_separator(), PMODE_HEAP_DUMP_FILENAME);
   {
     HeapDumper dumper(false, // No GC: it's already been performed by crac::checkpoint()
-                      true); // Include injected fields
+                      true); // Include all j.l.Class objects and injected fields
     if (dumper.dump(path,
                     nullptr,  // No additional output
                     -1,       // No compression, TODO: enable this when the parser supports it

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -43,6 +43,11 @@
 #include "oops/oopsHierarchy.hpp"
 #include "os.inline.hpp"
 #include "runtime/crac.hpp"
+#include "runtime/cracClassDumpParser.hpp"
+#include "runtime/cracClassDumper.hpp"
+#include "runtime/cracHeapRestorer.hpp"
+#include "runtime/cracStackDumpParser.hpp"
+#include "runtime/cracStackDumper.hpp"
 #include "runtime/crac_structs.hpp"
 #include "runtime/deoptimization.hpp"
 #include "runtime/handles.hpp"
@@ -68,14 +73,12 @@
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/heapDumpParser.hpp"
-#include "utilities/hprofTag.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/stackDumpParser.hpp"
-#include "utilities/stackDumper.hpp"
 
-// Filenames used by the portble mode
+// Filenames used by the portable mode
 static constexpr char PMODE_HEAP_DUMP_FILENAME[] = "heap.hprof";
 static constexpr char PMODE_STACK_DUMP_FILENAME[] = "stacks.bin";
+static constexpr char PMODE_CLASS_DUMP_FILENAME[] = "classes.bin";
 
 static const char* _crengine = NULL;
 static char* _crengine_arg_str = NULL;
@@ -85,10 +88,10 @@ static jlong _restore_start_time;
 static jlong _restore_start_nanos;
 
 // Used by portable restore
-ParsedHeapDump  *crac::_heap_dump;
-ParsedStackDump *crac::_stack_dump;
-ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP> *crac::_portable_loaded_classes;
-ResizeableResourceHashtable<HeapDump::ID, jobject, AnyObj::C_HEAP> *crac::_portable_restored_objects;
+ParsedHeapDump  *crac::_heap_dump = nullptr;
+ParsedStackDump *crac::_stack_dump = nullptr;
+HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *crac::_portable_restored_classes = nullptr;
+HeapDumpTable<jobject, AnyObj::C_HEAP> *crac::_portable_restored_objects = nullptr;
 
 // Timestamps recorded before checkpoint
 jlong crac::checkpoint_millis;
@@ -165,28 +168,39 @@ static VM_Crac::Outcome checkpoint_portable() {
   os::snprintf_checked(path, sizeof(path), "%s%s%s",
                        CRaCCheckpointTo, os::file_separator(), PMODE_STACK_DUMP_FILENAME);
   {
-    const StackDumper::Result res = StackDumper::dump(path);
+    const CracStackDumper::Result res = CracStackDumper::dump(path);
     switch (res.code()) {
-      case StackDumper::Result::Code::OK: break;
-      case StackDumper::Result::Code::IO_ERROR: {
+      case CracStackDumper::Result::Code::OK: break;
+      case CracStackDumper::Result::Code::IO_ERROR: {
         warning("Cannot dump thread stacks into %s: %s", path, res.io_error_msg());
         if (remove(path) != 0) warning("Cannot remove %s: %s", path, os::strerror(errno));
         return VM_Crac::Outcome::FAIL; // User action required
       }
-      case StackDumper::Result::Code::NON_JAVA_IN_MID: {
+      case CracStackDumper::Result::Code::NON_JAVA_IN_MID: {
         ResourceMark rm;
         warning("Cannot checkpoint now: thread %s has Java frames interleaved with native frames",
                 res.problematic_thread()->name());
         if (remove(path) != 0) warning("Cannot remove %s: %s", path, os::strerror(errno));
         return VM_Crac::Outcome::FAIL; // It'll probably take too long to wait until all such frames are gone
       }
-      case StackDumper::Result::Code::NON_JAVA_ON_TOP: {
+      case CracStackDumper::Result::Code::NON_JAVA_ON_TOP: {
         ResourceMark rm;
         warning("Cannot checkpoint now: thread %s is executing native code",
                 res.problematic_thread()->name());
         if (remove(path) != 0) warning("Cannot remove %s: %s", path, os::strerror(errno));
         return VM_Crac::Outcome::RETRY; // Hoping the thread will get out of non-Java code shortly
       }
+    }
+  }
+
+  // Dump classes
+  os::snprintf_checked(path, sizeof(path), "%s%s%s",
+                       CRaCCheckpointTo, os::file_separator(), PMODE_CLASS_DUMP_FILENAME);
+  {
+    const char* err = CracClassDumper::dump(path, false /* Don't overwrite */);
+    if (err != nullptr) {
+      warning("Cannot dump classes into %s: %s", path, err);
+      return VM_Crac::Outcome::FAIL; // User action required
     }
   }
 
@@ -202,13 +216,13 @@ static VM_Crac::Outcome checkpoint_portable() {
                     HeapDumper::default_num_of_dump_threads()) != 0) {
       ResourceMark rm;
       warning("Cannot dump heap into %s: %s", path, dumper.error_as_C_string());
-      return VM_Crac::Outcome::FAIL; // User action required (most likely)
+      return VM_Crac::Outcome::FAIL; // User action required
     }
   }
 
   return VM_Crac::Outcome::OK;
 #else  // INCLUDE_SERVICES
-  warning("This JVM cannot create checkpoints in portable mode: it is compiled without \"services\" feature");
+  warning("This VM cannot create checkpoints in portable mode: it is compiled without \"services\" feature");
   return VM_Crac::Outcome::FAIL;
 #endif  // INCLUDE_SERVICES
 }
@@ -521,17 +535,6 @@ static Handle ret_cr(int ret, Handle new_args, Handle new_props, Handle err_code
   return bundle;
 }
 
-static void init_basic_type_mirror_names(TRAPS) {
-  for (u1 t = T_BOOLEAN; t <= T_LONG; t++) {
-    Handle mirror(Thread::current(), Universe::java_mirror(static_cast<BasicType>(t)));
-    java_lang_Class::name(mirror, CHECK);
-  }
-  {
-    Handle void_mirror = Handle(Thread::current(), Universe::void_mirror());
-    java_lang_Class::name(void_mirror, CHECK);
-  }
-}
-
 /** Checkpoint main entry.
  */
 Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong jcmd_stream, TRAPS) {
@@ -542,13 +545,6 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
   if (-1 == os::mkdir(CRaCCheckpointTo) && errno != EEXIST) {
     warning("cannot create %s: %s", CRaCCheckpointTo, os::strerror(errno));
     return ret_cr(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
-  }
-
-  if (is_portable_mode()) {
-    // Trigger name field initialization for Class<*> instances of basic types
-    // so that these can be differentiated upon the restoration
-    // TODO figure out a more robust way to achieve this differentiation
-    init_basic_type_mirror_names(CHECK_NH);
   }
 
   Universe::heap()->set_cleanup_unused(true);
@@ -776,1115 +772,12 @@ void crac::update_javaTimeNanos_offset() {
   }
 }
 
-// Has the following assumptions about the heap dump:
-// 1. Nulls are represented by 0 ID.
-// 2. Class<*> instances are included into instance dumps only for primitive
-// types, and their name field is initialized.
-//
-// These assumptions are met when reading dumps generated by HeapDumper.
-class HeapRestorer : public StackObj {
- private:
-  // HPROF does not have a special notion for a null reference. We will trear 0
-  // ID as such.
-  static constexpr HeapDump::ID NULL_ID = 0;
-
- public:
-  HeapRestorer(const ParsedHeapDump  &heap_dump,
-               const GrowableArrayView<StackTrace *> &stack_traces,
-               ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP> **loaded_classes,
-               ResizeableResourceHashtable<HeapDump::ID, jobject, AnyObj::C_HEAP> **restored_objects)
-      : _heap_dump(heap_dump), _stack_traces(stack_traces) {
-    *loaded_classes = _loaded_classes;
-    *restored_objects = _restored_objects;
-  };
-
-  void restore_heap(TRAPS) {
-    // For now we rely on CDS to pre-initialize the built-in class loaders
-    if (SystemDictionary::java_platform_loader() == nullptr || SystemDictionary::java_system_loader() == nullptr) {
-      THROW_MSG(vmSymbols::java_lang_UnsupportedOperationException(),
-                "Not implemented: the built-in class loaders must be pre-initialized (by CDS)");
-    }
-
-    // Look through the dump to find platform and system class loaders' IDs
-    find_base_class_loader_ids(CHECK);
-
-    _heap_dump.class_dumps.iterate(
-      [&](HeapDump::ID _, const HeapDump::ClassDump &dump) -> bool {
-        // For now we only restore user-provided classes
-        if (dump.class_loader_id == _system_class_loader_id) {
-          restore_class(dump, CHECK_false);
-        }
-        return true;
-      }
-    );
-    if (HAS_PENDING_EXCEPTION) return;
-
-    // TODO restore all dumped objects instead of only these subsets
-    {
-      auto restore_iter = [&](HeapDump::ID id, const instanceHandle &_) -> bool {
-        restore_object(id, CHECK_false);
-        return true;
-      };
-      _prepared_class_loaders.iterate(restore_iter);
-      if (HAS_PENDING_EXCEPTION) return;
-      _allocated_prot_domains.iterate(restore_iter);
-      if (HAS_PENDING_EXCEPTION) return;
-    }
-    for (const auto *trace : _stack_traces) {
-      // TODO restore the thread, but what to do if it is the main thread?
-      // restore_object(trace->thread_id(), CHECK);
-      // Restore locals and operands
-      for (u4 i = 0; i < trace->frames_num(); i++) {
-        const StackTrace::Frame &frame = trace->frames(i);
-        for (u2 j = 0; j < frame.locals.size(); j++) {
-          const StackTrace::Frame::Value &v = frame.locals.mem()[j];
-          if (v.type == DumpedStackValueType::REFERENCE) {
-            restore_object(v.obj_id, CHECK);
-          }
-        }
-        for (u2 j = 0; j < frame.operands.size(); j++) {
-          const StackTrace::Frame::Value &v = frame.operands.mem()[j];
-          if (v.type == DumpedStackValueType::REFERENCE) {
-            restore_object(v.obj_id, CHECK);
-          }
-        }
-      }
-    }
-  }
-
- private:
-  const ParsedHeapDump  &_heap_dump;
-  const GrowableArrayView<StackTrace *> &_stack_traces;
-
-  Symbol *get_dumped_symbol(HeapDump::ID id, TRAPS) const {
-    HeapDump::UTF8 *utf8 = _heap_dump.utf8s.get(id);
-    if (utf8 != nullptr) return utf8->sym;
-    THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-               err_msg("UTF-8 record " INT64_FORMAT " referenced but absent", id), {});
-  }
-
-  Symbol *get_dumped_class_name(HeapDump::ID class_id, TRAPS) const {
-    HeapDump::LoadClass *lc = _heap_dump.load_classes.get(class_id);
-    if (lc == nullptr) {
-      THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                     err_msg("Class loading record " INT64_FORMAT " referenced but absent", class_id));
-    }
-    Symbol *name = get_dumped_symbol(lc->class_name_id, CHECK_NULL);
-    return name;
-  }
-
-  HeapDump::ClassDump *get_class_dump(HeapDump::ID id, TRAPS) const {
-    HeapDump::ClassDump *dump = _heap_dump.class_dumps.get(id);
-    if (dump != nullptr) return dump;
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                   err_msg("Class dump " INT64_FORMAT " referenced but absent", id));
-  }
-
-  HeapDump::InstanceDump *get_instance_dump(HeapDump::ID id, TRAPS) const {
-    HeapDump::InstanceDump *dump = _heap_dump.instance_dumps.get(id);
-    if (dump != nullptr) return dump;
-    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                   err_msg("Instance dump " INT64_FORMAT " referenced but absent", id));
-  }
-
-  HeapDump::ID _platform_class_loader_id = NULL_ID;
-  HeapDump::ID _builtin_app_class_loader_id = NULL_ID;
-  HeapDump::ID _system_class_loader_id = NULL_ID;
-
-  // Finds platform and system class loaders' IDs in the dump.
-  void find_base_class_loader_ids(TRAPS) {
-    _heap_dump.load_classes.iterate([&](HeapDump::ID _, const HeapDump::LoadClass &lc) -> bool {
-      Symbol *name = get_dumped_symbol(lc.class_name_id, CHECK_false);
-      if (name == vmSymbols::java_lang_ClassLoader()) {
-        set_system_class_loader_id(lc, CHECK_false);
-      } else if (name ==  vmSymbols::jdk_internal_loader_ClassLoaders()) {
-        set_builtin_class_loader_ids(lc, CHECK_false);
-      }
-      return true;
-    });
-
-    if (HAS_PENDING_EXCEPTION) {
-      Handle e(Thread::current(), PENDING_EXCEPTION);
-      CLEAR_PENDING_EXCEPTION;
-      THROW_MSG_CAUSE(vmSymbols::java_lang_IllegalArgumentException(), "Cannot find dumped built-in class loaders", e);
-    }
-    if (_platform_class_loader_id == NULL_ID ||
-        !_heap_dump.instance_dumps.contains(_platform_class_loader_id)) {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Cannot find dumped platform class loader");
-    }
-    if (_builtin_app_class_loader_id == NULL_ID ||
-        !_heap_dump.instance_dumps.contains(_builtin_app_class_loader_id)) {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Cannot find dumped built-in app class loader");
-    }
-    if (_system_class_loader_id == NULL_ID ||
-        !_heap_dump.instance_dumps.contains(_system_class_loader_id)) {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Cannot find dumped system class loader");
-    }
-    if (_platform_class_loader_id == _builtin_app_class_loader_id ||
-        _platform_class_loader_id == _system_class_loader_id) {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                "Platform and system class loaders cannot be dumped as the same instance");
-    }
-  }
-
-  void set_system_class_loader_id(const HeapDump::LoadClass &lc, TRAPS) {
-    // This relies on ClassLoader.getSystemClassLoader() implementation detail:
-    // the system class loader is stored in scl static field of j.l.ClassLoader
-    static constexpr char SCL_FIELD_NAME[] = "scl";
-
-    HeapDump::ClassDump *dump = get_class_dump(lc.class_id, CHECK);
-    if (dump->class_loader_id != NULL_ID) {
-      // Classes from java.* packages cannot be non-boot-loaded
-      ResourceMark rm;
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Class %s can only be loaded by the bootstrap class loader",
-                         vmClasses::ClassLoader_klass()->name()->as_C_string()));
-    }
-
-    if (_system_class_loader_id != NULL_ID) {
-      ResourceMark rm;
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Class %s has multiple dumps", vmClasses::ClassLoader_klass()->external_name()));
-    }
-
-    for (u2 i = 0; i < dump->static_fields.size(); i++) {
-      const HeapDump::ClassDump::Field &field_dump = dump->static_fields[i];
-      if (field_dump.info.type != HPROF_NORMAL_OBJECT) {
-        continue;
-      }
-      Symbol *field_name = get_dumped_symbol(field_dump.info.name_id, CHECK);
-      if (field_name->equals(SCL_FIELD_NAME)) {
-        if (_system_class_loader_id != NULL_ID) {
-          ResourceMark rm;
-          THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                    err_msg("Static field %s is repeated in %s dump " INT64_FORMAT,
-                            SCL_FIELD_NAME, vmClasses::ClassLoader_klass()->external_name(), dump->id));
-        }
-        if (field_dump.value.as_object_id == NULL_ID) {
-          THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Dumped system class loader is null");
-        }
-        _system_class_loader_id = field_dump.value.as_object_id;
-      }
-    }
-
-    if (_system_class_loader_id == NULL_ID) {
-      ResourceMark rm;
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Static field %s is missing from %s dump " INT64_FORMAT,
-                        SCL_FIELD_NAME, vmClasses::ClassLoader_klass()->external_name(), dump->id));
-    }
-  }
-
-  void set_builtin_class_loader_ids(const HeapDump::LoadClass &lc, TRAPS) {
-    // This relies on the ClassLoader.get*ClassLoader() implementation detail:
-    // the built-in platform and app class loaders are stored in
-    // PLATFORM_LOADER/APP_LOADER static fields of
-    // jdk.internal.loader.ClassLoaders
-    static constexpr char PLATFORM_LOADER_FIELD_NAME[] = "PLATFORM_LOADER";
-    static constexpr char APP_LOADER_FIELD_NAME[] = "APP_LOADER";
-
-    const HeapDump::ClassDump *dump = get_class_dump(lc.class_id, CHECK);
-    if (dump->class_loader_id != NULL_ID) {
-      // Classes from jdk.* packages can be non-boot-loaded, but we need the one
-      // that is
-      return;
-    }
-
-    if (_platform_class_loader_id != NULL_ID || _builtin_app_class_loader_id != NULL_ID) {
-      ResourceMark rm;
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Class %s has multiple dumps",
-                        vmClasses::jdk_internal_loader_ClassLoaders_klass()->external_name()));
-    }
-
-    for (u2 i = 0; i < dump->static_fields.size(); i++) {
-      const HeapDump::ClassDump::Field &field_dump = dump->static_fields[i];
-      if (field_dump.info.type != HPROF_NORMAL_OBJECT) {
-        continue;
-      }
-      Symbol *field_name = get_dumped_symbol(field_dump.info.name_id, CHECK);
-      if (field_name->equals(PLATFORM_LOADER_FIELD_NAME)) {
-        if (_platform_class_loader_id != NULL_ID) {
-          ResourceMark rm;
-          THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                    err_msg("Static field %s is repeated in %s dump " INT64_FORMAT, PLATFORM_LOADER_FIELD_NAME,
-                            vmClasses::jdk_internal_loader_ClassLoaders_klass()->external_name(), dump->id));
-        }
-        if (field_dump.value.as_object_id == NULL_ID) {
-          THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Dumped platform class loader is null");
-        }
-        _platform_class_loader_id = field_dump.value.as_object_id;
-      } else if (field_name->equals(APP_LOADER_FIELD_NAME)) {
-        if (_builtin_app_class_loader_id != NULL_ID) {
-          ResourceMark rm;
-          THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                    err_msg("Static field %s is repeated in %s dump " INT64_FORMAT, APP_LOADER_FIELD_NAME,
-                            vmClasses::jdk_internal_loader_ClassLoaders_klass()->external_name(), dump->id));
-        }
-        if (field_dump.value.as_object_id == NULL_ID) {
-          THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Dumped built-in app class loader is null");
-        }
-        _builtin_app_class_loader_id = field_dump.value.as_object_id;
-      }
-    }
-
-    if (_platform_class_loader_id == NULL_ID || _builtin_app_class_loader_id == NULL_ID) {
-      ResourceMark rm;
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Static field %s and/or %s are missing from %s dump " INT64_FORMAT,
-                        PLATFORM_LOADER_FIELD_NAME, APP_LOADER_FIELD_NAME, vmClasses::ClassLoader_klass()->external_name(),
-                        dump->id));
-    }
-  }
-
-  ResizeableResourceHashtable<HeapDump::ID, instanceHandle, AnyObj::C_HEAP> _prepared_class_loaders {11,   1228891};
-  ResizeableResourceHashtable<HeapDump::ID, instanceHandle, AnyObj::C_HEAP> _allocated_prot_domains {11,   1228891};
-  ResizeableResourceHashtable<HeapDump::ID, Klass *,        AnyObj::C_HEAP> *_loaded_classes =
-    new(mtInternal) ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP>              {107,  1228891};
-  ResizeableResourceHashtable<HeapDump::ID, Klass *,        AnyObj::C_HEAP> _restored_classes       {107,  1228891};
-  ResizeableResourceHashtable<HeapDump::ID, jobject,        AnyObj::C_HEAP> *_restored_objects =
-    new(mtInternal) ResizeableResourceHashtable<HeapDump::ID, jobject,  AnyObj::C_HEAP>             {1009, 1228891};
-
-  // Gets a value or puts an empty-initialized value if the key is absent.
-  template <class V>
-  V *get_or_put_stub(HeapDump::ID id, ResizeableResourceHashtable<HeapDump::ID, V, AnyObj::C_HEAP> *table) {
-    V *value = table->get(id);
-    if (value == nullptr) {
-      table->put_when_absent(id, {});
-      table->maybe_grow();
-    }
-    return value;
-  }
-
-  // Loads the class without restoring it.
-  Klass *load_class(const HeapDump::ClassDump &dump, TRAPS) {
-    Klass **ready = get_or_put_stub(dump.id, _loaded_classes);
-    if (ready != nullptr) {
-      if (*ready == nullptr) {
-        THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Loading curcularity detected for dumped class " INT64_FORMAT, dump.id));
-      }
-      return *ready;
-    }
-    log_trace(restore)("Loading class " INT64_FORMAT, dump.id);
-
-    // TODO have to also load interfaces, because otherwise the standard
-    // resolution mechanism will be called for them which may call the user code
-    if (dump.super_id != NULL_ID) {
-      HeapDump::ClassDump *super_dump = get_class_dump(dump.super_id, CHECK_NULL);
-      load_class(*super_dump, CHECK_NULL);
-    }
-
-    Symbol *name = get_dumped_class_name(dump.id, CHECK_NULL);
-
-    instanceHandle class_loader = get_prepared_class_loader(dump.class_loader_id, CHECK_NULL);
-    instanceHandle prot_domain = get_allocated_prot_domain(dump.protection_domain_id, CHECK_NULL);
-
-    Klass *klass;
-    if (true /* TODO replace with class_loader.is_null() */) {
-      klass = SystemDictionary::resolve_or_fail(name, class_loader, prot_domain, false, CHECK_NULL);
-    } else {
-      klass = define_dumped_class(name, dump, class_loader, prot_domain, CHECK_NULL);
-    }
-
-    if (klass->class_loader() != class_loader()) {
-      THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                     err_msg("Class loader specified in class dump " INT64_FORMAT " does not define the class", dump.id));
-    }
-
-    if (klass->is_instance_klass()) {
-      verify_fields(InstanceKlass::cast(klass), dump, CHECK_NULL);
-    }
-
-    _loaded_classes->put(dump.id, klass);
-    if (log_is_enabled(Trace, restore)) {
-      ResourceMark rm;
-      log_trace(restore)("Loaded class " INT64_FORMAT " as %s", dump.id, klass->external_name());
-    }
-    return klass;
-  }
-
-  // Returns the class loader with its state partially restored so it can be
-  // used for class definition.
-  instanceHandle get_prepared_class_loader(HeapDump::ID id, TRAPS) {
-    precond(vmClasses::ClassLoader_klass()->is_initialized());
-
-    if (id == NULL_ID) {  // Bootstrap class loader
-      return {};
-    }
-
-    instanceHandle *ready = get_or_put_stub(id, &_prepared_class_loaders);
-    if (ready != nullptr) {
-      if (ready->is_null()) {
-        THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                   err_msg("Preparation circularity detected for class loader dump " INT64_FORMAT, id), {});
-      }
-      return *ready;
-    }
-    log_trace(restore)("Preparing class loader " INT64_FORMAT, id);
-
-    HeapDump::InstanceDump *instance_dump = get_instance_dump(id, CHECK_({}));
-
-    InstanceKlass *klass = load_instance_class(instance_dump->class_id, true, THREAD);
-    if (HAS_PENDING_EXCEPTION) {
-      Handle e(Thread::current(), PENDING_EXCEPTION);
-      CLEAR_PENDING_EXCEPTION;
-      THROW_MSG_CAUSE_(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Cannot load class of class loader dump " INT64_FORMAT, id), e, {});
-    }
-    if (!klass->is_class_loader_instance_klass()) {
-      ResourceMark rm;
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Class loader class dump " INT64_FORMAT " is loaded as %s which does not extend %s",
-                         instance_dump->class_id, klass->external_name(), vmClasses::ClassLoader_klass()->external_name()),
-                 {});
-    }
-
-    instanceHandle handle = prepare_class_loader(klass, *instance_dump, CHECK_({}));
-
-    _prepared_class_loaders.put(id, handle);
-    if (log_is_enabled(Trace, restore)) {
-      ResourceMark rm;
-      log_trace(restore)("Prepared class loader " INT64_FORMAT " (%s)", id, klass->external_name());
-    }
-    return handle;
-  }
-
-  // Partially restores the class loader so it can be used for class definition.
-  // If it is dumped as a built-in class loader, it will be set as such.
-  instanceHandle prepare_class_loader(InstanceKlass *klass, const HeapDump::InstanceDump &dump, TRAPS) const {
-    precond(klass->is_subclass_of(vmClasses::ClassLoader_klass()));
-
-    if (dump.id == _platform_class_loader_id && SystemDictionary::java_platform_loader() != nullptr) {
-      warning("Using platform class loader as created by CDS");
-      return {Thread::current(), static_cast<instanceOop>(SystemDictionary::java_platform_loader())};
-    }
-    if (dump.id == _system_class_loader_id && SystemDictionary::java_system_loader() != nullptr) {
-      if (dump.id != _builtin_app_class_loader_id) {
-        THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                   err_msg("Dumped system class loader " INT64_FORMAT " is expected to also be "
-                           "the built-in app class loader " INT64_FORMAT, dump.id, _builtin_app_class_loader_id), {});
-      }
-      warning("Using system class loader as created by CDS");
-      return {Thread::current(), static_cast<instanceOop>(SystemDictionary::java_system_loader())};
-    }
-
-    // TODO for now, we only use the built-in platform and system class loaders
-    // newly constructed by CDS
-    Unimplemented();
-    return {};
-  }
-
-  // Returns an allocated protection domain so it can be used for class
-  // definition.
-  instanceHandle get_allocated_prot_domain(HeapDump::ID id, TRAPS) {
-    if (id == NULL_ID) {
-      return {};
-    }
-    instanceHandle *ready = get_or_put_stub(id, &_allocated_prot_domains);
-    if (ready != nullptr) {
-      if (ready->is_null()) {
-        THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                   err_msg("Preparation circularity detected for protection domain dump " INT64_FORMAT, id), {});
-      }
-      return *ready;
-    }
-    log_trace(restore)("Allocating protection domain " INT64_FORMAT, id);
-
-    HeapDump::InstanceDump *instance_dump = get_instance_dump(id, CHECK_({}));
-
-    InstanceKlass *klass = load_instance_class(instance_dump->class_id, true, THREAD);
-    if (HAS_PENDING_EXCEPTION) {
-      Handle e(Thread::current(), PENDING_EXCEPTION);
-      CLEAR_PENDING_EXCEPTION;
-      THROW_MSG_CAUSE_(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Cannot load class of protection domain dump " INT64_FORMAT, id), e, {});
-    }
-    if (!klass->is_subclass_of(vmClasses::ProtectionDomain_klass())) {
-      ResourceMark rm;
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Protection domain class dump " INT64_FORMAT " is loaded as %s which does not extend %s",
-                         instance_dump->class_id, klass->external_name(), vmClasses::ClassLoader_klass()->external_name()),
-                 {});
-    }
-
-    instanceHandle handle = klass->allocate_instance_handle(CHECK_({}));
-
-    _allocated_prot_domains.put(id, handle);
-    if (log_is_enabled(Trace, restore)) {
-      ResourceMark rm;
-      log_trace(restore)("Allocated protection domain " INT64_FORMAT " (%s)", id, klass->external_name());
-    }
-    return handle;
-  }
-
-  InstanceKlass *load_instance_class(HeapDump::ID id, bool check_instantiable, TRAPS) {
-    HeapDump::ClassDump *dump = get_class_dump(id, CHECK_NULL);
-    InstanceKlass *ik = load_instance_class(*dump, check_instantiable, CHECK_NULL);
-    return ik;
-  }
-
-  InstanceKlass *load_instance_class(const HeapDump::ClassDump &dump, bool check_instantiable, TRAPS) {
-    Klass *k = load_class(dump, CHECK_NULL);
-    if (check_instantiable) {
-      k->check_valid_for_instantiation(false, CHECK_NULL);
-    } else if (!k->is_instance_klass()) {
-      ResourceMark rm;
-      THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                     err_msg("%s is not an instance class", k->external_name()));
-    }
-    return InstanceKlass::cast(k);
-  }
-
-  // Verifies that names and basic types of all fields match.
-  void verify_fields(InstanceKlass *klass, const HeapDump::ClassDump &dump, TRAPS) const {
-    FieldStream fs(klass,
-                   true /* local fields only: super's fields are verified when processing supers */,
-                   true /* no interfaces (if the class is an interface it's still gonna be processed) */);
-    u2 static_i = 0;
-    u2 instance_i = 0;
-
-    while (!fs.eos()) {
-      bool is_static = fs.access_flags().is_static();
-      if (is_static && static_i >= dump.static_fields.size()) {
-        ResourceMark rm;
-        THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                  err_msg("Class %s has more static fields than its dump " INT64_FORMAT,
-                          klass->external_name(), dump.id));
-      } else if (!is_static && instance_i >= dump.instance_field_infos.size()) {
-        ResourceMark rm;
-        THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                  err_msg("Class %s has more non-static fields than its dump " INT64_FORMAT,
-                          klass->external_name(), dump.id));
-      }
-
-      const HeapDump::ClassDump::Field::Info &field_info = is_static ?
-                                                           dump.static_fields[static_i++].info :
-                                                           dump.instance_field_infos[instance_i++];
-      Symbol *field_name = get_dumped_symbol(field_info.name_id, CHECK);
-      if (field_name == vmSymbols::resolved_references_name()) {
-        continue;  // Not a real field
-      }
-      if (fs.name() != field_name || !is_same_basic_type(fs.signature(), field_info.type)) {
-        ResourceMark rm;
-        THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                  err_msg("Runtime field %s %s is dumped as %s %s (class %s, dump " INT64_FORMAT ")",
-                          type2name(Signature::basic_type(fs.signature())), fs.name()->as_C_string(),
-                          dumped_type2name(field_info.type), field_name->as_C_string(),
-                          klass->external_name(), dump.id));
-      }
-      fs.next();
-    }
-
-    // Skip any remaining dumped resolved references
-    while (static_i < dump.static_fields.size()) {
-      const HeapDump::ClassDump::Field::Info &field_info = dump.static_fields[static_i].info;
-      Symbol *field_name = get_dumped_symbol(field_info.name_id, CHECK);
-      if (field_name == vmSymbols::resolved_references_name()) {
-        static_i++;
-      } else {
-        break;
-      }
-    }
-
-    if (static_i < dump.static_fields.size() || instance_i < dump.instance_field_infos.size()) {
-      ResourceMark rm;
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Class %s has less %s fields than its dump " INT64_FORMAT, klass->external_name(),
-                        static_i < dump.static_fields.size() ? "static" : "non-static", dump.id));
-    }
-  }
-
-  static bool is_same_basic_type(Symbol *signature, u1 dumped_type) {
-    switch (signature->char_at(0)) {
-      case JVM_SIGNATURE_CLASS:
-      case JVM_SIGNATURE_ARRAY:   return dumped_type == HPROF_NORMAL_OBJECT;
-      case JVM_SIGNATURE_BOOLEAN: return dumped_type == HPROF_BOOLEAN;
-      case JVM_SIGNATURE_CHAR:    return dumped_type == HPROF_CHAR;
-      case JVM_SIGNATURE_FLOAT:   return dumped_type == HPROF_FLOAT;
-      case JVM_SIGNATURE_DOUBLE:  return dumped_type == HPROF_DOUBLE;
-      case JVM_SIGNATURE_BYTE:    return dumped_type == HPROF_BYTE;
-      case JVM_SIGNATURE_SHORT:   return dumped_type == HPROF_SHORT;
-      case JVM_SIGNATURE_INT:     return dumped_type == HPROF_INT;
-      case JVM_SIGNATURE_LONG:    return dumped_type == HPROF_LONG;
-      default:                    ShouldNotReachHere(); return false;
-    }
-  }
-
-  static const char *dumped_type2name(u1 type) {
-    switch (type) {
-      case HPROF_NORMAL_OBJECT: return "<reference type>";
-      case HPROF_BOOLEAN:       return type2name(T_BOOLEAN);
-      case HPROF_CHAR:          return type2name(T_CHAR);
-      case HPROF_FLOAT:         return type2name(T_FLOAT);
-      case HPROF_DOUBLE:        return type2name(T_DOUBLE);
-      case HPROF_BYTE:          return type2name(T_BYTE);
-      case HPROF_SHORT:         return type2name(T_SHORT);
-      case HPROF_INT:           return type2name(T_INT);
-      case HPROF_LONG:          return type2name(T_LONG);
-      default:                  ShouldNotReachHere(); return nullptr;
-    }
-  }
-
-  // Defines the specified class with the classfile using the provided class
-  // loader and protection domain.
-  static Klass *define_dumped_class(Symbol *name, const HeapDump::ClassDump &dump,
-                                    instanceHandle class_loader, Handle prot_domain, TRAPS) {
-    // TODO prepare the name like SystemDictionary::resolve_or_null() does, then
-    // call SystemDictionary::resolve_from_stream()
-    Unimplemented();
-    return nullptr;  // Make compilers happy
-  }
-
-  // Loads the class, initializes it by restoring its static fields, and
-  // verifies names and basic types of its non-static fields.
-  Klass *restore_class(const HeapDump::ClassDump &dump, TRAPS) {
-    Klass **ready = _restored_classes.get(dump.id);
-    if (ready != nullptr) {
-      return *ready;
-    }
-    log_trace(restore)("Restoring class " INT64_FORMAT, dump.id);
-
-    Klass *klass = load_class(dump, CHECK_NULL);
-    _restored_classes.put_when_absent(dump.id, klass);
-    _restored_classes.maybe_grow();
-
-    // We don't set signers during the class definition like the class loaders
-    // usually do, so restore and set them now
-    oop class_loader = klass->class_loader();
-    if (class_loader != nullptr) {
-      objArrayHandle signers = restore_signers(dump.signers_id, CHECK_NULL);
-      java_lang_Class::set_signers(klass->java_mirror(), signers());
-    }
-
-    if (klass->is_array_klass()) {
-      // Nothing to restore for primitive array classes, and if it is an object
-      // array, its bottom class should be restored individually
-      if (log_is_enabled(Trace, restore)) {
-        ResourceMark rm;
-        log_trace(restore)("Restored class " INT64_FORMAT " (%s): array class", dump.id, klass->external_name());
-      }
-      return klass;
-    }
-    assert(klass->is_instance_klass(), "Must be");
-
-    InstanceKlass *ik = InstanceKlass::cast(klass);
-
-    // TODO add initialization status into the dump and use it to decide whether
-    // to perform the initialization
-    if (ik->is_initialized()) {
-      assert(class_loader == nullptr, "Only boot-loaded classes can be pre-initialized");
-      if (log_is_enabled(Trace, restore)) {
-        ResourceMark rm;
-        log_trace(restore)("Restored class " INT64_FORMAT " (%s): was pre-initialized", dump.id, klass->external_name());
-      }
-      // TODO if it is ClassLoader$ParallelLoaders, restore its loaderTypes
-      // field to include all class loaders it should
-      return ik;
-    }
-
-    if (dump.super_id != NULL_ID && klass->java_super() != nullptr) {
-      HeapDump::ClassDump *super_dump = get_class_dump(dump.super_id, CHECK_NULL);
-      Klass *super = restore_class(*super_dump, CHECK_NULL);
-      if (super != klass->java_super()) {
-        ResourceMark rm;
-        THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Class dump " INT64_FORMAT " specifies %s as its super, "
-                               "but it is loaded as %s which specifies %s", dump.id,
-                               super->external_name(), klass->external_name(), klass->java_super()->external_name()));
-      }
-    } else if (dump.super_id == NULL_ID && klass->java_super() != nullptr) {
-      ResourceMark rm;
-      THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                     err_msg("Class dump " INT64_FORMAT " specifies no super, "
-                             "but it is loaded as %s which specifies %s", dump.id,
-                             klass->external_name(), klass->java_super()->external_name()));
-    } else if (dump.super_id != NULL_ID && klass->java_super() == nullptr) {
-      ResourceMark rm;
-      THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                     err_msg("Class dump " INT64_FORMAT " specifies a super, "
-                             "but it is loaded as %s which does not", dump.id, klass->external_name()));
-    }
-
-    ik->link_class(CHECK_NULL);
-#ifdef ASSERT
-    {
-      MonitorLocker ml(Thread::current(), ik->_init_monitor);
-      assert(!ik->is_being_initialized() && !ik->is_initialized(),
-             "This should be the only thread performing class initialization");
-      ik->set_init_state(InstanceKlass::being_initialized);
-      ik->set_init_thread(JavaThread::current());
-    }
-#else
-    ik->set_init_state(InstanceKlass::being_initialized);
-    ik->set_init_thread(JavaThread::current());
-#endif
-    set_static_fields(ik, dump, CHECK_NULL);
-    ik->set_initialization_state_and_notify(InstanceKlass::fully_initialized, JavaThread::current());
-
-    if (log_is_enabled(Trace, restore)) {
-      ResourceMark rm;
-      log_trace(restore)("Restored class " INT64_FORMAT " (%s)", dump.id, klass->external_name());
-    }
-    return klass;
-  }
-
-  objArrayHandle restore_signers(HeapDump::ID id, TRAPS) {
-    oop signers;
-    {
-      jobject signers_handle = restore_object(id, CHECK_({}));
-      signers = JNIHandles::resolve(signers_handle);
-    }
-    if (signers != nullptr && !signers->is_objArray()) {
-      ResourceMark rm;
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Unexpected signers object type: %s", signers->klass()->external_name()), {});
-    }
-    return {Thread::current(), static_cast<objArrayOop>(signers)};
-  }
-
-  // Sets static fields, basic types should have already been verified during
-  // the class loading.
-  void set_static_fields(InstanceKlass *ik, const HeapDump::ClassDump &dump, TRAPS) {
-    FieldStream fs(ik, true, true);
-    u2 static_i = 0;
-
-    while (!fs.eos() && static_i < dump.static_fields.size()) {
-      if (!fs.access_flags().is_static()) {
-        fs.next();
-        continue;
-      }
-
-      const HeapDump::ClassDump::Field &field = dump.static_fields[static_i++];
-
-      Symbol *field_name = get_dumped_symbol(field.info.name_id, CHECK);
-      if (field_name == vmSymbols::resolved_references_name()) {
-        // TODO restore and apply the resolved references?
-        continue;
-      }
-
-      precond(fs.name() == field_name && is_same_basic_type(fs.signature(), field.info.type));
-      set_field(ik->java_mirror(), fs, field.value, CHECK);
-
-      fs.next();
-    }
-
-    // Process any remaining dumped resolved references
-    while (static_i < dump.static_fields.size()) {
-      const HeapDump::ClassDump::Field::Info &field_info = dump.static_fields[static_i].info;
-      Symbol *field_name = get_dumped_symbol(field_info.name_id, CHECK);
-      if (field_name == vmSymbols::resolved_references_name()) {
-        // TODO restore and apply the resolved references?
-        static_i++;
-      } else {
-        break;
-      }
-    }
-
-    postcond(static_i == dump.static_fields.size());
-#ifdef ASSERT
-    for (; !fs.eos(); fs.next()) { postcond(!fs.access_flags().is_static()); }
-#endif
-  }
-
-  void set_field(oop obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS) {
-    switch (fs.signature()->char_at(0)) {
-      case JVM_SIGNATURE_CLASS:
-      case JVM_SIGNATURE_ARRAY: {
-        // Only basic type has been validated until now, so validate the class
-        Klass *field_class = get_field_class(fs, CHECK);
-        oop restored;
-        {
-          jobject restored_handle = restore_object(val.as_object_id, CHECK);
-          restored = JNIHandles::resolve(restored_handle);
-        }
-        if (restored != nullptr && !restored->klass()->is_subtype_of(field_class)) {
-          ResourceMark rm;
-          THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                    err_msg("Field referencing a %s is dumped as an incompatible %s instance",
-                            field_class->external_name(), restored->klass()->external_name()));
-        }
-        obj->obj_field_put(fs.offset(), restored);
-        break;
-      }
-      case JVM_SIGNATURE_BOOLEAN: obj->bool_field_put(fs.offset(), val.as_boolean);  break;
-      case JVM_SIGNATURE_CHAR:    obj->char_field_put(fs.offset(), val.as_char);     break;
-      case JVM_SIGNATURE_FLOAT:   obj->float_field_put(fs.offset(), val.as_float);   break;
-      case JVM_SIGNATURE_DOUBLE:  obj->double_field_put(fs.offset(), val.as_double); break;
-      case JVM_SIGNATURE_BYTE:    obj->byte_field_put(fs.offset(), val.as_byte);     break;
-      case JVM_SIGNATURE_SHORT:   obj->short_field_put(fs.offset(), val.as_short);   break;
-      case JVM_SIGNATURE_INT:     obj->int_field_put(fs.offset(), val.as_int);       break;
-      case JVM_SIGNATURE_LONG:    obj->long_field_put(fs.offset(), val.as_long);     break;
-      default:                    ShouldNotReachHere();
-    }
-  }
-
-  static Klass *get_field_class(const FieldStream &fs, TRAPS) {
-    Thread *current = Thread::current();
-    InstanceKlass *field_holder = fs.field_descriptor().field_holder();
-    Handle loader = Handle(current, field_holder->class_loader());
-
-    // TODO after dictionary restoration for initiating loaders is implemented,
-    // use SystemDictionary::find_instance_or_array_klass() instead
-    Klass *field_class = SystemDictionary::resolve_or_fail(fs.signature(), loader, Handle(), false, THREAD);
-    if (HAS_PENDING_EXCEPTION) {
-      Handle e(Thread::current(), PENDING_EXCEPTION);
-      CLEAR_PENDING_EXCEPTION;
-      ResourceMark rm;
-      THROW_MSG_CAUSE_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                           err_msg("Cannot find field class: field %s with signature %s in object of class %s",
-                                   fs.name()->as_C_string(), fs.signature()->as_C_string(), field_holder->external_name()),
-                           e);
-    }
-
-    return field_class;
-  }
-
-  jobject restore_object(HeapDump::ID id, TRAPS) {
-    if (id == NULL_ID) {
-      return {};
-    }
-    jobject *ready = _restored_objects->get(id);
-    if (ready != nullptr) {
-      return *ready;
-    }
-
-    HeapDump::InstanceDump  *instance_dump   = _heap_dump.instance_dumps.get(id);
-    HeapDump::ObjArrayDump  *obj_array_dump  = _heap_dump.obj_array_dumps.get(id);
-    HeapDump::PrimArrayDump *prim_array_dump = _heap_dump.prim_array_dumps.get(id);
-    // HeapDumper does not include Class<*> instances of non-primitive classes
-    // in the instance dumps
-    HeapDump::ClassDump     *class_dump      = _heap_dump.class_dumps.get(id);
-
-    if (instance_dump != nullptr && obj_array_dump == nullptr && prim_array_dump == nullptr && class_dump == nullptr) {
-      jobject handle = restore_instance(*instance_dump, CHECK_NULL);
-      return handle;
-    }
-    if (instance_dump == nullptr && obj_array_dump != nullptr && prim_array_dump == nullptr && class_dump == nullptr) {
-      jobject handle = restore_obj_array(*obj_array_dump, CHECK_NULL);
-      return handle;
-    }
-    if (instance_dump == nullptr && obj_array_dump == nullptr && prim_array_dump != nullptr && class_dump == nullptr) {
-      jobject handle = restore_prim_array(*prim_array_dump, CHECK_NULL);
-      return handle;
-    }
-    if (instance_dump == nullptr && obj_array_dump == nullptr && prim_array_dump == nullptr && class_dump != nullptr) {
-      Klass *klass = restore_class(*class_dump, CHECK_NULL);
-      jobject *handle_ptr = _restored_objects->get(id); // May have got added during static fields restoration
-      if (handle_ptr == nullptr) {
-        jobject handle = JNIHandles::make_global(Handle(Thread::current(), klass->java_mirror()));
-        _restored_objects->put_when_absent(id, handle);
-        return handle;
-      }
-      assert(JNIHandles::resolve(*handle_ptr) == klass->java_mirror(), "Must be");
-      return *handle_ptr;
-    }
-
-    THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-               err_msg("Object dump " INT64_FORMAT " occurs in none or multiple dump categories", id), {});
-  }
-
-  jobject restore_instance(const HeapDump::InstanceDump &dump, TRAPS) {
-    assert(!_restored_objects->contains(dump.id), "Use restore_object() which also checks for ID duplication");
-    log_trace(restore)("Restoring instance " INT64_FORMAT, dump.id);
-
-    HeapDump::ClassDump *class_dump = get_class_dump(dump.class_id, CHECK_({}));
-    InstanceKlass *klass = load_instance_class(*class_dump, false, THREAD);
-    if (HAS_PENDING_EXCEPTION) {
-      Handle e(Thread::current(), PENDING_EXCEPTION);
-      CLEAR_PENDING_EXCEPTION;
-      THROW_MSG_CAUSE_(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Cannot load class of instance dump " INT64_FORMAT, dump.id), e, {});
-    }
-
-    // HeapDumper creates Class<*> instance dumps for primitive types
-    if (klass == vmClasses::Class_klass()) {
-      jobject handle = get_primitive_class_mirror(*class_dump, dump, THREAD);
-      return handle; // Already saved by get_primitive_class_mirror()
-    }
-
-    instanceHandle handle;
-    if (klass->is_class_loader_instance_klass()) {
-      instanceHandle *ready = _prepared_class_loaders.get(dump.id);
-      if (ready != nullptr) {
-        assert(ready->not_null(), "Stub leak");
-        handle = *ready;
-      } else {
-        handle = prepare_class_loader(klass, dump, CHECK_({}));
-        _prepared_class_loaders.put_when_absent(dump.id, handle);
-      }
-    } else if (klass->is_subclass_of(vmClasses::ProtectionDomain_klass())) {
-      instanceHandle *ready = _allocated_prot_domains.get(dump.id);
-      if (ready != nullptr) {
-        assert(ready->not_null(), "Stub leak");
-        handle = *ready;
-      } else {
-        handle = klass->allocate_instance_handle(CHECK_({}));
-        _prepared_class_loaders.put_when_absent(dump.id, handle);
-      }
-    } else {
-      handle = klass->allocate_instance_handle(CHECK_({}));
-    }
-
-    jobject jni_handle = JNIHandles::make_global(handle);
-    assert(!_restored_objects->contains(dump.id), "Should still not be restored");
-    _restored_objects->put_when_absent(dump.id, jni_handle);
-    _restored_objects->maybe_grow();
-
-    restore_class(*class_dump, CHECK_({}));
-
-    // TODO also treat classes like java.lang.Thread specially
-    if (klass->is_class_loader_instance_klass()) {
-      // TODO if this not a platform/app class loader restored by CDS, restore
-      // all but the prepared fields, treating classes field specially
-    } else {
-      set_instance_fields(handle, dump, CHECK_({}));
-    }
-
-    if (log_is_enabled(Trace, restore)) {
-      ResourceMark rm;
-      log_trace(restore)("Restored instance " INT64_FORMAT " (%s)", dump.id, klass->external_name());
-    }
-    return jni_handle;
-  }
-
-  jobject get_primitive_class_mirror(const HeapDump::ClassDump &class_dump,
-                                     const HeapDump::InstanceDump &instance_dump, TRAPS) {
-    precond(!_restored_objects->contains(instance_dump.id));
-
-    // We rely on j.l.Class name field to reveal the primitive type
-#ifdef ASSERT
-    {
-      fieldDescriptor fd;
-      precond(vmClasses::Class_klass()->find_local_field(vmSymbols::name_name(), vmSymbols::string_signature(), &fd));
-    }
-#endif  // ASSERT
-
-    u4 name_field_offset = 0;
-    for (u2 i = 0; i < class_dump.instance_field_infos.size(); i++) {
-      const HeapDump::ClassDump::Field::Info &field_info = class_dump.instance_field_infos[i];
-      if (field_info.type != HPROF_NORMAL_OBJECT) {
-        assert(HeapDump::prim2size(field_info.type) != 0, "Must be a primitive type");
-        name_field_offset += HeapDump::prim2size(field_info.type);
-        continue;
-      }
-      Symbol *field_name = get_dumped_symbol(field_info.name_id, CHECK_({}));
-      if (field_name != vmSymbols::name_name()) {
-        name_field_offset += _heap_dump.id_size;
-        continue;
-      }
-      break;
-    }
-    if (name_field_offset >= instance_dump.fields_data.size()) {
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Incorrect class instance dump " INT64_FORMAT ": no name field", instance_dump.id), {});
-    }
-
-    HeapDump::BasicValue name_id;
-    if (instance_dump.read_field(name_field_offset, JVM_SIGNATURE_CLASS, _heap_dump.id_size, &name_id) == 0) {
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Unexpected fields data size in class instance dump " INT64_FORMAT, instance_dump.id), {});
-    }
-
-    oop name;
-    {
-      jobject name_handle = restore_object(name_id.as_object_id, CHECK_({}));
-      name = JNIHandles::resolve(name_handle);
-    }
-    if (name == nullptr) {
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Name field of class instance dump " INT64_FORMAT " is uninitialized", instance_dump.id), {});
-    }
-    assert(name->klass() == vmClasses::String_klass(), "This must be checked during the field verification");
-
-    ResourceMark rm;
-    char *name_str = java_lang_String::as_quoted_ascii(name);
-
-    BasicType type = name2type(name_str);
-    if (!is_java_primitive(type) && type != T_VOID) {
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Only classes of primitive types can be instance-dumped, "
-                         "but found class instance dump named %s", name_str), {});
-    }
-
-    jobject handle = JNIHandles::make_global(Handle(Thread::current(), Universe::java_mirror(type)));
-    assert(handle != nullptr, "Primitive class mirror must not be null");
-    assert(!_restored_objects->contains(instance_dump.id), "Should still not be restored");
-    _restored_objects->put_when_absent(instance_dump.id, handle);
-    _restored_objects->maybe_grow();
-    return handle;
-  }
-
-  // Sets non-static fields, basic types should have already been verified
-  // during the class loading.
-  void set_instance_fields(instanceHandle handle, const HeapDump::InstanceDump &dump, TRAPS) {
-    precond(handle.not_null());
-
-    FieldStream fs(InstanceKlass::cast(handle->klass()), false, false);
-    u4 dump_offset = 0;
-
-    for (; !fs.eos() && dump_offset < dump.fields_data.size(); fs.next()) {
-      if (fs.access_flags().is_static()) {
-        continue;
-      }
-
-      HeapDump::BasicValue value;
-      u4 bytes_read = dump.read_field(dump_offset, fs.signature()->char_at(0), _heap_dump.id_size, &value);
-      if (bytes_read == 0) {  // Reading violates dumped fields array bounds
-        break;
-      }
-      set_field(handle(), fs, value, CHECK);
-
-      dump_offset += bytes_read;
-    }
-
-    // Skip any remaining static fields
-    while (!fs.eos() && fs.access_flags().is_static()) {
-      fs.next();
-    }
-
-    if (!fs.eos() || dump_offset < dump.fields_data.size()) {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
-                err_msg("Unexpected fields data size in instance dump " INT64_FORMAT, dump.id));
-    }
-  }
-
-  jobject restore_obj_array(const HeapDump::ObjArrayDump &dump, TRAPS) {
-    assert(!_restored_objects->contains(dump.id), "Use restore_object() which also checks for ID duplication");
-    log_trace(restore)("Restoring object array " INT64_FORMAT, dump.id);
-
-    HeapDump::ClassDump *class_dump = get_class_dump(dump.array_class_id, CHECK_({}));
-    ObjArrayKlass *klass;
-    {
-      Klass *k = load_class(*class_dump, CHECK_({}));
-      if (!k->is_objArray_klass()) {
-        ResourceMark rm;
-        THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                   err_msg("Object array dump " INT64_FORMAT " has illegal class %s", dump.id, k->external_name()),
-                   {});
-      }
-      klass = ObjArrayKlass::cast(k);
-    }
-
-    // Ensure won't overflow array length which is an int
-    if (dump.elem_ids.size() > INT_MAX) {
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Object array dump " UINT64_FORMAT " has too many elements: " UINT32_FORMAT " > %i",
-                         dump.id, dump.elem_ids.size(), INT_MAX), {});
-    }
-    int elems_num = static_cast<int>(dump.elem_ids.size());
-
-    jobject handle;
-    {
-      objArrayOop o = klass->allocate(elems_num, CHECK_({}));
-      handle = JNIHandles::make_global(Handle(Thread::current(), o));
-    }
-
-    assert(!_restored_objects->contains(dump.id), "Should still be not restored");
-    _restored_objects->put_when_absent(dump.id, handle);
-    _restored_objects->maybe_grow();
-
-    restore_class(*class_dump, CHECK_({}));
-
-    for (int i = 0; i < elems_num; i++) {
-      oop elem;
-      {
-        jobject elem_handle = restore_object(dump.elem_ids[i], CHECK_({}));
-        elem = JNIHandles::resolve(elem_handle);
-      }
-      if (elem == nullptr || elem->klass()->is_subtype_of(klass->element_klass())) {
-        static_cast<objArrayOop>(JNIHandles::resolve(handle))->obj_at_put(i, elem);
-      } else {
-        ResourceMark rm;
-        THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                   err_msg("%s array has element %i of incompatible type %s in the dump",
-                           klass->element_klass()->external_name(), i, elem->klass()->external_name()),
-                   {});
-      }
-    }
-
-    if (log_is_enabled(Trace, restore)) {
-      ResourceMark rm;
-      log_trace(restore)("Restored object array " INT64_FORMAT " (%s)", dump.id, klass->external_name());
-    }
-    return handle;
-  }
-
-  jobject restore_prim_array(const HeapDump::PrimArrayDump &dump, TRAPS) {
-    assert(!_restored_objects->contains(dump.id), "Use restore_object() which also checks for ID duplication");
-    log_trace(restore)("Restoring primitive array " INT64_FORMAT, dump.id);
-
-    // Ensure won't overflow array length which is an int
-    if (dump.elems_num > INT_MAX) {
-      THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-                 err_msg("Primitive array dump " UINT64_FORMAT " has too many elements: " UINT32_FORMAT " > %i",
-                         dump.id, dump.elems_num, INT_MAX), {});
-    }
-    int elems_num = static_cast<int>(dump.elems_num);
-
-    typeArrayOop o;
-    switch (dump.elem_type) {
-      case HPROF_BOOLEAN:
-        o = oopFactory::new_typeArray_nozero(T_BOOLEAN, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jboolean) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->bool_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      case HPROF_CHAR:
-        o = oopFactory::new_typeArray_nozero(T_CHAR, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jchar) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->char_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      case HPROF_FLOAT:
-        o = oopFactory::new_typeArray_nozero(T_FLOAT, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jfloat) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->float_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      case HPROF_DOUBLE:
-        o = oopFactory::new_typeArray_nozero(T_DOUBLE, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jdouble) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->double_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      case HPROF_BYTE:
-        o = oopFactory::new_typeArray_nozero(T_BYTE, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jbyte) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->byte_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      case HPROF_SHORT:
-        o = oopFactory::new_typeArray_nozero(T_SHORT, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jshort) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->short_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      case HPROF_INT:
-        o = oopFactory::new_typeArray_nozero(T_INT, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jint) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->int_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      case HPROF_LONG:
-        o = oopFactory::new_typeArray_nozero(T_LONG, elems_num, CHECK_({}));
-        precond(elems_num * sizeof(jlong) == dump.elems_data.size());
-        if (elems_num > 0) memcpy(o->long_at_addr(0), dump.elems_data.mem(), dump.elems_data.size());
-        break;
-      default:
-        ShouldNotReachHere();  // Ensured by the parser
-    }
-
-    jobject handle = JNIHandles::make_global(Handle(Thread::current(), o));
-    _restored_objects->put_when_absent(dump.id, handle);
-    _restored_objects->maybe_grow();
-    if (log_is_enabled(Trace, restore)) {
-      ResourceMark rm;
-      log_trace(restore)("Restored primitive array " INT64_FORMAT " (%s)", dump.id, o->klass()->external_name());
-    }
-    return handle;
-  }
-};
-
 // Restore in portable mode.
 void crac::restore_heap(TRAPS) {
   assert(is_portable_mode(), "Use crac::restore() instead");
   precond(CRaCRestoreFrom != nullptr);
   precond(_heap_dump == nullptr && _stack_dump == nullptr &&
-          _portable_loaded_classes == nullptr && _portable_restored_objects == nullptr);
+          _portable_restored_classes == nullptr && _portable_restored_objects == nullptr);
 
   char path[JVM_MAXPATHLEN];
 
@@ -1892,41 +785,57 @@ void crac::restore_heap(TRAPS) {
   _heap_dump = new ParsedHeapDump();
   const char* err_str = HeapDumpParser::parse(path, _heap_dump);
   if (err_str != nullptr) {
-    delete _heap_dump;
+    clear_restoration_data();
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               err_msg("Restore failed: cannot parse heap dump %s (%s)", path, err_str));
   }
+  assert(!_heap_dump->utf8s.contains(HeapDump::NULL_ID) &&
+         !_heap_dump->class_dumps.contains(HeapDump::NULL_ID) &&
+         !_heap_dump->instance_dumps.contains(HeapDump::NULL_ID) &&
+         !_heap_dump->obj_array_dumps.contains(HeapDump::NULL_ID) &&
+         !_heap_dump->prim_array_dumps.contains(HeapDump::NULL_ID), "records cannot have null ID");
 
   os::snprintf_checked(path, sizeof(path), "%s%s%s", CRaCRestoreFrom, os::file_separator(), PMODE_STACK_DUMP_FILENAME);
   _stack_dump = new ParsedStackDump();
-  err_str = StackDumpParser::parse(path, _stack_dump);
+  err_str = CracStackDumpParser::parse(path, _stack_dump);
   if (err_str != nullptr) {
-    delete _heap_dump;
-    delete _stack_dump;
+    clear_restoration_data();
     THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
               err_msg("Restore failed: cannot parse stack dump %s (%s)", path, err_str));
   }
   if (_stack_dump->word_size() != oopSize) {
-    delete _heap_dump;
-    delete _stack_dump;
-    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
+    const u2 dumped_word_size = _stack_dump->word_size();
+    clear_restoration_data();
+    THROW_MSG(vmSymbols::java_lang_UnsupportedOperationException(),
               err_msg("Restore failed: stack dump comes from an incompatible platform "
-                      "(dumped word size %i != current word size %i)", _stack_dump->word_size(), oopSize));
+                      "(dumped word size %i != current word size %i)", dumped_word_size, oopSize));
   }
 
-  // TODO _portable_restored_objects will be filled with handles, so have to
-  //  ensure they won't be destroyed by the time thread restoration code uses
-  //  them. Use local JNI handles as HandleMark's description suggests?
-  HeapRestorer heap_restorer(*_heap_dump, _stack_dump->stack_traces(),
-                             &_portable_loaded_classes, &_portable_restored_objects);
-  heap_restorer.restore_heap(THREAD);
-  if (HAS_PENDING_EXCEPTION) {
-    delete _heap_dump;
-    delete _stack_dump;
-    delete _portable_loaded_classes;
-    delete _portable_restored_objects; // TODO destroy JNI handles?
+  HeapDumpTable<ArrayKlass *,AnyObj::C_HEAP> array_classes(107, 10000);
+  _portable_restored_classes = new(mtInternal) HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP>(107, 10000);
+  _portable_restored_objects = new(mtInternal) HeapDumpTable<jobject,         AnyObj::C_HEAP>(107, 100000);
 
-    Handle e(Thread::current(), PENDING_EXCEPTION);
+  ResourceMark rm; // For HeapRestorer's fields
+  CracHeapRestorer heap_restorer(*_heap_dump, *_portable_restored_classes, array_classes, _portable_restored_objects, THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    clear_restoration_data();
+    return;
+  }
+
+  os::snprintf_checked(path, sizeof(path), "%s%s%s", CRaCRestoreFrom, os::file_separator(), PMODE_CLASS_DUMP_FILENAME);
+  HeapDumpTable<ClassHeapDeps, AnyObj::C_HEAP> heap_deps(107, 10000);
+  CracClassDumpParser::parse(path, *_heap_dump, &heap_restorer, _portable_restored_classes, &array_classes, &heap_deps, THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    clear_restoration_data();
+    const Handle e(Thread::current(), PENDING_EXCEPTION);
+    CLEAR_PENDING_EXCEPTION;
+    THROW_MSG_CAUSE(vmSymbols::java_lang_IllegalArgumentException(), "Restore failed: cannot create classes", e);
+  }
+
+  heap_restorer.restore_heap(heap_deps, _stack_dump->stack_traces(), THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    clear_restoration_data();
+    const Handle e(Thread::current(), PENDING_EXCEPTION);
     CLEAR_PENDING_EXCEPTION;
     THROW_MSG_CAUSE(vmSymbols::java_lang_IllegalArgumentException(), "Restore failed: cannot restore heap", e);
   }
@@ -1936,21 +845,18 @@ class vframeRestoreArrayElement : public vframeArrayElement {
  public:
    void fill_in(const StackTrace::Frame &snapshot,
                 bool reexecute,
-                const ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP> &classes,
-                const ResizeableResourceHashtable<HeapDump::ID, jobject,  AnyObj::C_HEAP> &objects,
-                const ParsedHeapDump::RecordTable<HeapDump::UTF8>                        &symbols,
-                TRAPS) {
-    _method = get_method(snapshot, classes, symbols, CHECK);
+                const ResizeableResourceHashtable<HeapDump::ID, InstanceKlass *, AnyObj::C_HEAP> &classes,
+                const ResizeableResourceHashtable<HeapDump::ID, jobject, AnyObj::C_HEAP> &objects,
+                const ParsedHeapDump::RecordTable<HeapDump::UTF8> &symbols) {
+    _method = get_method(snapshot, classes, symbols);
 
     _bci = snapshot.bci;
-    if (_method->validate_bci(_bci) != _bci) {
-      THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Invalid bytecode index %i", _bci));
-    }
+    guarantee(_method->validate_bci(_bci) == _bci, "invalid bytecode index %i", _bci);
 
     _reexecute = reexecute;
 
-    _locals = get_stack_values(snapshot.locals, objects, CHECK);
-    _expressions = get_stack_values(snapshot.operands, objects, CHECK);
+    _locals = get_stack_values(snapshot.locals, objects);
+    _expressions = get_stack_values(snapshot.operands, objects);
 
     // TODO add monitor info into the snapshot; for now assuming no monitors
     _monitors = nullptr;
@@ -1958,60 +864,42 @@ class vframeRestoreArrayElement : public vframeArrayElement {
    }
 
  private:
+  // TODO when the stack dump format is simplified to include method idnum,
+  //  remove the symbols dependency and make heap dump resource-allocated
   static Method *get_method(const StackTrace::Frame &snapshot,
-                            const ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP> &classes,
-                            const ParsedHeapDump::RecordTable<HeapDump::UTF8>                        &symbols,
-                            TRAPS) {
+                            const ResizeableResourceHashtable<HeapDump::ID, InstanceKlass *, AnyObj::C_HEAP> &classes,
+                            const ParsedHeapDump::RecordTable<HeapDump::UTF8> &symbols) {
     InstanceKlass *method_class;
     {
-      Klass **c = classes.get(snapshot.class_id);
-      if (c == nullptr) {
-        THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Unknown class ID " UINT64_FORMAT, snapshot.class_id));
-      }
-      if (!(*c)->is_instance_klass()) {
-        ResourceMark rm;
-        THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Class %s (ID " UINT64_FORMAT ") is not an instance class",
-                               (*c)->external_name(), snapshot.class_id));
-      }
+      InstanceKlass **const c = classes.get(snapshot.class_id);
+      guarantee(c != nullptr, "unknown class ID " HDID_FORMAT, snapshot.class_id);
       method_class = InstanceKlass::cast(*c);
     }
     assert(method_class->is_linked(), "Must be rewritten before executing its methods");
 
     Symbol *method_name;
     {
-      HeapDump::UTF8 *r = symbols.get(snapshot.method_name_id);
-      if (r == nullptr) {
-        THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Unknown method name ID " UINT64_FORMAT, snapshot.method_sig_id));
-      }
+      HeapDump::UTF8 *const r = symbols.get(snapshot.method_name_id);
+      guarantee(r != nullptr, "unknown method name ID " HDID_FORMAT, snapshot.method_sig_id);
       method_name = r->sym;
     }
 
     Symbol *method_sig;
     {
       HeapDump::UTF8 *r = symbols.get(snapshot.method_sig_id);
-      if (r == nullptr) {
-        THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Unknown method signature ID " UINT64_FORMAT, snapshot.method_sig_id));
-      }
+      guarantee(r != nullptr, "unknown method signature ID " HDID_FORMAT, snapshot.method_sig_id);
       method_sig = r->sym;
     }
 
     Method *method = method_class->find_method(method_name, method_sig);
-    if (method == nullptr) {
-      THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                     err_msg("Method %s %s not found in class %s",
-                             method_sig->as_C_string(), method_name->as_C_string(), method_class->external_name()));
-    }
+    guarantee(method != nullptr, "method %s %s not found in class %s",
+              method_sig->as_C_string(), method_name->as_C_string(), method_class->external_name());
 
     return method;
   }
 
   static StackValueCollection *get_stack_values(const ExtendableArray<StackTrace::Frame::Value, u2> &src,
-                                                const ResizeableResourceHashtable<HeapDump::ID, jobject,  AnyObj::C_HEAP> &objects,
-                                                TRAPS) {
+                                                const ResizeableResourceHashtable<HeapDump::ID, jobject, AnyObj::C_HEAP> &objects) {
     auto *stack_values = new StackValueCollection(src.size()); // stack_values->size() == 0 until we add the actual values
     for (int i = 0; i < src.size(); i++) {
       const StackTrace::Frame::Value &src_value = src[i];
@@ -2028,10 +916,7 @@ class vframeRestoreArrayElement : public vframeArrayElement {
           jobject handle = nullptr;
           if (src_value.obj_id != 0) { // 0 ID means null
             jobject *handle_ptr = objects.get(src_value.obj_id);
-            if (handle_ptr == nullptr) {
-              THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                             err_msg("Unknown object ID " UINT64_FORMAT " in stack value %i", src_value.obj_id, i));
-            }
+            guarantee(handle_ptr != nullptr, "unknown object ID " HDID_FORMAT " in stack value %i", src_value.obj_id, i);
             handle = *handle_ptr;
           }
           // Unpacking code of vframeArrayElement expects a raw oop
@@ -2049,15 +934,11 @@ class vframeRestoreArrayElement : public vframeArrayElement {
 class vframeRestoreArray : public vframeArray {
  public:
   static vframeRestoreArray *allocate(const StackTrace &stack,
-                                      const ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP> &classes,
-                                      const ResizeableResourceHashtable<HeapDump::ID, jobject,  AnyObj::C_HEAP> &objects,
-                                      const ParsedHeapDump::RecordTable<HeapDump::UTF8>                        &symbols,
-                                      TRAPS) {
-    if (stack.frames_num() > INT_MAX) {
-      THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
-                     err_msg("Stack trace of thread " UINT64_FORMAT " is too long: " UINT32_FORMAT " > %i",
-                             stack.thread_id(), stack.frames_num(), INT_MAX));
-    }
+                                      const ResizeableResourceHashtable<HeapDump::ID, InstanceKlass *, AnyObj::C_HEAP> &classes,
+                                      const ResizeableResourceHashtable<HeapDump::ID, jobject, AnyObj::C_HEAP> &objects,
+                                      const ParsedHeapDump::RecordTable<HeapDump::UTF8> &symbols) {
+    guarantee(stack.frames_num() <= INT_MAX, "stack trace of thread " HDID_FORMAT " is too long: " UINT32_FORMAT " > %i",
+              stack.thread_id(), stack.frames_num(), INT_MAX);
     auto *result = reinterpret_cast<vframeRestoreArray *>(AllocateHeap(sizeof(vframeArray) + // fixed part
                                                                        sizeof(vframeArrayElement) * (stack.frames_num() - 1), // variable part
                                                                        mtInternal));
@@ -2070,28 +951,23 @@ class vframeRestoreArray : public vframeArray {
     result->_caller = frame();       // Seems to be the same as _sender
     result->_original = frame();     // Deoptimized frame which we don't have
 
-    result->fill_in(stack, classes, objects, symbols, CHECK_NULL);
+    result->fill_in(stack, classes, objects, symbols);
     return result;
   }
 
   void fill_in(const StackTrace &stack,
-               const ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP> &classes,
-               const ResizeableResourceHashtable<HeapDump::ID, jobject,  AnyObj::C_HEAP> &objects,
-               const ParsedHeapDump::RecordTable<HeapDump::UTF8>                        &symbols,
-               TRAPS) {
+               const ResizeableResourceHashtable<HeapDump::ID, InstanceKlass *, AnyObj::C_HEAP> &classes,
+               const ResizeableResourceHashtable<HeapDump::ID, jobject, AnyObj::C_HEAP> &objects,
+               const ParsedHeapDump::RecordTable<HeapDump::UTF8> &symbols) {
     _frame_size = 0; // Unused (no frame is being deoptimized)
 
     // The first frame is the youngest, the last is the oldest
-    log_trace(restore)("Filling stack trace for thread " UINT64_FORMAT, stack.thread_id());
+    log_trace(crac)("Filling stack trace for thread " HDID_FORMAT, stack.thread_id());
     precond(frames() == static_cast<int>(stack.frames_num()));
     for (int i = 0; i < frames(); i++) {
-      log_trace(restore)("Filling frame %i", i);
-      static_cast<vframeRestoreArrayElement *>(element(i))->fill_in(stack.frames(i), i == 0 && stack.should_reexecute_youngest(), classes, objects, symbols, THREAD);
-      if (HAS_PENDING_EXCEPTION) {
-        Handle e(Thread::current(), PENDING_EXCEPTION);
-        CLEAR_PENDING_EXCEPTION;
-        THROW_MSG_CAUSE(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Illegal frame snapshot: %i", i), e);
-      }
+      log_trace(crac)("Filling frame %i", i);
+      auto *const elem = static_cast<vframeRestoreArrayElement *>(element(i));
+      elem->fill_in(stack.frames(i), i == 0 && stack.should_reexecute_youngest(), classes, objects, symbols);
     }
   }
 };
@@ -2100,7 +976,7 @@ class vframeRestoreArray : public vframeArray {
 // fill them.
 JRT_LEAF(void, crac::fill_in_frames())
   JavaThread *current = JavaThread::current();
-  log_debug(restore)("Thread %p: filling skeletal frames", current);
+  log_debug(crac)("Thread %p: filling skeletal frames", current);
 
   // The code below is analogous to Deoptimization::unpack_frames()
 
@@ -2118,7 +994,7 @@ JRT_LEAF(void, crac::fill_in_frames())
   guarantee(current->frames_to_pop_failed_realloc() == 0,
             "We don't deoptimize, so no reallocations of scalar replaced objects can happen and fail");
   array->unpack_to_stack(unpack_frame, Deoptimization::Unpack_deopt /* TODO this or reexecute? */, initial_caller_parameters);
-  log_debug(restore)("Thread %p: skeletal frames filled", current);
+  log_debug(crac)("Thread %p: skeletal frames filled", current);
 
   // Cleanup, analogous to Deoptimization::cleanup_deopt_info()
   current->set_vframe_array_head(nullptr);
@@ -2185,9 +1061,9 @@ class NullArgumentsFiller : public SignatureIterator {
 JavaValue crac::restore_current_thread(TRAPS) {
   precond(!_stack_dump->stack_traces().is_empty());
   JavaThread *current = JavaThread::current();
-  if (log_is_enabled(Info, restore)) {
+  if (log_is_enabled(Info, crac)) {
     ResourceMark rm;
-    log_info(restore)("Thread %p (%s): starting the restoration", current, current->name());
+    log_info(crac)("Thread %p (%s): starting the restoration", current, current->name());
   }
   HandleMark hm(current);
 
@@ -2208,7 +1084,7 @@ JavaValue crac::restore_current_thread(TRAPS) {
   {
     const StackTrace *stack = _stack_dump->stack_traces().pop();
     if (stack->frames_num() == 0) { // TODO should this be considered an error?
-      log_info(restore)("Thread %p: no frames in stack snapshot (ID " UINT64_FORMAT ")", current, stack->thread_id());
+      log_info(crac)("Thread %p: no frames in stack snapshot (ID " HDID_FORMAT ")", current, stack->thread_id());
       if (_stack_dump->stack_traces().is_empty()) {
         clear_restoration_data();
       }
@@ -2217,26 +1093,16 @@ JavaValue crac::restore_current_thread(TRAPS) {
     }
 
     array = vframeRestoreArray::allocate(*stack,
-                                         *crac::_portable_loaded_classes,
+                                         *crac::_portable_restored_classes,
                                          *crac::_portable_restored_objects,
-                                         crac::_heap_dump->utf8s, THREAD);
+                                         crac::_heap_dump->utf8s);
     if (_stack_dump->stack_traces().is_empty()) {
       clear_restoration_data();
-    }
-    if (HAS_PENDING_EXCEPTION) {
-      ResourceMark rm; // Thread name
-      Handle e(current, PENDING_EXCEPTION);
-      CLEAR_PENDING_EXCEPTION;
-      StackTrace::ID thread_id = stack->thread_id();
-      delete stack;
-      THROW_MSG_CAUSE_(vmSymbols::java_lang_IllegalArgumentException(),
-                       err_msg("Cannot restore state of thread %s (ID " UINT64_FORMAT ")", current->name(), thread_id),
-                       e, {});
     }
     postcond(array->frames() == static_cast<int>(stack->frames_num()));
     delete stack;
   }
-  log_debug(restore)("Thread %p: filled frame array (%i frames)", current, array->frames());
+  log_debug(crac)("Thread %p: filled frame array (%i frames)", current, array->frames());
 
   // Determine sizes and return pcs of the constructed frames.
   //
@@ -2307,16 +1173,16 @@ JavaValue crac::restore_current_thread(TRAPS) {
   // Make the CallStub call RestoreStub instead of the actual method entry
   args.set_use_restore_stub(true);
 
-  if (log_is_enabled(Info, restore)) {
+  if (log_is_enabled(Info, crac)) {
     ResourceMark rm;
-    log_debug(restore)("Thread %p: calling %s to enter restore stub", current, method->name_and_sig_as_C_string());
+    log_debug(crac)("Thread %p: calling %s to enter restore stub", current, method->name_and_sig_as_C_string());
   }
   JavaValue result(method->result_type());
   JavaCalls::call(&result, method, &args, CHECK_({}));
   // Note: any resources allocated in this scope have been freed by the
   // deopt_mark by now
 
-  log_info(restore)("Thread %p: restored execution completed", current);
+  log_info(crac)("Thread %p: restored execution completed", current);
   return result;
 }
 
@@ -2324,7 +1190,7 @@ void crac::restore_threads(TRAPS) {
   assert(is_portable_mode(), "Use crac::restore() instead");
   precond(CRaCRestoreFrom != nullptr);
   assert(_heap_dump != nullptr && _stack_dump != nullptr &&
-         _portable_loaded_classes != nullptr && _portable_restored_objects != nullptr,
+         _portable_restored_classes != nullptr && _portable_restored_objects != nullptr,
          "Call crac::restore_heap() first");
 
   // TODO for now we only restore the main thread
@@ -2336,17 +1202,17 @@ void crac::restore_threads(TRAPS) {
          strcmp(JavaThread::current()->name(), "main") == 0, "Must be called on the main thread");
   }
 #endif // ASSERT
-  JavaValue result = restore_current_thread(THREAD);
-  if (!HAS_PENDING_EXCEPTION) {
-    log_info(restore)("Main thread execution resulted in type: %s", type2name(result.get_type()));
-  }
+  JavaValue result = restore_current_thread(CHECK);
+  log_info(crac)("Main thread execution resulted in type: %s", type2name(result.get_type()));
 }
 
 void crac::clear_restoration_data() {
   delete _heap_dump;
   delete _stack_dump;
-  delete _portable_loaded_classes;
-  // TODO we iterate the whole restored heap here, is there a faster way?
-  _portable_restored_objects->iterate_all([](HeapDump::ID _, jobject h) -> void { JNIHandles::destroy_global(h); });
+  delete _portable_restored_classes;
+  if (_portable_restored_objects != nullptr) {
+    // TODO we iterate the whole restored heap here, is there a faster way?
+  _portable_restored_objects->iterate_all([](HeapDump::ID _, jobject h) { JNIHandles::destroy_global(h); });
+  }
   delete _portable_restored_objects;
 }

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -208,7 +208,8 @@ static VM_Crac::Outcome checkpoint_portable() {
   os::snprintf_checked(path, sizeof(path), "%s%s%s",
                        CRaCCheckpointTo, os::file_separator(), PMODE_HEAP_DUMP_FILENAME);
   {
-    HeapDumper dumper(false /* No GC: it's already done by crac::checkpoint */);
+    HeapDumper dumper(false, // No GC: it's already been performed by crac::checkpoint()
+                      true); // Include injected fields
     if (dumper.dump(path,
                     nullptr,  // No additional output
                     -1,       // No compression, TODO: enable this when the parser supports it

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -823,8 +823,8 @@ void crac::restore_heap(TRAPS) {
   }
 
   os::snprintf_checked(path, sizeof(path), "%s%s%s", CRaCRestoreFrom, os::file_separator(), PMODE_CLASS_DUMP_FILENAME);
-  HeapDumpTable<ClassHeapDeps, AnyObj::C_HEAP> heap_deps(107, 10000);
-  CracClassDumpParser::parse(path, *_heap_dump, &heap_restorer, _portable_restored_classes, &array_classes, &heap_deps, THREAD);
+  HeapDumpTable<UnfilledClassInfo, AnyObj::C_HEAP> class_infos(107, 10000);
+  CracClassDumpParser::parse(path, *_heap_dump, &heap_restorer, _portable_restored_classes, &array_classes, &class_infos, THREAD);
   if (HAS_PENDING_EXCEPTION) {
     clear_restoration_data();
     const Handle e(Thread::current(), PENDING_EXCEPTION);
@@ -832,7 +832,7 @@ void crac::restore_heap(TRAPS) {
     THROW_MSG_CAUSE(vmSymbols::java_lang_IllegalArgumentException(), "Restore failed: cannot create classes", e);
   }
 
-  heap_restorer.restore_heap(heap_deps, _stack_dump->stack_traces(), THREAD);
+  heap_restorer.restore_heap(class_infos, _stack_dump->stack_traces(), THREAD);
   if (HAS_PENDING_EXCEPTION) {
     clear_restoration_data();
     const Handle e(Thread::current(), PENDING_EXCEPTION);

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -25,10 +25,10 @@
 #define SHARE_RUNTIME_CRAC_HPP
 
 #include "memory/allStatic.hpp"
+#include "runtime/cracStackDumpParser.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/heapDumpParser.hpp"
-#include "utilities/stackDumpParser.hpp"
 
 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #define UUID_LENGTH 36
@@ -79,9 +79,8 @@ private:
 
   static ParsedHeapDump  *_heap_dump;
   static ParsedStackDump *_stack_dump;
-  // TODO use restored classes once we are able to restore system classes
-  static ResizeableResourceHashtable<HeapDump::ID, Klass *, AnyObj::C_HEAP> *_portable_loaded_classes;
-  static ResizeableResourceHashtable<HeapDump::ID, jobject, AnyObj::C_HEAP> *_portable_restored_objects;
+  static HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *_portable_restored_classes;
+  static HeapDumpTable<jobject, AnyObj::C_HEAP> *_portable_restored_objects;
 };
 
 #endif //SHARE_RUNTIME_CRAC_HPP

--- a/src/hotspot/share/runtime/cracClassDumpParser.cpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.cpp
@@ -1726,6 +1726,13 @@ void CracClassDumpParser::parse_primitive_array_classes(TRAPS) {
     _aks->put_when_absent(prim_array_class_id, TypeArrayKlass::cast(tak));
     parse_obj_array_classes(tak, CHECK);
   }
+  {
+    const HeapDump::ID filler_array_class_id = read_id(false, CHECK);
+    Klass *const tak = Universe::fillerArrayKlassObj();
+    precond(!_aks->contains(filler_array_class_id));
+    _aks->put_when_absent(filler_array_class_id, TypeArrayKlass::cast(tak));
+    parse_obj_array_classes(tak, CHECK);
+  }
   log_debug(crac, class, parser)("Parsed primitive array classes");
 }
 

--- a/src/hotspot/share/runtime/cracClassDumpParser.cpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.cpp
@@ -1283,7 +1283,7 @@ class CracInstanceClassDumpParser : public StackObj /* constructor allocates res
     const u2 default_methods_num = read<u2>(CHECK);
     if (default_methods_num > 0) {
       guarantee(_ik_flags.has_nonstatic_concrete_methods(),
-                "class without non-static non-abstract methods in its hierarchy should not have default methods");
+                "class without default methods in its hierarchy should not have default methods");
 
       // Pre-fill with nulls so that deallocation works correctly if an error occures before the array is filled
       _default_methods = MetadataFactory::new_array<Method *>(_loader_data, default_methods_num, nullptr, CHECK);
@@ -1587,7 +1587,7 @@ class CracInstanceClassDumpParser : public StackObj /* constructor allocates res
                                    CHECK);
 
     if (ik.default_methods() != nullptr) {
-      assert(ik.has_nonstatic_concrete_methods(), "should have been checked when parsing the default methods");
+      precond(ik.has_nonstatic_concrete_methods());
       Method::sort_methods(ik.default_methods(), /*set_idnums=*/ false);
       ik.create_new_default_vtable_indices(ik.default_methods()->length(), CHECK);
     }

--- a/src/hotspot/share/runtime/cracClassDumpParser.cpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.cpp
@@ -1,0 +1,2217 @@
+#include "precompiled.hpp"
+#include "classfile/classFileParser.hpp"
+#include "classfile/classLoaderData.hpp"
+#include "classfile/dictionary.hpp"
+#include "classfile/fieldLayoutBuilder.hpp"
+#include "classfile/javaClasses.hpp"
+#include "classfile/moduleEntry.hpp"
+#include "classfile/resolutionErrors.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "classfile/vmClasses.hpp"
+#include "classfile/vmIntrinsics.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "classfile_constants.h"
+#include "interpreter/bytecodeStream.hpp"
+#include "interpreter/bytecodes.hpp"
+#include "jni.h"
+#include "jvm_constants.h"
+#include "logging/log.hpp"
+#include "memory/allocation.hpp"
+#include "memory/metadataFactory.hpp"
+#include "memory/resourceArea.hpp"
+#include "memory/universe.hpp"
+#include "metaprogramming/enableIf.hpp"
+#include "oops/annotations.hpp"
+#include "oops/array.hpp"
+#include "oops/constMethod.hpp"
+#include "oops/constMethodFlags.hpp"
+#include "oops/constantPool.hpp"
+#include "oops/constantPool.inline.hpp"
+#include "oops/cpCache.hpp"
+#include "oops/fieldInfo.hpp"
+#include "oops/fieldInfo.inline.hpp"
+#include "oops/fieldStreams.inline.hpp"
+#include "oops/instanceKlass.hpp"
+#include "oops/instanceKlassFlags.hpp"
+#include "oops/klassVtable.hpp"
+#include "oops/method.hpp"
+#include "oops/method.inline.hpp"
+#include "oops/methodFlags.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "oops/recordComponent.hpp"
+#include "oops/resolvedFieldEntry.hpp"
+#include "oops/resolvedIndyEntry.hpp"
+#include "prims/jvmtiExport.hpp"
+#include "prims/jvmtiRedefineClasses.hpp"
+#include "runtime/arguments.hpp"
+#include "runtime/cracClassDumpParser.hpp"
+#include "runtime/cracClassDumper.hpp"
+#include "runtime/cracClassStateRestorer.hpp"
+#include "runtime/cracHeapRestorer.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/handles.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "runtime/os.hpp"
+#include "runtime/signature.hpp"
+#include "runtime/thread.hpp"
+#include "services/classLoadingService.hpp"
+#include "utilities/accessFlags.hpp"
+#include "utilities/basicTypeReader.hpp"
+#include "utilities/bytes.hpp"
+#include "utilities/constantTag.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/exceptions.hpp"
+#include "utilities/formatBuffer.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/growableArray.hpp"
+#include "utilities/heapDumpParser.hpp"
+#include "utilities/macros.hpp"
+#include "utilities/pair.hpp"
+#include "utilities/tribool.hpp"
+#include <type_traits>
+#if INCLUDE_JFR
+#include "jfr/support/jfrTraceIdExtension.hpp"
+#endif // INCLUDE_JFR
+
+static constexpr bool IS_ZERO = ZERO_ONLY(true) NOT_ZERO(false);
+static constexpr bool HAVE_JVMTI = JVMTI_ONLY(true) NOT_JVMTI(false);
+
+void ClassDumpReader::set_id_size(u2 value, TRAPS) {
+  if (!is_supported_id_size(value)) {
+    THROW_MSG(vmSymbols::java_lang_UnsupportedOperationException(),
+              err_msg("ID size %i is not supported: should be 1, 2, 4 or 8", value));
+  }
+  _id_size = value;
+}
+
+void ClassDumpReader::read_raw(void *buf, size_t size, TRAPS) {
+  if (!_reader->read_raw(buf, size)) {
+    log_error(crac, class, parser)("Raw reading error (position %zu, size %zu): %s", _reader->pos(), size, os::strerror(errno));
+    THROW_MSG(vmSymbols::java_io_IOException(), "Truncated dump");
+  }
+}
+
+template <class T>
+T ClassDumpReader::read(TRAPS) {
+  T result;
+  if (!_reader->read(&result)) {
+    log_error(crac, class, parser)("Basic type reading error (position %zu, size %zu): %s", _reader->pos(), sizeof(T), os::strerror(errno));
+    THROW_MSG_(vmSymbols::java_io_IOException(), "Truncated dump", {});
+  }
+  return result;
+}
+
+bool ClassDumpReader::read_bool(TRAPS) {
+  const auto byte = read<u1>(CHECK_false);
+  guarantee(byte <= 1, "not a boolean: expected 0 or 1, got %i", byte);
+  return byte == 1;
+}
+
+HeapDump::ID ClassDumpReader::read_id(bool can_be_null, TRAPS) {
+  precond(_id_size > 0);
+  HeapDump::ID result;
+  if (!_reader->read_uint(&result, _id_size)) {
+    log_error(crac, class, parser)("ID reading error (position %zu, size %i): %s", _reader->pos(), _id_size, os::strerror(errno));
+    THROW_MSG_0(vmSymbols::java_io_IOException(), "Truncated dump");
+  }
+  guarantee(can_be_null || result != HeapDump::NULL_ID, "unexpected null ID");
+  return result;
+}
+
+void ClassDumpReader::skip(size_t size, TRAPS) {
+  if (!_reader->skip(size)) {
+    log_error(crac, class, parser)("Reading error (position %zu, size %zu): %s", _reader->pos(), size, os::strerror(errno));
+    THROW_MSG(vmSymbols::java_io_IOException(), "Truncated dump");
+  }
+}
+
+// Parses a particular class in a class dump and creates it.
+class CracInstanceClassDumpParser : public StackObj /* constructor allocates resources */,
+                                    public ClassDumpReader {
+ private:
+  const ParsedHeapDump &_heap_dump;                      // Heap dump accompanying the class dump
+  const HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> &_created_classes; // Classes already created (super and interfaces should be here)
+  const HeapDump::ClassDump &_class_dump;
+  ClassLoaderData *const _loader_data;
+
+  bool _finished = false;
+  InstanceKlass *_ik = nullptr;
+  InstanceKlass::ClassState _class_state;
+  HeapDump::ID _class_initialization_error_id;
+  InterclassRefs _interclass_refs;
+
+ public:
+  CracInstanceClassDumpParser(u2 id_size, BasicTypeReader *reader, const ParsedHeapDump &heap_dump,
+                              const HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> &created_classes,
+                              const HeapDump::ClassDump &class_dump, ClassLoaderData *loader_data, TRAPS) :
+      ClassDumpReader(reader, id_size), _heap_dump(heap_dump),
+      _created_classes(created_classes), _class_dump(class_dump),
+      _loader_data(loader_data) {
+    precond(reader != nullptr);
+    precond(loader_data != nullptr);
+    parse_class(CHECK);
+    create_class(CHECK);
+    _finished = true;
+    postcond(_ik != nullptr);
+  }
+
+  InstanceKlass *created_class()     const           { precond(_finished); return _ik; }
+  // Returned arrays are resource-allocated in the parser's constructor. The
+  // caller must ensure there is no resource mark boundaries between the call to
+  // the constructor and the usage of the returned arrays.
+  InterclassRefs interclass_references() const       { precond(_finished); return _interclass_refs; }
+  InstanceKlass::ClassState class_state() const      { precond(_finished); return _class_state; }
+  HeapDump::ID class_initialization_error_id() const { precond(_finished); return _class_initialization_error_id; }
+
+  ~CracInstanceClassDumpParser() {
+    if (_finished) {
+      // The data has been transfered to the created class which is now
+      // responsible for deallocation
+      return;
+    }
+
+    if (_ik != nullptr) {
+      // Do what ClassFileParser does
+      _loader_data->add_to_deallocate_list(_ik);
+    }
+
+    if (_nest_members != Universe::the_empty_short_array()) {
+      MetadataFactory::free_array(_loader_data, _nest_members);
+    }
+    if (_inner_classes != Universe::the_empty_short_array()) {
+      MetadataFactory::free_array(_loader_data, _inner_classes);
+    }
+    if (_permitted_subclasses != Universe::the_empty_short_array()) {
+      MetadataFactory::free_array(_loader_data, _inner_classes);
+    }
+    if (_source_debug_extension != nullptr) {
+      FREE_C_HEAP_ARRAY(char, _source_debug_extension);
+    }
+    MetadataFactory::free_array(_loader_data, _bsm_operands);
+    MetadataFactory::free_array(_loader_data, _class_annotations);
+    MetadataFactory::free_array(_loader_data, _class_type_annotations);
+    InstanceKlass::deallocate_record_components(_loader_data, _record_components);
+
+    SystemDictionary::delete_resolution_error(_cp);
+    MetadataFactory::free_metadata(_loader_data, _cp);
+
+    InstanceKlass::deallocate_interfaces(_loader_data, _super, _local_interfaces, _transitive_interfaces);
+
+    if (_original_method_ordering != Universe::the_empty_int_array()) {
+      MetadataFactory::free_array(_loader_data, _original_method_ordering);
+    }
+    InstanceKlass::deallocate_methods(_loader_data, _methods);
+    if (_default_methods != Universe::the_empty_method_array()) {
+      MetadataFactory::free_array(_loader_data, _default_methods);
+    }
+
+    MetadataFactory::free_array(_loader_data, _field_info_stream);
+    MetadataFactory::free_array(_loader_data, _field_statuses);
+    Annotations::free_contents(_loader_data, _field_annotations);
+    Annotations::free_contents(_loader_data, _field_type_annotations);
+
+    JVMTI_ONLY(os::free(_cached_class_file)); // Handles nullptr
+  };
+
+ private:
+  // First the parsed data is put into these fields, then when there is enough
+  // data to allocate the class, the ownership of this data istransfered to it
+
+  u2 _minor_version;                                      // Class file's minor version
+  u2 _major_version;                                      // Class file's major version
+  JVMTI_ONLY(jint _redefinition_version);                 // Class redefinition version
+
+  AccessFlags _class_access_flags;                        // Class access flags from class file + internal flags from Klass
+  InstanceKlassFlags _ik_flags;                           // Internal flags and statuses from InstanceKlass
+
+  u2 _source_file_name_index;                             // SourceFile class attribute
+  u2 _generic_signature_index;                            // Signature class attribute
+  u2 _nest_host_index;                                    // NestHost class attribute
+  Array<u2> *_nest_members = nullptr;                     // NestMembers class attribute
+  Array<u2> *_inner_classes = nullptr;                    // InnerClasses and EnclosingMethod class attributes
+  char *_source_debug_extension = nullptr;                // SourceDebugExtension class attribute (nul-terminated, heap-allocated)
+  Array<u2> *_bsm_operands = nullptr;                     // BootstrapMethods class attribute (gets moved into the ConstantPool as soon as it's ready)
+  Array<RecordComponent *> *_record_components = nullptr; // Record class attribute
+  Array<u2> *_permitted_subclasses = nullptr;             // PermittedSubclasses class attribute
+  AnnotationArray *_class_annotations = nullptr;          // Runtime(In)VisibleAnnotations
+  AnnotationArray *_class_type_annotations = nullptr;     // Runtime(In)VisibleTypeAnnotations class attribute
+
+  ConstantPool *_cp = nullptr;
+
+  u2 _this_class_index;
+  InstanceKlass *_super = nullptr;
+  Array<InstanceKlass *> *_local_interfaces = nullptr;
+  Array<InstanceKlass *> *_transitive_interfaces = nullptr;
+
+  u2 _java_fields_num;
+  u2 _injected_fields_num;
+  u2 _static_oop_fields_num;
+  GrowableArrayCHeap<FieldInfo, mtInternal> _field_infos;
+  Array<u1> *_field_info_stream = nullptr;
+  Array<FieldStatus> *_field_statuses = nullptr;
+  Array<AnnotationArray *> *_field_annotations = nullptr;
+  Array<AnnotationArray *> *_field_type_annotations = nullptr;
+
+  Array<int> *_original_method_ordering = nullptr;
+  Array<Method *> *_methods = nullptr;
+  Array<Method *> *_default_methods = nullptr;
+
+  JVMTI_ONLY(JvmtiCachedClassFileData *_cached_class_file = nullptr);
+
+  // ###########################################################################
+  // Parsing helpers
+  // ###########################################################################
+
+  template <class UINT_T, ENABLE_IF((std::is_same<UINT_T, u1>::value || std::is_same<UINT_T, u2>::value ||
+                                     std::is_same<UINT_T, u4>::value || std::is_same<UINT_T, u8>::value))>
+  void read_uint_array_data(UINT_T *buf, size_t length, TRAPS) {
+    if (Endian::is_Java_byte_ordering_different()) { // Have to convert
+      for (size_t i = 0; i < length; i++) {
+        buf[i] = read<UINT_T>(CHECK);
+      }
+    } else { // Can read directly
+      read_raw(buf, length * sizeof(UINT_T), CHECK);
+    }
+  }
+
+  template <class UINT_T, ENABLE_IF((std::is_same<UINT_T, u1>::value || std::is_same<UINT_T, u2>::value ||
+                                     std::is_same<UINT_T, u4>::value || std::is_same<UINT_T, u8>::value))>
+  Array<UINT_T> *read_uint_array(Array<UINT_T> *if_none, TRAPS) {
+    precond(_loader_data != nullptr);
+
+    const auto len = read<u4>(CHECK_NULL);
+    if (len == CracClassDumper::NO_ARRAY_SENTINEL) {
+      return if_none;
+    }
+    guarantee(len <= INT_MAX, "metadata array length too large: " UINT32_FORMAT " > %i", len, INT_MAX);
+
+    Array<UINT_T> *arr = MetadataFactory::new_array<UINT_T>(_loader_data, len, CHECK_NULL);
+    read_uint_array_data(arr->data(), arr->length(), THREAD);
+    if (HAS_PENDING_EXCEPTION) {
+      MetadataFactory::free_array(_loader_data, arr);
+    }
+    return arr;
+  }
+
+  // ###########################################################################
+  // Parsing
+  // ###########################################################################
+
+  void parse_class_state(TRAPS) {
+    const auto raw_state = read<u1>(CHECK);
+    guarantee(raw_state == InstanceKlass::loaded || raw_state == InstanceKlass::linked ||
+              raw_state == InstanceKlass::fully_initialized || raw_state == InstanceKlass::initialization_error,
+              "illegal class state: %i", raw_state);
+    _class_state = static_cast<InstanceKlass::ClassState>(raw_state);
+
+    if (raw_state == InstanceKlass::initialization_error) {
+      _class_initialization_error_id = read_id(true, CHECK);
+    } else {
+      _class_initialization_error_id = HeapDump::NULL_ID;
+    }
+
+    log_trace(crac, class, parser)("  Parsed class state");
+  }
+
+  void parse_class_versions(TRAPS) {
+    _minor_version = read<u2>(CHECK);
+    _major_version = read<u2>(CHECK);
+
+    const auto redefinition_version = read<jint>(CHECK);
+#if INCLUDE_JVMTI
+    _redefinition_version = redefinition_version;
+#else  // INCLUDE_JVMTI
+    // Note: the fact that this verion is 0 doesn't mean the class hasn't been
+    // redefined (overflow is allowed), so we'll also check the corresponding
+    // internal flag later.
+    //
+    // Also, not sure this being not 0 will cause any problems when JVM TI isn't
+    // included, but under the normal circumstances such situation cannot
+    // happen, so abort just to be safe
+    guarantee(redefinition_version == 0,
+              "class has been redefined by a JVM TI agent (has a non-zero redefinition version), "
+              "so this dump can only be restored on VMs that have JVM TI included");
+#endif // INCLUDE_JVMTI
+
+    log_trace(crac, class, parser)("  Parsed class versions");
+  }
+
+  void parse_class_flags(TRAPS) {
+    const u4 raw_access_flags = read<u4>(CHECK);
+    guarantee((raw_access_flags & JVM_ACC_WRITTEN_FLAGS & ~JVM_RECOGNIZED_CLASS_MODIFIERS) == 0,
+              "illegal class file flags " UINT32_FORMAT, raw_access_flags & JVM_ACC_WRITTEN_FLAGS);
+    guarantee((raw_access_flags & ~JVM_ACC_WRITTEN_FLAGS &
+               ~(JVM_ACC_HAS_FINALIZER | JVM_ACC_IS_CLONEABLE_FAST | JVM_ACC_IS_HIDDEN_CLASS | JVM_ACC_IS_VALUE_BASED_CLASS)) == 0,
+              "unrecognized internal class flags: " UINT32_FORMAT, raw_access_flags & ~JVM_ACC_WRITTEN_FLAGS);
+    // has_finalizer depends on VM-options, so we'll recompute it
+    // Don't use set_flags -- it will drop internal Klass flags
+    const AccessFlags access_flags(checked_cast<int>(raw_access_flags & ~JVM_ACC_HAS_FINALIZER));
+    guarantee(!access_flags.is_cloneable_fast() || vmClasses::Cloneable_klass_loaded(), // Must implement clonable, so we should've created it as interface
+              "either dump order is incorrect or internal class flags are inconsistent with the implemented interfaces");
+
+    const u2 internal_flags = read<u2>(CHECK);
+    const u1 internal_status = read<u1>(CHECK);
+    InstanceKlassFlags ik_flags(internal_flags, internal_status);
+    guarantee(!ik_flags.shared_loading_failed() && ik_flags.is_shared_unregistered_class(),
+              "illegal internal instance class flags");
+    guarantee(!ik_flags.is_being_redefined() && !ik_flags.is_scratch_class() && !ik_flags.is_marked_dependent() && !ik_flags.is_being_restored(),
+              "illegal internal instance class statuses");
+    guarantee(!ik_flags.declares_nonstatic_concrete_methods() || ik_flags.has_nonstatic_concrete_methods(),
+              "inconsistent internal instance class flags");
+    guarantee(!ik_flags.declares_nonstatic_concrete_methods() || access_flags.is_interface(),
+              "internal instance class flags are not consistent with class access flags");
+    guarantee(_class_state < InstanceKlass::ClassState::linked || ik_flags.rewritten(),
+              "internal instance class statuses are not consistent with class initialization state");
+    if (!HAVE_JVMTI && ik_flags.has_been_redefined()) {
+      // At the moment there shouldn't be any problems with just the fact that
+      // this flag is set when JVM TI isn't included, but under the normal
+      // circumstances such situation cannot happen, so abort just to be safe
+      THROW_MSG(vmSymbols::java_lang_UnsupportedOperationException(),
+                "class has been redefined by a JVM TI agent (has the corresponding flag set), "
+                "making this dump restorable only on VMs that have JVM TI included");
+    }
+    ik_flags.set_is_being_restored(true);
+
+    _class_access_flags = access_flags;
+    _ik_flags = ik_flags;
+
+    log_trace(crac, class, parser)("  Parsed class flags");
+  }
+
+  void parse_nest_host_attr(TRAPS) {
+    _nest_host_index = read<u2>(CHECK);
+    _interclass_refs.dynamic_nest_host = read_id(true, CHECK);
+    guarantee(_interclass_refs.dynamic_nest_host == HeapDump::NULL_ID || _class_access_flags.is_hidden_class(),
+              "only hidden classes can have a dynamic nest host");
+  }
+
+  void parse_source_debug_extension_attr(TRAPS) {
+    const bool has_sde = read_bool(CHECK);
+    if (!has_sde) {
+      return; // No SourceDebugExtension attribute
+    }
+
+    const auto len = read<jint>(CHECK);
+    // Will use int adding 1 for the trailing nul. ClassFileParser doesn't
+    // validate this for some reason (there is only an assert).
+    guarantee(len <= INT_MAX - 1, "SourceDebugExtension length is too large: %i > %i", len, INT_MAX - 1);
+
+    if (!JvmtiExport::can_get_source_debug_extension()) {
+      // Skip if SourceDebugExtension won't be retrieved (just as ClassFileParser does)
+      skip(len, CHECK);
+      return;
+    }
+
+    _source_debug_extension = NEW_C_HEAP_ARRAY(char, len + 1, mtClass);
+    read_raw(_source_debug_extension, len, CHECK);
+    _source_debug_extension[len] = '\0';
+  }
+
+  void parse_record_attr(TRAPS) {
+    const auto has_record = read_bool(CHECK);
+    if (!has_record) {
+      return;
+    }
+
+    const auto components_num = read<u2>(CHECK);
+    // Pre-fill with nulls so that deallocation works correctly if an error occures before the array is filled
+    _record_components = MetadataFactory::new_array<RecordComponent *>(_loader_data, components_num, nullptr, CHECK);
+    for (u2 i = 0; i < components_num; i++) {
+      const auto name_index = read<u2>(CHECK);
+      const auto descriptor_index = read<u2>(CHECK);
+      const auto attributes_count = read<u2>(CHECK);
+      const auto generic_signature_index = read<u2>(CHECK);
+      AnnotationArray *annotations = read_uint_array<u1>(nullptr, CHECK);
+      AnnotationArray *type_annotations = read_uint_array<u1>(nullptr, CHECK);
+
+      auto *component = RecordComponent::allocate(_loader_data, name_index, descriptor_index,
+                                                  attributes_count, generic_signature_index,
+                                                  annotations, type_annotations, CHECK);
+      _record_components->at_put(i, component);
+    }
+  }
+
+  void parse_class_attrs(TRAPS) {
+    _source_file_name_index = read<u2>(CHECK);
+    _generic_signature_index = read<u2>(CHECK);
+    parse_nest_host_attr(CHECK);
+    _nest_members = read_uint_array(Universe::the_empty_short_array(), CHECK);
+    _inner_classes = read_uint_array(Universe::the_empty_short_array(), CHECK);
+    parse_source_debug_extension_attr(CHECK);
+    _bsm_operands = read_uint_array<u2>(nullptr, CHECK);
+    parse_record_attr(CHECK);
+    _permitted_subclasses = read_uint_array(Universe::the_empty_short_array(), CHECK);
+    _class_annotations = read_uint_array<u1>(nullptr, CHECK);
+    _class_type_annotations = read_uint_array<u1>(nullptr, CHECK);
+    log_trace(crac, class, parser)("  Parsed class attributes");
+  }
+
+  void parse_resolution_error_symbols(int err_table_index, TRAPS) {
+    const HeapDump::ID error_sym_id = read_id(true, CHECK);
+    Symbol *error_sym = error_sym_id == HeapDump::NULL_ID ? nullptr : _heap_dump.get_symbol(error_sym_id);
+    const HeapDump::ID msg_sym_id = read_id(true, CHECK);
+    Symbol *msg_sym = msg_sym_id == HeapDump::NULL_ID ? nullptr : _heap_dump.get_symbol(msg_sym_id);
+    const HeapDump::ID cause_sym_id = read_id(true, CHECK);
+    Symbol *cause_sym = cause_sym_id == HeapDump::NULL_ID ? nullptr : _heap_dump.get_symbol(cause_sym_id);
+    const HeapDump::ID cause_msg_sym_id = cause_sym_id == HeapDump::NULL_ID ? HeapDump::NULL_ID : read_id(true, CHECK);
+    Symbol *cause_msg_sym = cause_msg_sym_id == HeapDump::NULL_ID ? nullptr : _heap_dump.get_symbol(cause_msg_sym_id);
+
+    char *nest_host_err_msg = nullptr;
+    if (err_table_index == _nest_host_index) {
+      const auto nest_host_err_len = read<u4>(CHECK);
+      nest_host_err_msg = NEW_C_HEAP_ARRAY(char, nest_host_err_len + 1, mtInternal);
+      read_raw(nest_host_err_msg, nest_host_err_len, THREAD);
+      if (HAS_PENDING_EXCEPTION) {
+        FREE_C_HEAP_ARRAY(char, nest_host_err_msg);
+      }
+      nest_host_err_msg[nest_host_err_len] = '\0';
+    }
+
+    const constantPoolHandle cph(Thread::current(), _cp);
+#ifdef ASSERT
+    {
+      MutexLocker ml(Thread::current(), SystemDictionary_lock); // ResolutionErrorTable requires this to be locked
+      assert(ResolutionErrorTable::find_entry(cph, err_table_index) == nullptr, "duplicated resolution error");
+    }
+#endif // ASSERT
+    SystemDictionary::add_resolution_error(cph, err_table_index, error_sym, msg_sym, cause_sym, cause_msg_sym);
+    if (nest_host_err_msg != nullptr) {
+      SystemDictionary::add_nest_host_error(cph, err_table_index, nest_host_err_msg);
+    }
+  }
+
+  void parse_constant_pool(TRAPS) {
+    const auto pool_len = read<u2>(CHECK);
+    _cp = ConstantPool::allocate(_loader_data, pool_len, CHECK);
+    postcond(_cp->length() == pool_len);
+
+    const auto classes_num = read<u2>(CHECK);
+    _cp->allocate_resolved_klasses(_loader_data, classes_num, CHECK);
+
+    u2 current_class_i = 0; // Resolved classes array indexing
+    log_trace(crac, class, parser)("  Parsing %i constant pool slots", pool_len);
+    for (u2 pool_i = 1 /* index 0 is unused */; pool_i < pool_len; pool_i++) {
+      const auto tag = read<u1>(CHECK);
+      switch (tag) {
+        case JVM_CONSTANT_Utf8: {
+          const HeapDump::ID sym_id = read_id(false, CHECK);
+          Symbol *sym = _heap_dump.get_symbol(sym_id);
+          _cp->symbol_at_put(pool_i, sym);
+          break;
+        }
+        case JVM_CONSTANT_NameAndType: {
+          const auto name_index = read<u2>(CHECK);
+          const auto type_index = read<u2>(CHECK);
+          _cp->name_and_type_at_put(pool_i, name_index, type_index);
+          break;
+        }
+
+        case JVM_CONSTANT_Integer: {
+          const auto n = read<jint>(CHECK);
+          _cp->int_at_put(pool_i, n);
+          break;
+        }
+        case JVM_CONSTANT_Float: {
+          const auto n = read<jfloat>(CHECK);
+          _cp->float_at_put(pool_i, n);
+          break;
+        }
+        case JVM_CONSTANT_Long: {
+          const auto n = read<jlong>(CHECK);
+          _cp->long_at_put(pool_i, n);
+          guarantee(++pool_i != pool_len, "long occupies two constant pool slots and thus cannot start on the last slot");
+          break;
+        }
+        case JVM_CONSTANT_Double: {
+          const auto n = read<jdouble>(CHECK);
+          _cp->double_at_put(pool_i, n);
+          guarantee(++pool_i != pool_len, "double occupies two constant pool slots and thus cannot start on the last slot");
+          break;
+        }
+        case JVM_CONSTANT_String: {
+          const HeapDump::ID sym_id = read_id(false, CHECK);
+          Symbol *const sym = _heap_dump.get_symbol(sym_id);
+          _cp->unresolved_string_at_put(pool_i, sym);
+          // Resolved String objects will be restored as part of cache restoration
+          break;
+        }
+
+        case JVM_CONSTANT_Class:
+        case JVM_CONSTANT_UnresolvedClass:
+        case JVM_CONSTANT_UnresolvedClassInError: {
+          guarantee(current_class_i < classes_num, "more classes in constant pool than specified");
+          const auto class_name_index = read<u2>(CHECK);
+          _cp->unresolved_klass_at_put(pool_i, class_name_index, current_class_i++);
+
+          if (tag == JVM_CONSTANT_Class) {
+            const HeapDump::ID class_id = read_id(false, CHECK);
+            _interclass_refs.cp_class_refs->append({pool_i, class_id});
+            if (pool_i == _nest_host_index) {
+              const bool has_nest_host_res_error = read_bool(CHECK);
+              if (has_nest_host_res_error) {
+                parse_resolution_error_symbols(pool_i, CHECK);
+              }
+            }
+          } else if (tag == JVM_CONSTANT_UnresolvedClassInError) {
+            parse_resolution_error_symbols(pool_i, CHECK);
+            _cp->tag_at_put(pool_i, JVM_CONSTANT_UnresolvedClassInError);
+          }
+          break;
+        }
+        case JVM_CONSTANT_Fieldref:
+        case JVM_CONSTANT_Methodref:
+        case JVM_CONSTANT_InterfaceMethodref: {
+          const auto class_index = read<u2>(CHECK);
+          const auto name_and_type_index = read<u2>(CHECK);
+          if (tag == JVM_CONSTANT_Fieldref) {
+            _cp->field_at_put(pool_i, class_index, name_and_type_index);
+          } else if (tag == JVM_CONSTANT_Methodref) {
+            _cp->method_at_put(pool_i, class_index, name_and_type_index);
+          } else {
+            _cp->interface_method_at_put(pool_i, class_index, name_and_type_index);
+          }
+          break;
+        }
+        case JVM_CONSTANT_MethodType:
+        case JVM_CONSTANT_MethodTypeInError: {
+          const auto mt_index = read<u2>(CHECK);
+          _cp->method_type_index_at_put(pool_i, mt_index);
+          if (tag == JVM_CONSTANT_MethodTypeInError) {
+            parse_resolution_error_symbols(pool_i, CHECK);
+            _cp->tag_at_put(pool_i, JVM_CONSTANT_MethodTypeInError);
+          }
+          break;
+        }
+        case JVM_CONSTANT_MethodHandle:
+        case JVM_CONSTANT_MethodHandleInError: {
+          const auto mh_kind = read<u1>(CHECK);
+          const auto mh_index = read<u2>(CHECK);
+          _cp->method_handle_index_at_put(pool_i, mh_kind, mh_index);
+          if (tag == JVM_CONSTANT_MethodHandleInError) {
+            parse_resolution_error_symbols(pool_i, CHECK);
+            _cp->tag_at_put(pool_i, JVM_CONSTANT_MethodHandleInError);
+          }
+          break;
+        }
+        case JVM_CONSTANT_Dynamic:
+        case JVM_CONSTANT_DynamicInError:
+        case JVM_CONSTANT_InvokeDynamic: {
+          const auto bsm_attr_index = read<u2>(CHECK);
+          const auto name_and_type_index = read<u2>(CHECK);
+          if (tag == JVM_CONSTANT_InvokeDynamic) {
+            _cp->invoke_dynamic_at_put(pool_i, bsm_attr_index, name_and_type_index);
+          } else {
+            _cp->dynamic_constant_at_put(pool_i, bsm_attr_index, name_and_type_index);
+            _cp->set_has_dynamic_constant();
+            if (tag == JVM_CONSTANT_DynamicInError) {
+              parse_resolution_error_symbols(pool_i, CHECK);
+              _cp->tag_at_put(pool_i, JVM_CONSTANT_DynamicInError);
+            }
+          }
+          break;
+        }
+
+        default:
+          guarantee(false, "illegal tag %i at constant pool slot %i", tag, pool_i);
+      }
+    }
+    guarantee(current_class_i == classes_num, "less classes in constant pool than specified: %i < %i", current_class_i, classes_num);
+
+    log_trace(crac, class, parser)("  Parsed constant pool");
+  }
+
+  static int prepare_resolved_method_flags(u1 raw_flags) {
+    using crac_shifts = CracClassDumper::ResolvedMethodEntryFlagShift;
+    using cache_shifts = ConstantPoolCacheEntry;
+    return static_cast<int>(is_set_nth_bit(raw_flags, crac_shifts::has_local_signature_shift)) << cache_shifts::has_local_signature_shift |
+           static_cast<int>(is_set_nth_bit(raw_flags, crac_shifts::has_appendix_shift))        << cache_shifts::has_appendix_shift        |
+           static_cast<int>(is_set_nth_bit(raw_flags, crac_shifts::is_forced_virtual_shift))   << cache_shifts::is_forced_virtual_shift   |
+           static_cast<int>(is_set_nth_bit(raw_flags, crac_shifts::is_final_shift))            << cache_shifts::is_final_shift            |
+           static_cast<int>(is_set_nth_bit(raw_flags, crac_shifts::is_vfinal_shift))           << cache_shifts::is_vfinal_shift;
+  }
+
+  void parse_constant_pool_cache(TRAPS) {
+    precond(_cp != nullptr);
+
+    const auto field_entries_len = read<u2>(CHECK);
+    const auto method_entries_len = read<jint>(CHECK); // AKA cache length
+    const auto indy_entries_len = read<jint>(CHECK);
+    guarantee(method_entries_len >= 0, "amount of resolved methods cannot be negative");
+    guarantee(indy_entries_len >= 0, "amount of resolved invokedynamic instructions cannot be negative");
+
+    ConstantPoolCache *cp_cache =
+      ConstantPoolCache::allocate_uninitialized(_loader_data, method_entries_len, indy_entries_len, field_entries_len, CHECK);
+    _cp->set_cache(cp_cache); // Make constant pool responsible for cache deallocation
+
+    for (u2 field_i = 0; field_i < field_entries_len; field_i++) {
+      const auto cp_index = read<u2>(CHECK);
+      guarantee(cp_index > 0, "resolved field entry %i is uninitialized", field_i);
+      ResolvedFieldEntry field_entry(cp_index);
+
+      const auto get_code = read<u1>(CHECK);
+      const auto put_code = read<u1>(CHECK);
+      if (get_code != 0 && get_code != Bytecodes::_getfield && get_code != Bytecodes::_getstatic) {
+        const char *code_name = Bytecodes::is_defined(get_code) ? Bytecodes::name(Bytecodes::cast(get_code)) :
+                                                                  static_cast<const char *>(err_msg("%i", get_code));
+        guarantee(false, "not a get* bytecode: %s", code_name);
+      }
+      if (put_code != 0 && put_code != Bytecodes::_putfield && put_code != Bytecodes::_putstatic) {
+        const char *code_name = Bytecodes::is_defined(put_code) ? Bytecodes::name(Bytecodes::cast(put_code)) :
+                                                                  static_cast<const char *>(err_msg("%i", put_code));
+        guarantee(false, "not a put* bytecode: %s", code_name);
+      }
+      guarantee(get_code != 0 || put_code == 0, "field entry cannot be resolved for put* bytecodes only");
+
+      if (get_code != 0) {
+        const HeapDump::ID holder_id = read_id(false, CHECK);
+        _interclass_refs.field_refs->append({field_i, holder_id}); // Save to resolve later
+
+        const auto field_index = read<u2>(CHECK);
+        const auto tos_state = read<u1>(CHECK);
+        guarantee(tos_state < TosState::number_of_states, "illegal resolved field entry ToS state: %i", tos_state);
+        const auto flags = read<u1>(CHECK);
+        field_entry.fill_in_partial(field_index, tos_state, flags, get_code, put_code);
+      }
+
+      *cp_cache->resolved_field_entry_at(field_i) = field_entry;
+    }
+
+    for (int cache_i = 0; cache_i < method_entries_len; cache_i++) {
+      const auto cp_index = read<u2>(CHECK);
+      guarantee(cp_index > 0, "resolved method entry %i is uninitialized", cache_i);
+      ConstantPoolCacheEntry cache_entry;
+      cache_entry.initialize_entry(cp_index);
+
+      const auto raw_bytecode1 = read<u1>(CHECK);
+      const auto raw_bytecode2 = read<u1>(CHECK);
+      guarantee(Bytecodes::is_defined(raw_bytecode1), "undefined method resolution bytecode 1: %i", raw_bytecode1);
+      guarantee(Bytecodes::is_defined(raw_bytecode2), "undefined method resolution bytecode 2: %i", raw_bytecode2);
+
+      if (raw_bytecode1 > 0 || raw_bytecode2 > 0) { // If resolved
+        const auto flags = read<u1>(CHECK);
+        guarantee(flags >> CracClassDumper::num_method_entry_flags == 0,
+                  "unrecognized resolved method entry flags: " UINT8_FORMAT_X_0, flags);
+        const auto tos_state = read<u1>(CHECK);
+        guarantee(tos_state < TosState::number_of_states, "illegal resolved method entry ToS state: %i", tos_state);
+        const auto params_num = read<u1>(CHECK);
+        cache_entry.set_method_flags(checked_cast<TosState>(tos_state), prepare_resolved_method_flags(flags), params_num);
+        postcond(cache_entry.is_method_entry());
+
+        // Not readable from the entry until f1 is set
+        const bool has_appendix = is_set_nth_bit(flags, CracClassDumper::ResolvedMethodEntryFlagShift::has_appendix_shift);
+
+        // f1
+        bool f1_is_method = false;
+        HeapDump::ID f1_class_id = HeapDump::NULL_ID;
+        u2 f1_method_idnum;
+        const Bytecodes::Code bytecode1 = Bytecodes::cast(raw_bytecode1);
+        switch (bytecode1) {
+          case Bytecodes::_invokestatic:
+          case Bytecodes::_invokespecial:
+          case Bytecodes::_invokehandle:
+            f1_is_method = true;
+            f1_class_id = read_id(false, CHECK);
+            f1_method_idnum = read<u2>(CHECK);
+            break;
+          case Bytecodes::_invokeinterface:
+            if (!cache_entry.is_forced_virtual()) {
+              f1_class_id = read_id(false, CHECK);
+            }
+            break;
+          case 0: // bytecode1 is not set
+            break;
+          default:
+            guarantee(false, "illegal method resolution bytecode 1: %s", Bytecodes::name(bytecode1));
+        }
+        cache_entry.set_bytecode_1(bytecode1); // The bytecode has been validated
+
+        // f2
+        HeapDump::ID f2_class_id = HeapDump::NULL_ID;
+        u2 f2_method_idnum;
+        const Bytecodes::Code bytecode2 = Bytecodes::cast(raw_bytecode2);
+        guarantee(bytecode2 == 0 || bytecode2 == Bytecodes::_invokevirtual, "illegal method resolution bytecode 2: %s", Bytecodes::name(bytecode2));
+        if (cache_entry.is_vfinal() || (bytecode1 == Bytecodes::_invokeinterface && !cache_entry.is_forced_virtual())) {
+          guarantee(bytecode1 != Bytecodes::_invokestatic && bytecode1 != Bytecodes::_invokehandle &&
+                    (bytecode1 == Bytecodes::_invokeinterface || bytecode2 == Bytecodes::_invokevirtual),
+                    "illegal resolved method data: b1 = %s, b2 = %s, is_vfinal = %s, is_forced_virtual = %s",
+                    Bytecodes::name(bytecode1), Bytecodes::name(bytecode2),
+                    BOOL_TO_STR(cache_entry.is_vfinal()), BOOL_TO_STR(cache_entry.is_forced_virtual()));
+          f2_class_id = read_id(false, CHECK);
+          f2_method_idnum = read<u2>(CHECK);
+        } else if (bytecode1 == Bytecodes::_invokeinterface || bytecode2 == Bytecodes::_invokevirtual ||
+                  (bytecode1 == Bytecodes::_invokehandle && has_appendix)) {
+          guarantee(bytecode1 != Bytecodes::_invokestatic,
+                    "illegal resolved method data: b1 = %s, b2 = %s, is_vfinal = %s, is_forced_virtual = %s, has_appendix = %s",
+                    Bytecodes::name(bytecode1), Bytecodes::name(bytecode2),
+                    BOOL_TO_STR(cache_entry.is_vfinal()), BOOL_TO_STR(cache_entry.is_forced_virtual()), BOOL_TO_STR(cache_entry.has_appendix()));
+          const auto f2_index = read<jint>(CHECK);
+          cache_entry.set_f2(f2_index);
+        }
+        cache_entry.set_bytecode_2(bytecode2); // The bytecode has been validated
+
+        if (f1_class_id != HeapDump::NULL_ID || f2_class_id != HeapDump::NULL_ID) { // Save to resolve later
+          _interclass_refs.method_refs->append({cache_i, f1_is_method, f1_class_id, f1_method_idnum, f2_class_id, f2_method_idnum});
+        }
+      }
+
+      *cp_cache->entry_at(cache_i) = cache_entry;
+    }
+
+    for (int indy_i = 0; indy_i < indy_entries_len; indy_i++) {
+      const auto cp_index = read<u2>(CHECK);
+      guarantee(cp_index > 0, "resolved invokedynamic entry %i is uninitialized", indy_i);
+      const auto resolved_references_index = read<u2>(CHECK);
+      ResolvedIndyEntry indy_entry(resolved_references_index, cp_index);
+
+      const auto extended_flags = read<u1>(CHECK);
+      guarantee(extended_flags >> (ResolvedIndyEntry::num_flags + 1) == 0,
+                "unrecognized resolved invokedynamic entry flags: " UINT8_FORMAT_X_0, extended_flags);
+      const bool is_resolution_failed = is_set_nth_bit(extended_flags, 0); // TODO define the shift in ResolvedIndyEntry
+      const bool has_appendix         = is_set_nth_bit(extended_flags, ResolvedIndyEntry::has_appendix_shift);
+      const bool is_resolved          = is_set_nth_bit(extended_flags, ResolvedIndyEntry::num_flags);
+      guarantee((is_resolved && !is_resolution_failed) || (!is_resolved && !has_appendix),
+                "illegal invokedynamic entry flag combination: " UINT8_FORMAT_X_0, extended_flags);
+
+      if (is_resolved) {
+        const HeapDump::ID adapter_holder_id = read_id(false, CHECK);
+        const auto adapter_idnum = read<u2>(CHECK);
+        _interclass_refs.indy_refs->append({indy_i, adapter_holder_id, adapter_idnum}); // Save to resolve later
+
+        const auto adapter_num_params = read<u2>(CHECK);
+        const auto adapter_ret_type = read<u1>(CHECK);
+        indy_entry.fill_in_partial(adapter_num_params, adapter_ret_type, has_appendix);
+      } else if (is_resolution_failed) {
+        const int indy_res_err_i = ResolutionErrorTable::encode_cpcache_index(ConstantPool::encode_invokedynamic_index(indy_i));
+        parse_resolution_error_symbols(indy_res_err_i, CHECK);
+        indy_entry.set_resolution_failed();
+      }
+    }
+
+    // Mapping from the first part of resolved references back to constant pool
+    Array<u2> *const reference_map = read_uint_array<u2>(nullptr, CHECK);
+    cp_cache->set_reference_map(reference_map);
+
+    log_trace(crac, class, parser)("  Parsed constant pool cache");
+  }
+
+  void parse_this_class_index(TRAPS) {
+    const auto this_class_index = read<u2>(CHECK);
+    guarantee(this_class_index > 0 && this_class_index < _cp->length(),
+              "this class index %i is out of constant pool bounds", this_class_index);
+    // Would be nice to assert this points to a resolved class for hidden
+    // classes (ClassFileParser performs the resolution in such cases), but we
+    // postpone restoring the class references for later
+    _this_class_index = this_class_index;
+    log_trace(crac, class, parser)("  Parsed this class index");
+  }
+
+  void find_super(TRAPS) {
+    if (_class_dump.super_id == HeapDump::NULL_ID) {
+      log_trace(crac, class, parser)("  No super");
+      return;
+    }
+
+    InstanceKlass **const super_ptr = _created_classes.get(_class_dump.super_id);
+    guarantee(super_ptr != nullptr,
+              "invalid dump order: class " HDID_FORMAT " is dumped ahead of its super class " HDID_FORMAT,
+              _class_dump.id, _class_dump.super_id);
+
+    InstanceKlass *const super = *super_ptr;
+    precond(super->is_loaded());
+    guarantee(!super->is_interface(), "class %s (ID " HDID_FORMAT ") cannot be extended by " HDID_FORMAT " because it is an interface",
+              super->external_name(), _class_dump.super_id, _class_dump.id);
+    guarantee(!super->has_nonstatic_concrete_methods() || _ik_flags.has_nonstatic_concrete_methods(),
+              "internal class flags are not consistent with those of the super class");
+
+    _super = super;
+    if (log_is_enabled(Trace, crac, class, parser)) {
+      ResourceMark rm;
+      log_trace(crac, class, parser)("  Found super: %s", super->external_name());
+    }
+  }
+
+  void parse_interfaces(TRAPS) {
+    const auto interfaces_num = read<u2>(CHECK);
+    if (interfaces_num == 0) {
+      _local_interfaces = Universe::the_empty_instance_klass_array();
+      log_trace(crac, class, parser)("  No local interfaces");
+      return;
+    }
+
+    _local_interfaces = MetadataFactory::new_array<InstanceKlass *>(_loader_data, interfaces_num, CHECK);
+    for (u2 i = 0; i < interfaces_num; i++) {
+      const HeapDump::ID interface_id = read_id(false, CHECK);
+      InstanceKlass **const interface_ptr = _created_classes.get(interface_id);
+      guarantee(interface_ptr != nullptr,
+                "invalid dump order: class " HDID_FORMAT " is dumped ahead of its interface " HDID_FORMAT,
+                _class_dump.id, interface_id);
+
+      InstanceKlass *const interface = *interface_ptr;
+      precond(interface->is_loaded());
+      guarantee(interface->is_interface(),
+                "class %s (ID " HDID_FORMAT ") cannot be implemented by " HDID_FORMAT " because it is not an interface",
+                interface->external_name(), interface_id, _class_dump.id);
+      guarantee(!interface->has_nonstatic_concrete_methods() || _ik_flags.has_nonstatic_concrete_methods(),
+                "internal class flags are not consistent with those of implemented interfaces");
+
+      _local_interfaces->at_put(i, interface);
+    }
+
+    log_trace(crac, class, parser)("  Parsed %i local interfaces", interfaces_num);
+  }
+
+  void parse_field_annotations(int field_index, int java_fields_num, Array<AnnotationArray *> **const annotations_collection, TRAPS) {
+    precond(field_index < java_fields_num);
+    precond(annotations_collection != nullptr);
+    AnnotationArray *annotations = read_uint_array<u1>(nullptr, CHECK);
+    if (annotations == nullptr) {
+      return;
+    }
+    if (*annotations_collection == nullptr) {
+      // Pre-fill with nulls since some slots may remain unfilled (fields without annotations)
+      *annotations_collection = MetadataFactory::new_array<AnnotationArray *>(_loader_data, java_fields_num, nullptr, THREAD);
+      if (HAS_PENDING_EXCEPTION) {
+        MetadataFactory::free_array(_loader_data, annotations);
+        return;
+      }
+    }
+    (*annotations_collection)->at_put(field_index, annotations);
+  }
+
+  void parse_fields(TRAPS) {
+    const auto java_fields_num = read<u2>(CHECK);
+    const auto injected_fields_num = read<u2>(CHECK);
+    const u2 total_fields_num = java_fields_num + injected_fields_num;
+
+    _field_infos.reserve(total_fields_num);
+    _field_statuses = MetadataFactory::new_array<FieldStatus>(_loader_data, total_fields_num, CHECK);
+
+    _static_oop_fields_num = 0;
+    for (u2 i = 0; i < total_fields_num; i++) {
+      const auto name_index = read<u2>(CHECK);
+      const auto signature_index = read<u2>(CHECK);
+      const auto raw_access_flags = read<jshort>(CHECK);
+      guarantee((raw_access_flags & JVM_RECOGNIZED_FIELD_MODIFIERS) == raw_access_flags,
+                "unrecognized field access flags: " INT16_FORMAT_X_0, raw_access_flags);
+      const auto raw_field_flags = read<u1>(CHECK);
+      const auto initializer_index = read<u2>(CHECK);
+      const auto generic_signature_index = read<u2>(CHECK);
+      const auto contention_group = read<u2>(CHECK);
+
+      {
+        const AccessFlags access_flags(raw_access_flags);
+        // Check this to skip interfaces when restoring non-static fields. Omit
+        // the rest of field flag validation for simplicity.
+        guarantee(!_class_access_flags.is_interface() || (access_flags.is_public() && access_flags.is_static() && access_flags.is_final()),
+                  "interface fields must be public, static and final");
+        const FieldInfo::FieldFlags field_flags(raw_field_flags);
+        guarantee(field_flags.is_injected() == (i >= java_fields_num), "injected fields go last");
+        guarantee(!field_flags.is_injected() || raw_access_flags == 0,
+                  "injected fields don't have any access flags set");
+        guarantee(!field_flags.is_contended() || _ik_flags.has_contended_annotations(),
+                  "class having contended fields not marked as having contended annotations");
+
+        FieldInfo field_info(access_flags, name_index, signature_index, initializer_index, field_flags);
+        field_info.set_generic_signature_index(generic_signature_index);
+        field_info.set_contended_group(contention_group);
+        _field_infos.append(field_info);
+
+        if (field_flags.is_injected()) {
+          _injected_fields_num++;
+        }
+        // Use FieldInfo::signature() and not the raw signature_index to account for injected fields
+        if (access_flags.is_static() && is_reference_type(Signature::basic_type(field_info.signature(_cp)))) {
+          _static_oop_fields_num++;
+        }
+      }
+
+      const auto raw_field_status = read<u1>(CHECK);
+      _field_statuses->at_put(i, FieldStatus(raw_field_status));
+
+      if (i < java_fields_num) { // Only non-injected fields have annotations
+        parse_field_annotations(i, java_fields_num, &_field_annotations, CHECK);
+        parse_field_annotations(i, java_fields_num, &_field_type_annotations, CHECK);
+      }
+    }
+
+    _java_fields_num = java_fields_num;
+    _injected_fields_num = injected_fields_num;
+    log_trace(crac, class, parser)("  Parsed fields: %i normal, %i injected", java_fields_num, injected_fields_num);
+  }
+
+  InlineTableSizes parse_method_inline_table_sizes(const ConstMethodFlags &flags, TRAPS) {
+    const u2 exception_table_length = !flags.has_exception_table() ? 0 : read<u2>(CHECK_({}));
+    guarantee(!flags.has_exception_table() || exception_table_length > 0, "existing exception table cannot be empty");
+
+    const jint compressed_linenumber_size = !flags.has_linenumber_table() ? 0 : read<jint>(CHECK_({}));
+    guarantee(!flags.has_linenumber_table() || compressed_linenumber_size > 0, "existing line number table cannot be empty");
+
+    const u2 localvariable_table_length = !flags.has_localvariable_table() ? 0 : read<u2>(CHECK_({}));
+    guarantee(!flags.has_localvariable_table() || localvariable_table_length > 0, "existing local variable table cannot be empty");
+
+    const u2 checked_exceptions_length = !flags.has_checked_exceptions() ? 0 : read<u2>(CHECK_({}));
+    guarantee(!flags.has_checked_exceptions() || checked_exceptions_length > 0, "existing checked exceptions list cannot be empty");
+
+    const int method_parameters_length = !flags.has_method_parameters() ? -1 : read<u1>(CHECK_({})) /* can be zero */;
+
+    const u2 generic_signature_index = !flags.has_generic_signature() ? 0 : read<u2>(CHECK_({}));
+    guarantee(!flags.has_generic_signature() || (generic_signature_index > 0 && generic_signature_index < _cp->length()),
+              "method's signature index %i is out of constant pool bounds", generic_signature_index);
+
+    const jint method_annotations_length = !flags.has_method_annotations() ? 0 : read<jint>(CHECK_({}));
+    guarantee(!flags.has_method_annotations() || method_annotations_length > 0, "existing method annotations cannot be empty");
+
+    const jint parameter_annotations_length = !flags.has_parameter_annotations() ? 0 : read<jint>(CHECK_({}));
+    guarantee(!flags.has_parameter_annotations() || parameter_annotations_length > 0, "existing method parameter annotations cannot be empty");
+
+    const jint type_annotations_length = !flags.has_type_annotations() ? 0 : read<jint>(CHECK_({}));
+    guarantee(!flags.has_type_annotations() || type_annotations_length > 0, "existing method type annotations cannot be empty");
+
+    const jint default_annotations_length = !flags.has_default_annotations() ? 0 : read<jint>(CHECK_({}));
+    guarantee(!flags.has_default_annotations() || default_annotations_length > 0, "existing method default annotations cannot be empty");
+
+#define INLINE_TABLE_NAME_PARAM(name) name,
+    return {
+      INLINE_TABLES_DO(INLINE_TABLE_NAME_PARAM)
+      0 /* end of iteration */
+    };
+#undef INLINE_TABLE_NAME_PARAM
+  }
+
+  static InlineTableSizes update_method_inline_table_sizes(const InlineTableSizes &orig) {
+    return {
+      orig.localvariable_table_length(),
+      orig.compressed_linenumber_size(),
+      orig.exception_table_length(),
+      orig.checked_exceptions_length(),
+      // TODO ClassFIleParser does this, but why? What if j.l.r.Parameter gets loaded later?
+      vmClasses::Parameter_klass_loaded() ? orig.method_parameters_length() : -1,
+      orig.generic_signature_index(),
+      orig.method_annotations_length(),
+      orig.parameter_annotations_length(),
+      orig.type_annotations_length(),
+      orig.default_annotations_length(),
+      0
+    };
+  }
+
+  static void fixup_bytecodes(Method *method) {
+    RawBytecodeStream stream(methodHandle(Thread::current(), method));
+    for (Bytecodes::Code code = stream.raw_next(); !stream.is_last_bytecode(); code = stream.raw_next()) {
+      guarantee((Bytecodes::is_java_code(code) && code != Bytecodes::_lookupswitch) ||
+                 code == Bytecodes::_invokehandle ||
+                 code == Bytecodes::_fast_aldc || code == Bytecodes::_fast_aldc_w ||
+                 code == Bytecodes::_fast_linearswitch || code == Bytecodes::_fast_binaryswitch ||
+                 code == Bytecodes::_return_register_finalizer, "illegal bytecode: %s", Bytecodes::name(code));
+
+      if (Endian::is_Java_byte_ordering_different()) {
+        const address param_bcp = stream.bcp() + 1;
+        if (Bytecodes::is_field_code(code) || Bytecodes::is_invoke(code) || code == Bytecodes::_invokehandle) {
+          if (code == Bytecodes::_invokedynamic) {
+            Bytes::put_native_u4(param_bcp, Bytes::get_Java_u4(param_bcp));
+          } else {
+            Bytes::put_native_u2(param_bcp, Bytes::get_Java_u2(param_bcp));
+          }
+          continue;
+        }
+        if (code == Bytecodes::_fast_aldc_w) {
+          Bytes::put_native_u2(param_bcp, Bytes::get_Java_u2(param_bcp));
+          continue;
+        }
+        postcond(!Bytecodes::native_byte_order(code));
+      }
+
+      if (IS_ZERO && code == Bytecodes::_fast_linearswitch && code == Bytecodes::_fast_binaryswitch) {
+        (*stream.bcp()) = Bytecodes::_lookupswitch;
+      }
+    }
+  }
+
+  void parse_code_attr(Method *method, int compressed_linenumber_table_size, TRAPS) {
+    precond(method->code_size() > 0);
+
+    {
+      const auto max_stack = read<u2>(CHECK);
+      const auto max_locals = read<u2>(CHECK);
+      method->set_max_stack(max_stack);
+      method->set_max_stack(max_locals);
+    }
+
+    read_raw(method->code_base(), method->code_size(), CHECK);
+    if (_ik_flags.rewritten() && (Endian::is_Java_byte_ordering_different() || IS_ZERO)) {
+      fixup_bytecodes(method);
+    }
+
+    if (method->has_exception_handler()) {
+      STATIC_ASSERT(sizeof(ExceptionTableElement) == 4 * sizeof(u2)); // Check no padding
+      const size_t len = method->exception_table_length() * sizeof(ExceptionTableElement) / sizeof(u2);
+      read_uint_array_data(reinterpret_cast<u2 *>(method->exception_table_start()), len, CHECK);
+    }
+
+    if (method->has_linenumber_table()) {
+      assert(compressed_linenumber_table_size > 0, "checked when parsing");
+      read_raw(method->compressed_linenumber_table(), compressed_linenumber_table_size, CHECK);
+    }
+    if (method->has_localvariable_table()) {
+      STATIC_ASSERT(sizeof(LocalVariableTableElement) == 6 * sizeof(u2)); // Check no padding
+      const size_t len = method->localvariable_table_length() * sizeof(LocalVariableTableElement) / sizeof(u2);
+      read_uint_array_data(reinterpret_cast<u2 *>(method->localvariable_table_start()), len, CHECK);
+    }
+    Array<u1> *const stackmap_table_data = read_uint_array<u1>(nullptr, CHECK);
+    if (stackmap_table_data != nullptr) {
+      guarantee(!stackmap_table_data->is_empty(), "existing stack map table cannot be empty");
+      method->set_stackmap_data(stackmap_table_data);
+    }
+  }
+
+  static void set_method_flags(Method *method, const ConstMethodFlags &flags) {
+    // Check flags that are set based on the legths/sizes we passed
+    postcond(method->is_overpass() == flags.is_overpass());
+    postcond(method->has_linenumber_table() == flags.has_linenumber_table());
+    postcond(method->constMethod()->has_checked_exceptions() == flags.has_checked_exceptions());
+    postcond(method->has_localvariable_table() == flags.has_localvariable_table());
+    postcond(method->has_exception_handler() == flags.has_exception_table());
+    postcond(method->constMethod()->has_generic_signature() == flags.has_generic_signature());
+    postcond(method->has_method_parameters() == flags.has_method_parameters());
+    postcond(method->constMethod()->has_method_annotations() == flags.has_method_annotations());
+    postcond(method->constMethod()->has_parameter_annotations() == flags.has_parameter_annotations());
+    postcond(method->constMethod()->has_type_annotations() == flags.has_type_annotations());
+    postcond(method->constMethod()->has_default_annotations() == flags.has_default_annotations());
+    // Set the rest of the flags
+    if (flags.caller_sensitive())       method->set_caller_sensitive();
+    if (flags.is_hidden())              method->set_is_hidden();
+    if (flags.has_injected_profile())   method->set_has_injected_profile();
+    if (flags.reserved_stack_access())  method->set_has_reserved_stack_access();
+    if (flags.is_scoped())              method->set_scoped();
+    if (flags.changes_current_thread()) method->set_changes_current_thread();
+    if (flags.jvmti_mount_transition()) method->set_jvmti_mount_transition();
+    if (flags.intrinsic_candidate()) {
+      guarantee(!method->is_synthetic(), "synthetic method cannot be an intrinsic candidate");
+      method->set_intrinsic_candidate();
+    }
+  }
+
+  void parse_method(Method **method_out, TRAPS) {
+    precond(method_out != nullptr);
+
+    const auto idnum = read<u2>(CHECK);
+    const auto orig_idnum = read<u2>(CHECK);
+
+    const auto raw_access_flags = read<u2>(CHECK);
+    guarantee((raw_access_flags & JVM_RECOGNIZED_METHOD_MODIFIERS) == raw_access_flags,
+              "unrecognized method access flags: " UINT16_FORMAT_X_0, raw_access_flags);
+    const AccessFlags access_flags(raw_access_flags);
+    guarantee(!access_flags.is_final() || _ik_flags.has_final_method(), "class with a final method not marked as such");
+
+    const auto raw_flags = read<jint>(CHECK);
+    const ConstMethodFlags flags(raw_flags);
+    guarantee(!_class_access_flags.is_hidden_class() || flags.is_hidden(), "methods of hidden class must be marked hidden");
+    guarantee(!flags.has_localvariable_table() || _ik_flags.has_localvariable_table(), "class with methods with a local variable table not marked as such");
+    guarantee(!_class_access_flags.is_interface() || access_flags.is_static() || access_flags.is_abstract() ||
+              flags.is_overpass() /* overpasses don't exist in class files and thus don't count as declared */ ||
+              _ik_flags.declares_nonstatic_concrete_methods(),
+              "interface with a declared non-static non-abstract method not marked as such");
+
+    const auto raw_statuses = read<jint>(CHECK);
+    const MethodFlags statuses(raw_statuses);
+    guarantee(!statuses.queued_for_compilation() && !statuses.is_not_c1_compilable() &&
+              !statuses.is_not_c2_compilable() && !statuses.is_not_c2_osr_compilable(),
+              "illegal internal method statuses: " INT32_FORMAT_X_0, raw_statuses);
+
+    const auto name_index = read<u2>(CHECK);
+    guarantee(name_index > 0 && name_index < _cp->length(), "method name index %i is out of constant pool bounds", name_index);
+    const auto signature_index = read<u2>(CHECK);
+    guarantee(signature_index > 0 && signature_index < _cp->length(), "method descriptor index %i is out of constant pool bounds", signature_index);
+    Symbol *const name = _cp->symbol_at(name_index);
+    Symbol *const signature = _cp->symbol_at(signature_index);
+
+    const auto code_size = read<u2>(CHECK);
+    guarantee(code_size != 0 || (!flags.has_exception_table() && !flags.has_linenumber_table() && !flags.has_localvariable_table()),
+              "method cannot have Code attribute's contents in the absence of Code attribute");
+    const InlineTableSizes orig_inline_sizes = parse_method_inline_table_sizes(flags, CHECK);
+
+    const auto method_type = flags.is_overpass() ? ConstMethod::MethodType::OVERPASS : ConstMethod::MethodType::NORMAL;
+    InlineTableSizes updated_inline_sizes = update_method_inline_table_sizes(orig_inline_sizes);
+    Method *const method = Method::allocate(_loader_data, code_size, access_flags, &updated_inline_sizes, method_type, name, CHECK);
+    *method_out = method; // Save eagerly to get it deallocated in case of a error
+
+    ClassLoadingService::add_class_method_size(method->size() * wordSize); // ClassFileParser does this, so we do too
+
+    method->set_constants(_cp);
+    method->set_name_index(name_index);
+    method->set_signature_index(signature_index);
+    method->constMethod()->compute_from_signature(signature, access_flags.is_static());
+
+    if (code_size > 0) {
+      parse_code_attr(method, orig_inline_sizes.compressed_linenumber_size(), CHECK);
+    }
+    if (flags.has_checked_exceptions()) {
+      STATIC_ASSERT(sizeof(CheckedExceptionElement) == sizeof(u2)); // Check no padding
+      const size_t len = method->checked_exceptions_length() * sizeof(CheckedExceptionElement) / sizeof(u2);
+      read_uint_array_data(reinterpret_cast<u2 *>(method->checked_exceptions_start()), len, CHECK);
+    }
+    if (flags.has_method_parameters()) {
+      STATIC_ASSERT(sizeof(MethodParametersElement) == 2 * sizeof(u2)); // Check no padding
+      const size_t size = orig_inline_sizes.method_parameters_length() * sizeof(MethodParametersElement);
+      if (vmClasses::Parameter_klass_loaded()) {
+        const size_t len = size / sizeof(u2);
+        read_uint_array_data(reinterpret_cast<u2 *>(method->method_parameters_start()), len, CHECK);
+      } else {
+        skip(size, CHECK);
+      }
+    }
+    if (flags.has_method_annotations()) {
+      AnnotationArray *const annots = MetadataFactory::new_array<u1>(_loader_data, orig_inline_sizes.method_annotations_length(), CHECK);
+      method->constMethod()->set_method_annotations(annots);
+      read_uint_array_data(annots->data(), annots->length(), CHECK);
+    }
+    if (flags.has_parameter_annotations()) {
+      AnnotationArray *const annots = MetadataFactory::new_array<u1>(_loader_data, orig_inline_sizes.parameter_annotations_length(), CHECK);
+      method->constMethod()->set_parameter_annotations(annots);
+      read_uint_array_data(annots->data(), annots->length(), CHECK);
+    }
+    if (flags.has_type_annotations()) {
+      AnnotationArray *const annots = MetadataFactory::new_array<u1>(_loader_data, orig_inline_sizes.type_annotations_length(), CHECK);
+      method->constMethod()->set_type_annotations(annots);
+      read_uint_array_data(annots->data(), annots->length(), CHECK);
+    }
+    if (flags.has_default_annotations()) {
+      AnnotationArray *const annots = MetadataFactory::new_array<u1>(_loader_data, orig_inline_sizes.default_annotations_length(), CHECK);
+      method->constMethod()->set_default_annotations(annots);
+      read_uint_array_data(annots->data(), annots->length(), CHECK);
+    }
+
+    set_method_flags(method, flags);
+
+    const bool is_compiled_lambda_form = read_bool(CHECK);
+    if (is_compiled_lambda_form) {
+      precond(method->intrinsic_id() == vmIntrinsics::_none);
+      method->set_intrinsic_id(vmIntrinsics::_compiledLambdaForm);
+      postcond(method->is_compiled_lambda_form());
+    }
+
+    method->set_method_idnum(idnum);
+    method->set_orig_method_idnum(orig_idnum);
+    method->set_statuses(statuses);
+
+    // Not a guarantee because is_vanilla_constructor() call may take some time
+    assert(!(_super == nullptr ||
+             (_super->has_vanilla_constructor() &&
+              name == vmSymbols::object_initializer_name() &&
+              signature == vmSymbols::void_method_signature() &&
+              method->is_vanilla_constructor())) ||
+           _ik_flags.has_vanilla_constructor(),
+           "class with a vanilla constructor not marked as such");
+
+    NOT_PRODUCT(method->verify());
+  }
+
+  NOT_DEBUG(static) TriBool is_finalizer(const Method &method) {
+    if (!InstanceKlass::is_finalization_enabled()) {
+      assert(!_class_access_flags.has_finalizer(), "must have been unset");
+      return {};    // Not a finalizer
+    }
+    if (method.name() != vmSymbols::finalize_method_name() || method.signature() != vmSymbols::void_method_signature()) {
+      return {};    // Not a finalizer
+    }
+    if (method.is_empty_method()) {
+      return false; // Empty finalizer
+    }
+    return true;    // Non-empty finalizer
+  }
+
+  void parse_methods(TRAPS) {
+    const auto methods_num = read<u2>(CHECK);
+    if (methods_num > 0) {
+      // Pre-fill with nulls so that deallocation works correctly if an error occures before the array is filled
+      _methods = MetadataFactory::new_array<Method *>(_loader_data, methods_num, nullptr, CHECK);
+    } else {
+      _methods = Universe::the_empty_method_array();
+    }
+    if (JvmtiExport::can_maintain_original_method_order() || Arguments::is_dumping_archive()) {
+      _original_method_ordering = MetadataFactory::new_array<int>(_loader_data, methods_num, CHECK);
+    } else {
+      _original_method_ordering = Universe::the_empty_int_array();
+    }
+
+    TriBool has_finalizer; // Default - no finalizer, false - empty finalizer, true - non-empty finalizer
+    for (u2 i = 0; i < methods_num; i++) {
+      const auto orig_i = read<u2>(CHECK);
+      guarantee(orig_i < methods_num, "original method index %i exceeds the number of methods %i", orig_i, methods_num);
+      if (_original_method_ordering != Universe::the_empty_int_array()) {
+        _original_method_ordering->at_put(i, orig_i);
+      }
+
+      parse_method(_methods->adr_at(i), CHECK);
+
+      const TriBool is_fin = is_finalizer(*_methods->at(i));
+      if (!is_fin.is_default()) continue; // Not a finalizer
+      guarantee(has_finalizer.is_default(), "class defines multiple finalizers");
+      has_finalizer = is_fin;             // Set the finalizer info
+    }
+    log_trace(crac, class, parser)("  Parsed %i methods", methods_num);
+
+    if (has_finalizer || (has_finalizer.is_default() && _super != nullptr && _super->has_finalizer())) {
+      assert(!InstanceKlass::is_finalization_enabled(), "has_finalizer should not be set");
+      _class_access_flags.set_has_finalizer();
+    } else {
+      assert(!_class_access_flags.has_finalizer(), "must have been unset");
+    }
+
+    const u2 default_methods_num = read<u2>(CHECK);
+    if (default_methods_num > 0) {
+      guarantee(_ik_flags.has_nonstatic_concrete_methods(),
+                "class without non-static non-abstract methods in its hierarchy should not have default methods");
+
+      // Pre-fill with nulls so that deallocation works correctly if an error occures before the array is filled
+      _default_methods = MetadataFactory::new_array<Method *>(_loader_data, default_methods_num, nullptr, CHECK);
+      for (u2 i = 0; i < default_methods_num; i++) {
+        const HeapDump::ID holder_id = read_id(false, CHECK);
+        InstanceKlass **const holder_ptr = _created_classes.get(holder_id);
+        // Implemented interfaces have been parsed and found as loaded, so if
+        // it was one of them we would have found it
+        guarantee(holder_ptr != nullptr, "default method %i belongs to a class not implemented by this class", i);
+        /*const*/ InstanceKlass &holder = **holder_ptr; // FIXME make InstanceKlass::method_with_idnum() const as it should be
+        // Would be great to check that the holder is among transitive
+        // interfaces, but that's a heavy check (requires iterating over them)
+
+        const auto method_idnum = read<u2>(CHECK);
+        Method *const method = holder.method_with_idnum(method_idnum);
+        guarantee(method != nullptr, "default method %i cannot be found", i);
+        guarantee(method->is_default_method(), "default method %i resolved to %s which is not declared default", i, method->external_name());
+        guarantee(holder.is_interface(), "only interfaces have default methods");
+        _default_methods->at_put(i, method);
+      }
+    }
+    log_trace(crac, class, parser)("  Parsed %i default methods", default_methods_num);
+  }
+
+  void parse_cached_class_file(TRAPS) {
+    const auto len = read<jint>(CHECK);
+    if (len == CracClassDumper::NO_CACHED_CLASS_FILE_SENTINEL) {
+      log_trace(crac, class, parser)("  No cached class file");
+      return;
+    }
+
+#if INCLUDE_JVMTI
+    _cached_class_file = reinterpret_cast<JvmtiCachedClassFileData *>(
+      AllocateHeap(offset_of(JvmtiCachedClassFileData, data) + len, mtInternal));
+    postcond(_cached_class_file != nullptr);
+
+    _cached_class_file->length = len;
+    read_raw(_cached_class_file->data, len, CHECK);
+#else // INCLUDE_JVMTI
+    THROW_MSG(vmSymbols::java_lang_UnsupportedOperationException(),
+              "class file has been modified by a JVM TI agent, "
+              "making this dump restorable only on VMs that have JVM TI included");
+#endif // INCLUDE_JVMTI
+
+    log_trace(crac, class, parser)("  Parsed cached class file");
+  }
+
+  // Parses the class dump. Roughly equivalent to ClassFileParser's constructor.
+  void parse_class(TRAPS) {
+    parse_class_state(CHECK);
+    parse_class_versions(CHECK);
+    parse_class_flags(CHECK);
+    parse_class_attrs(CHECK);
+    parse_constant_pool(CHECK);
+    if (_ik_flags.rewritten()) {
+      parse_constant_pool_cache(CHECK);
+    }
+    parse_this_class_index(CHECK);
+    find_super(CHECK);
+    parse_interfaces(CHECK);
+    parse_fields(CHECK);
+    parse_methods(CHECK);
+    parse_cached_class_file(CHECK);
+    log_trace(crac, class, parser)("  Instance class dump parsing completed");
+  }
+
+  // ###########################################################################
+  // Class creation
+  // ###########################################################################
+
+  int compute_vtable_size(const Symbol *class_name DEBUG_ONLY(COMMA TRAPS)) {
+    precond(_transitive_interfaces != nullptr);
+
+    ResourceMark rm;
+    int vtable_size;
+    int num_mirandas; GrowableArray<Method *> all_mirandas; // Filled but shouldn't be used (see the comments below)
+    const Handle loader_h(Thread::current(), _loader_data->class_loader());
+    klassVtable::compute_vtable_size_and_num_mirandas(&vtable_size, &num_mirandas, &all_mirandas, _super, _methods,
+                                                      _class_access_flags, _major_version, loader_h, class_name, _local_interfaces);
+
+#ifdef ASSERT
+    // The parsed methods already include overpass methods which are normally
+    // only generated after computing the mirandas above. Because some of the
+    // overpasses can be ex-mirandas the mirandas list computed above may be
+    // incomplete, so recompute without the overpasses to do the asserts below.
+    GrowableArray<Method *> methods_no_overpasses_tmp(_methods->length());
+    for (int i = 0; i < _methods->length(); i++) {
+      Method *const m = _methods->at(i);
+      if (!m->is_overpass()) {
+        methods_no_overpasses_tmp.append(m);
+      }
+    }
+    log_trace(crac, class, parser)("  Class has %i overpass methods", _methods->length() - methods_no_overpasses_tmp.length());
+
+    Array<Method *> *const methods_no_overpasses = MetadataFactory::new_array<Method *>(_loader_data, methods_no_overpasses_tmp.length(), CHECK_0);
+    if (!methods_no_overpasses->is_empty()) {
+      memcpy(methods_no_overpasses->data(), methods_no_overpasses_tmp.adr_at(0), methods_no_overpasses->length() * sizeof(Method *));
+    }
+
+    int vtable_size_debug;
+    int num_mirandas_debug; GrowableArray<Method *> all_mirandas_debug; // These will be the right values
+    klassVtable::compute_vtable_size_and_num_mirandas(&vtable_size_debug, &num_mirandas_debug, &all_mirandas_debug, _super, methods_no_overpasses,
+                                                      _class_access_flags, _major_version, loader_h, class_name, _local_interfaces);
+    assert(vtable_size == vtable_size_debug, "absence of overpass methods should not change the vtable size");
+    assert(num_mirandas <= num_mirandas_debug, "overpasses might have been mirandas");
+
+    const bool has_miranda_methods = num_mirandas_debug > 0 || (_super != nullptr && _super->has_miranda_methods());
+    assert(_ik_flags.has_miranda_methods() == has_miranda_methods,
+          "internal instance class flag 'has miranda methods' dumped with incorrect value: expected %s", BOOL_TO_STR(has_miranda_methods));
+    MetadataFactory::free_array(_loader_data, methods_no_overpasses);
+#endif
+
+    return vtable_size;
+  }
+
+  FieldLayoutInfo compute_field_layout(const Symbol *class_name) {
+    FieldLayoutInfo field_layout_info; // Will contain resource-allocated data
+    FieldLayoutBuilder lb(class_name, _super, _cp, &_field_infos, _ik_flags.is_contended(), &field_layout_info);
+    lb.build_layout(); // Fills FieldLayoutInfo and offsets of field infos
+    return field_layout_info;
+  }
+
+  static Annotations *create_combined_annotations(ClassLoaderData *loader_data,
+                                                  AnnotationArray *class_annos,
+                                                  AnnotationArray *class_type_annos,
+                                                  Array<AnnotationArray *> *field_annos,
+                                                  Array<AnnotationArray *> *field_type_annos,
+                                                  TRAPS) {
+    if (class_annos == nullptr && class_type_annos == nullptr &&
+        field_annos == nullptr && field_type_annos == nullptr) {
+      return nullptr; // Don't create the Annotations object unnecessarily.
+    }
+
+    Annotations* const annotations = Annotations::allocate(loader_data, CHECK_NULL);
+    annotations->set_class_annotations(class_annos);
+    annotations->set_class_type_annotations(class_type_annos);
+    annotations->set_fields_annotations(field_annos);
+    annotations->set_fields_type_annotations(field_type_annos);
+    return annotations;
+  }
+
+  void move_data_to_class(TRAPS) {
+    InstanceKlass &ik = *_ik;
+    // Move everything we've parsed so far and null the pointers so that they
+    // won't get freed in the destructor
+
+    _cp->set_operands(_bsm_operands);
+    _cp->set_pool_holder(&ik);
+    ik.set_constants(_cp); // Must do this before setting the indices below
+    _bsm_operands = nullptr;
+    _cp = nullptr;
+
+    ik.set_nest_members(_nest_members);
+    ik.set_inner_classes(_inner_classes);
+    ik.set_source_debug_extension(_source_debug_extension);
+    ik.set_record_components(_record_components);
+    ik.set_permitted_subclasses(_permitted_subclasses);
+    _nest_members = nullptr;
+    _inner_classes = nullptr;
+    _source_debug_extension = nullptr;
+    _record_components = nullptr;
+    _permitted_subclasses = nullptr;
+
+    Annotations *const combined_annotations = create_combined_annotations(_loader_data,
+                                                                          _class_annotations, _class_type_annotations,
+                                                                          _field_annotations, _field_type_annotations,
+                                                                          CHECK);
+    ik.set_annotations(combined_annotations);
+    _class_annotations = nullptr;
+    _class_type_annotations = nullptr;
+    _field_annotations = nullptr;
+    _field_type_annotations = nullptr;
+
+    ik.set_fieldinfo_stream(_field_info_stream);
+    ik.set_fields_status(_field_statuses);
+    _field_info_stream = nullptr;
+    _field_statuses = nullptr;
+
+    ik.set_methods(_methods);
+    ik.set_method_ordering(_original_method_ordering);
+    ik.set_default_methods(_default_methods); // Vtable indices for these will be set later not to get an allocation exception here
+    _methods = nullptr;
+    _original_method_ordering = nullptr;
+    _default_methods = nullptr;
+
+    ik.initialize_supers(_super, _transitive_interfaces, CHECK);
+    ik.set_local_interfaces(_local_interfaces);
+    ik.set_transitive_interfaces(_transitive_interfaces);
+    _local_interfaces = nullptr;
+    _transitive_interfaces = nullptr;
+    // No need to set super to null because the destructor won't free it
+
+#if INCLUDE_JVMTI
+    ik.set_cached_class_file(_cached_class_file);
+    _cached_class_file = nullptr;
+#endif // INCLUDE_JVMTI
+  }
+
+  // Allocates and fills the class. Roughly equivalent to
+  // ClassFileParser::create_instance_class().
+  void create_class(TRAPS) {
+    Thread *const thread = Thread::current();
+    Symbol *const class_name = _heap_dump.get_class_name(_class_dump.id);
+
+    // Allocate the class
+
+    // TODO instead of re-computing the sizes from the ground up save
+    //  vtable/itable lengths and quickly compute the sizes based on them
+    _transitive_interfaces = ClassFileParser::compute_transitive_interfaces(_super, _local_interfaces, _loader_data, CHECK);
+    const int vtable_size = compute_vtable_size(class_name DEBUG_ONLY(COMMA CHECK));
+    const int itable_size = !_class_access_flags.is_interface() ? klassItable::compute_itable_size(_transitive_interfaces) : 0;
+
+    ResourceMark rm; // For FieldLayoutInfo contents
+    FieldLayoutInfo field_layout_info = compute_field_layout(class_name); // Also fills offsets in _field_infos
+    _field_info_stream = FieldInfoStream::create_FieldInfoStream(&_field_infos, _java_fields_num, _injected_fields_num, _loader_data, CHECK);
+    _field_infos.clear_and_deallocate(); // Don't need them anymore
+    guarantee(field_layout_info._has_nonstatic_fields == _ik_flags.has_nonstatic_fields(),
+              "internal instance class flag 'has nonstatic fields' dumped with incorrect value: expected %s",
+              BOOL_TO_STR(field_layout_info._has_nonstatic_fields));
+
+    const InstanceKlassSizes ik_sizes{vtable_size, itable_size, field_layout_info._instance_size,
+                                      field_layout_info._static_field_size,
+                                      field_layout_info.oop_map_blocks->_nonstatic_oop_map_count};
+    InstanceKlass &ik = *InstanceKlass::allocate_instance_klass(_loader_data, class_name, _super, _class_access_flags, ik_sizes, CHECK);
+    _ik = &ik; // Set eagerly to get it deallocated in case of a error
+
+    // Fill the allocated class
+
+    ik.set_class_loader_data(_loader_data);
+    ik.set_name(class_name);
+
+    _loader_data->add_class(&ik, /* publicize = */ false);
+
+    ik.set_internal_flags(_ik_flags);
+
+    ik.set_nonstatic_field_size(field_layout_info._nonstatic_field_size);
+    ik.set_static_oop_field_count(_static_oop_fields_num);
+    // has_nonstatic_fields is set via internal class flags
+
+    move_data_to_class(CHECK); // Cannot use the majority of the parser's fields from this point on
+
+    // These require constant pool to be set
+    ik.set_source_file_name_index(_source_file_name_index);
+    ik.set_generic_signature_index(_generic_signature_index);
+    ik.set_nest_host_index(_nest_host_index);
+
+    // Method-related flags (including has_miranda_methods) has already been
+    // checked, the original method ordering has also been set
+    // TODO JVM TI RedefineClasses support may require this to be handeled
+    //  differently (save/restore _idnum_allocated_count or take max idnum of
+    //  all methods in this class and its previous versions)
+    ik.set_initial_method_idnum(checked_cast<u2>(ik.methods()->length()));
+
+    ik.set_this_class_index(_this_class_index);
+    // Resolution of this class index for a hidden class will be done later,
+    // together with the rest of the class references
+
+    ik.set_minor_version(_minor_version);
+    ik.set_major_version(_major_version);
+
+    ClassLoaderData *non_reflection_loader_data =
+      ClassLoaderData::class_loader_data_or_null(java_lang_ClassLoader::non_reflection_class_loader(ik.class_loader()));
+    ik.set_package(non_reflection_loader_data, nullptr, CHECK);
+
+    ClassFileParser::check_methods_for_intrinsics(&ik);
+
+    // Update the corresponding CDS flag (which we don't save)
+    if (ik.is_value_based()) {
+      ik.set_has_value_based_class_annotation();
+    }
+    // Other annotations- and attributes-related flags and values have already
+    // been set
+
+    // Interfaces have been already set, so can do this
+    klassItable::setup_itable_offset_table(&ik);
+
+    const OopMapBlocksBuilder &oop_map_blocks = *field_layout_info.oop_map_blocks;
+    if (oop_map_blocks._nonstatic_oop_map_count > 0) {
+      oop_map_blocks.copy(ik.start_of_nonstatic_oop_maps());
+    }
+
+    ClassFileParser::check_can_allocate_fast(&ik);
+    // Other "precomputed" flags have been checked/set already
+
+    // Access control checks are skipped for simplicity (if no one tampered with
+    // the dump, this should've been checked when loading the class)
+
+    precond(ik.is_being_restored()); // Makes create_mirror() omit static field initialization
+    java_lang_Class::create_mirror(&ik,
+                                   Handle(thread, _loader_data->class_loader()),
+                                   Handle(thread, ik.module()->module()),
+                                   Handle(), Handle(), // Prot. domain and class data -- to be restored later
+                                   CHECK);
+
+    if (ik.default_methods() != nullptr) {
+      assert(ik.has_nonstatic_concrete_methods(), "should have been checked when parsing the default methods");
+      ik.create_new_default_vtable_indices(ik.default_methods()->length(), CHECK);
+    }
+
+    // TODO JVMTI redefine/retransform support: if the class was changed by a
+    //  class loading hook, set has_default_read_edges flag for its module
+    //  (that's what ClassFileParser does)
+
+    ClassLoadingService::notify_class_loaded(&ik, false);
+
+    JFR_ONLY(INIT_ID(&ik));
+
+    JVMTI_ONLY(ik.constants()->set_version(_redefinition_version));
+
+    DEBUG_ONLY(ik.verify());
+
+    if (log_is_enabled(Debug, crac, class, parser)) {
+      log_debug(crac, class, parser)("  Instance class created: %s", ik.external_name());
+    }
+  }
+};
+
+// Parses dump of a particular class without creating its representation.
+class CracInstanceClassDumpSkipper : public ClassDumpReader {
+ public:
+  CracInstanceClassDumpSkipper(u2 id_size, BasicTypeReader *reader, TRAPS) : ClassDumpReader(reader, id_size) {
+    precond(reader != nullptr);
+    parse_class(CHECK);
+  }
+
+ private:
+  bool _is_rewritten;
+  u2 _nest_host_index;
+
+  template <class UINT_T, ENABLE_IF((std::is_same<UINT_T, u1>::value || std::is_same<UINT_T, u2>::value ||
+                                     std::is_same<UINT_T, u4>::value || std::is_same<UINT_T, u8>::value))>
+  void skip_uint_array(TRAPS) {
+    const auto len = read<u4>(CHECK);
+    if (len == CracClassDumper::NO_ARRAY_SENTINEL) {
+      return;
+    }
+    skip(len * sizeof(UINT_T), CHECK);
+  }
+
+  void parse_class_state(TRAPS) {
+    const auto raw_state = read<u1>(CHECK);
+    guarantee(raw_state == InstanceKlass::loaded || raw_state == InstanceKlass::linked ||
+              raw_state == InstanceKlass::fully_initialized || raw_state == InstanceKlass::initialization_error,
+              "illegal class state: %i", raw_state);
+    const auto class_state = static_cast<InstanceKlass::ClassState>(raw_state);
+
+    if (raw_state == InstanceKlass::initialization_error) {
+      skip(id_size(), CHECK);
+    }
+
+    log_trace(crac, class, parser)("  Skipped class state");
+  }
+
+  void parse_class_flags(TRAPS) {
+    skip(sizeof(u4), CHECK); // Access flags
+    const u2 internal_flags = read<u2>(CHECK);
+    skip(sizeof(u1), CHECK); // Internal statuses
+    const InstanceKlassFlags ik_flags(internal_flags, /* internal statuses */ 0);
+    _is_rewritten = ik_flags.rewritten();
+    log_trace(crac, class, parser)("  Skipped class flags");
+  }
+
+  void parse_source_debug_extension_attr(TRAPS) {
+    const bool has_sde = read_bool(CHECK);
+    if (has_sde) {
+      const auto len = read<jint>(CHECK);
+      skip(len, CHECK);
+    }
+  }
+
+  void parse_record_attr(TRAPS) {
+    const auto has_record = read_bool(CHECK);
+    if (!has_record) {
+      return;
+    }
+
+    const auto components_num = read<u2>(CHECK);
+    for (u2 i = 0; i < components_num; i++) {
+      skip(4 * sizeof(u2), CHECK);
+      skip_uint_array<u1>(CHECK);
+      skip_uint_array<u1>(CHECK);
+    }
+  }
+
+  void parse_class_attrs(TRAPS) {
+    skip(2 * sizeof(u2), CHECK); // SourceFileName, Signature
+    _nest_host_index = read<u2>(CHECK);
+    skip(id_size(), CHECK);      // Resolved nest host
+    skip_uint_array<u2>(CHECK);  // NestMembers
+    skip_uint_array<u2>(CHECK);  // InnerClasses
+    parse_source_debug_extension_attr(CHECK);
+    skip_uint_array<u2>(CHECK);  // BootstrapMethods
+    parse_record_attr(CHECK);
+    skip_uint_array<u2>(CHECK);  // PermittedSubclasses
+    skip_uint_array<u1>(CHECK);  // Runtime(In)VisibleAnnotations
+    skip_uint_array<u1>(CHECK);  // Runtime(In)VisibleTypeAnnotations
+    log_trace(crac, class, parser)("  Skipped class attributes");
+  }
+
+  void parse_resolution_error_symbols(bool is_nest_host_error, TRAPS) {
+    skip(2 * id_size(), CHECK); // Error and message IDs
+    const HeapDump::ID cause_sym_id = read_id(true, CHECK);
+    if (cause_sym_id != HeapDump::NULL_ID) {
+      skip(id_size(), CHECK); // Cause message ID
+    }
+    if (is_nest_host_error) {
+      const auto nest_host_err_len = read<u4>(CHECK);
+      skip(nest_host_err_len, CHECK);
+    }
+  }
+
+  void parse_constant_pool(TRAPS) {
+    const auto pool_len = read<u2>(CHECK);
+    skip(sizeof(u2), CHECK); // Number of classes
+    log_trace(crac, class, parser)("  Skipping %i constant pool slots", pool_len);
+    for (u2 pool_i = 1 /* index 0 is unused */; pool_i < pool_len; pool_i++) {
+      const auto tag = read<u1>(CHECK);
+      switch (tag) {
+        case JVM_CONSTANT_Utf8: skip(id_size(), CHECK); break;
+        case JVM_CONSTANT_NameAndType: skip(2 * sizeof(u2), CHECK); break;
+
+        case JVM_CONSTANT_Integer: skip(sizeof(jint), CHECK); break;
+        case JVM_CONSTANT_Float: skip(sizeof(jfloat), CHECK); break;
+        case JVM_CONSTANT_Long:
+          skip(sizeof(jlong), CHECK);
+          guarantee(++pool_i != pool_len, "long occupies two constant pool slots and thus cannot start on the last slot");
+          break;
+        case JVM_CONSTANT_Double:
+          skip(sizeof(jdouble), CHECK);
+          guarantee(++pool_i != pool_len, "double occupies two constant pool slots and thus cannot start on the last slot");
+          break;
+        case JVM_CONSTANT_String: skip(id_size(), CHECK); break;
+
+        case JVM_CONSTANT_Class:
+        case JVM_CONSTANT_UnresolvedClass:
+        case JVM_CONSTANT_UnresolvedClassInError:
+          skip(sizeof(u2), CHECK);
+          if (tag == JVM_CONSTANT_Class) {
+            skip(id_size(), CHECK);
+            if (pool_i == _nest_host_index) {
+              const bool has_nest_host_res_error = read_bool(CHECK);
+              if (has_nest_host_res_error) {
+                parse_resolution_error_symbols(true, CHECK);
+              }
+            }
+          } else if (tag == JVM_CONSTANT_UnresolvedClassInError) {
+            parse_resolution_error_symbols(false, CHECK);
+          }
+          break;
+        case JVM_CONSTANT_Fieldref:
+        case JVM_CONSTANT_Methodref:
+        case JVM_CONSTANT_InterfaceMethodref:
+          skip(2 * sizeof(u2), CHECK);
+          break;
+        case JVM_CONSTANT_MethodType:
+        case JVM_CONSTANT_MethodTypeInError:
+          skip(sizeof(u2), CHECK);
+          if (tag == JVM_CONSTANT_MethodTypeInError) {
+            parse_resolution_error_symbols(false, CHECK);
+          }
+          break;
+        case JVM_CONSTANT_MethodHandle:
+        case JVM_CONSTANT_MethodHandleInError:
+          skip(sizeof(u1) + sizeof(u2), CHECK);
+          if (tag == JVM_CONSTANT_MethodHandleInError) {
+            parse_resolution_error_symbols(false, CHECK);
+          }
+          break;
+        case JVM_CONSTANT_Dynamic:
+        case JVM_CONSTANT_DynamicInError:
+        case JVM_CONSTANT_InvokeDynamic:
+          skip(2 * sizeof(u2), CHECK);
+          if (tag == JVM_CONSTANT_DynamicInError) {
+            parse_resolution_error_symbols(false, CHECK);
+          }
+          break;
+
+        default:
+          guarantee(false, "illegal tag %i at constant pool slot %i", tag, pool_i);
+      }
+      log_trace(crac, class, parser)("    Skipped constant pool slot with tag %i", tag);
+    }
+
+    log_trace(crac, class, parser)("  Skipped constant pool");
+  }
+
+  void parse_constant_pool_cache(TRAPS) {
+    const auto field_entries_len = read<u2>(CHECK);
+    const auto method_entries_len = read<jint>(CHECK); // AKA cache length
+    const auto indy_entries_len = read<jint>(CHECK);
+    guarantee(method_entries_len >= 0, "amount of resolved methods cannot be negative");
+    guarantee(indy_entries_len >= 0, "amount of resolved invokedynamic instructions cannot be negative");
+
+    for (u2 field_i = 0; field_i < field_entries_len; field_i++) {
+      skip(sizeof(u2), CHECK); // Constant pool index
+
+      const auto get_code = read<u1>(CHECK);
+      skip(sizeof(u1), CHECK); // put code
+
+      if (get_code != 0) {
+        skip(id_size(), CHECK); // Holder class ID
+        skip(sizeof(u2) + 2 * sizeof(u1), CHECK); // Field info
+      }
+    }
+
+    for (int cache_i = 0; cache_i < method_entries_len; cache_i++) {
+      skip(sizeof(u2), CHECK); // Constant pool index
+
+      const auto raw_bytecode1 = read<u1>(CHECK);
+      const auto raw_bytecode2 = read<u1>(CHECK);
+      guarantee(Bytecodes::is_defined(raw_bytecode1), "undefined method resolution bytecode 1: %i", raw_bytecode1);
+      guarantee(Bytecodes::is_defined(raw_bytecode2), "undefined method resolution bytecode 2: %i", raw_bytecode2);
+
+      if (raw_bytecode1 > 0 || raw_bytecode2 > 0) { // If resolved
+        const auto flags = read<u1>(CHECK);
+        const bool is_forced_virtual = is_set_nth_bit(flags, CracClassDumper::is_forced_virtual_shift);
+        const bool is_vfinal = is_set_nth_bit(flags, CracClassDumper::is_vfinal_shift);
+        const bool has_appendix = is_set_nth_bit(flags, CracClassDumper::has_appendix_shift);
+        skip(2 * sizeof(u1), CHECK); // ToS state, number of parameters
+
+        // f1
+        const Bytecodes::Code bytecode1 = Bytecodes::cast(raw_bytecode1);
+        switch (bytecode1) {
+          case Bytecodes::_invokestatic:
+          case Bytecodes::_invokespecial:
+          case Bytecodes::_invokehandle:
+            skip(id_size() + sizeof(u2), CHECK);
+            break;
+          case Bytecodes::_invokeinterface:
+            if (!is_forced_virtual) {
+              skip(id_size(), CHECK);
+            }
+            break;
+          case 0: // bytecode1 is not set
+            break;
+          default:
+            guarantee(false, "illegal method resolution bytecode 1: %s", Bytecodes::name(bytecode1));
+        }
+
+        // f2
+        const Bytecodes::Code bytecode2 = Bytecodes::cast(raw_bytecode2);
+        guarantee(bytecode2 == 0 || bytecode2 == Bytecodes::_invokevirtual, "illegal method resolution bytecode 2: %s", Bytecodes::name(bytecode2));
+        if (is_vfinal || (bytecode1 == Bytecodes::_invokeinterface && !is_forced_virtual)) {
+          skip(id_size() + sizeof(u2), CHECK);
+        } else if (bytecode1 == Bytecodes::_invokeinterface || bytecode2 == Bytecodes::_invokevirtual ||
+                  (bytecode1 == Bytecodes::_invokehandle && has_appendix)) {
+          skip(sizeof(jint), CHECK);
+        }
+      }
+    }
+
+    for (int indy_i = 0; indy_i < indy_entries_len; indy_i++) {
+      skip(2 * sizeof(u2), CHECK); // Constant pool index
+
+      const auto extended_flags = read<u1>(CHECK);
+      const bool is_resolution_failed = is_set_nth_bit(extended_flags, 0); // TODO define the shift in ResolvedIndyEntry
+      const bool is_resolved          = is_set_nth_bit(extended_flags, ResolvedIndyEntry::num_flags);
+
+      if (is_resolved) {
+        skip(id_size() + 2 * sizeof(u2) + sizeof(u1), CHECK);
+      } else if (is_resolution_failed) {
+        parse_resolution_error_symbols(false, CHECK);
+      }
+    }
+
+    skip_uint_array<u2>(CHECK); // Resolved references map
+
+    log_trace(crac, class, parser)("  Skipped constant pool cache");
+  }
+
+  void parse_interfaces(TRAPS) {
+    const auto interfaces_num = read<u2>(CHECK);
+    for (u2 i = 0; i < interfaces_num; i++) {
+      skip(id_size(), CHECK);
+    }
+    log_trace(crac, class, parser)("  Skipped %i local interfaces", interfaces_num);
+  }
+
+  void parse_fields(TRAPS) {
+    const auto java_fields_num = read<u2>(CHECK);
+    const auto injected_fields_num = read<u2>(CHECK);
+    for (u2 i = 0; i < java_fields_num + injected_fields_num; i++) {
+      skip(5 * sizeof(u2) + sizeof(jshort) + 2 * sizeof(u1), CHECK);
+      if (i < java_fields_num) { // Non-injected fields have annotations
+        skip_uint_array<u1>(CHECK); // Runtime(In)VisibleAnnotations
+        skip_uint_array<u1>(CHECK); // Runtime(In)VisibleTypeAnnotations
+      }
+    }
+
+    log_trace(crac, class, parser)("  Skipped %i fields", java_fields_num + injected_fields_num);
+  }
+
+  InlineTableSizes parse_method_inline_table_sizes(const ConstMethodFlags &flags, TRAPS) {
+    const u2 exception_table_length = !flags.has_exception_table() ? 0 : read<u2>(CHECK_({}));
+    const jint compressed_linenumber_size = !flags.has_linenumber_table() ? 0 : read<jint>(CHECK_({}));
+    const u2 localvariable_table_length = !flags.has_localvariable_table() ? 0 : read<u2>(CHECK_({}));
+    const u2 checked_exceptions_length = !flags.has_checked_exceptions() ? 0 : read<u2>(CHECK_({}));
+    const int method_parameters_length = !flags.has_method_parameters() ? 0 : read<u1>(CHECK_({})); // Not using -1 to ease skipping
+    const u2 generic_signature_index = !flags.has_generic_signature() ? 0 : read<u2>(CHECK_({}));
+    const jint method_annotations_length = !flags.has_method_annotations() ? 0 : read<jint>(CHECK_({}));
+    const jint parameter_annotations_length = !flags.has_parameter_annotations() ? 0 : read<jint>(CHECK_({}));
+    const jint type_annotations_length = !flags.has_type_annotations() ? 0 : read<jint>(CHECK_({}));
+    const jint default_annotations_length = !flags.has_default_annotations() ? 0 : read<jint>(CHECK_({}));
+#define INLINE_TABLE_NAME_PARAM(name) name,
+    return {
+      INLINE_TABLES_DO(INLINE_TABLE_NAME_PARAM)
+      0 /* end of iteration */
+    };
+#undef INLINE_TABLE_NAME_PARAM
+  }
+
+  void parse_code_attr(const ConstMethodFlags &flags, u2 code_size, const InlineTableSizes &table_sizes, TRAPS) {
+    skip(2 * sizeof(u2) + code_size, CHECK); // Max stack, max locals, bytecodes
+    if (flags.has_exception_table()) {
+      STATIC_ASSERT(sizeof(ExceptionTableElement) == 4 * sizeof(u2)); // Check no padding
+      const size_t size = table_sizes.exception_table_length() * sizeof(ExceptionTableElement);
+      skip(size, CHECK);
+    }
+    if (flags.has_linenumber_table()) {
+      skip(table_sizes.compressed_linenumber_size(), CHECK);
+    }
+    if (flags.has_localvariable_table()) {
+      STATIC_ASSERT(sizeof(LocalVariableTableElement) == 6 * sizeof(u2)); // Check no padding
+      const size_t size = table_sizes.localvariable_table_length() * sizeof(LocalVariableTableElement);
+      skip(size, CHECK);
+    }
+    skip_uint_array<u1>(CHECK); // StackMap table
+  }
+
+  void parse_method(TRAPS) {
+    skip(3 * sizeof(u2), CHECK); // idnums and access flags
+
+    const auto raw_flags = read<jint>(CHECK);
+    const ConstMethodFlags flags(raw_flags);
+
+    skip(sizeof(jint) + 2 * sizeof(u2), CHECK); // Statuses, name and signature indices
+
+    const auto code_size = read<u2>(CHECK);
+    const InlineTableSizes table_sizes = parse_method_inline_table_sizes(flags, CHECK);
+
+    if (code_size > 0) {
+      parse_code_attr(flags, code_size, table_sizes, CHECK);
+    }
+
+    STATIC_ASSERT(sizeof(CheckedExceptionElement) == sizeof(u2)); // Check no padding
+    const size_t checked_exceptions_table_size = table_sizes.checked_exceptions_length() * sizeof(CheckedExceptionElement);
+
+    STATIC_ASSERT(sizeof(MethodParametersElement) == 2 * sizeof(u2)); // Check no padding
+    const size_t method_params_table_size = table_sizes.method_parameters_length() * sizeof(MethodParametersElement);
+
+    skip(checked_exceptions_table_size + method_params_table_size +
+         table_sizes.method_annotations_length() + table_sizes.parameter_annotations_length() +
+         table_sizes.type_annotations_length() + table_sizes.default_annotations_length() +
+         sizeof(u1) /* is compiled lambda form */, CHECK);
+  }
+
+  void parse_methods(TRAPS) {
+    const auto methods_num = read<u2>(CHECK);
+    for (u2 i = 0; i < methods_num; i++) {
+      skip(sizeof(u2), CHECK); // Original index
+      parse_method(CHECK);
+    }
+    log_trace(crac, class, parser)("Skipped %i methods", methods_num);
+
+    const u2 default_methods_num = read<u2>(CHECK);
+    for (u2 i = 0; i < default_methods_num; i++) {
+      skip(id_size() + sizeof(u2), CHECK);
+    }
+    log_trace(crac, class, parser)("Skipped %i default methods", default_methods_num);
+  }
+
+  void parse_cached_class_file(TRAPS) {
+    const auto len = read<jint>(CHECK);
+    if (len != CracClassDumper::NO_CACHED_CLASS_FILE_SENTINEL) {
+      skip(len, CHECK);
+    }
+    log_trace(crac, class, parser)("  Skipped cached class file");
+  }
+
+  void parse_class(TRAPS) {
+    parse_class_state(CHECK);
+    skip(2 * sizeof(u2) + sizeof(jint), CHECK); // Class versions
+    parse_class_flags(CHECK);
+    parse_class_attrs(CHECK);
+    parse_constant_pool(CHECK);
+    if (_is_rewritten) {
+      parse_constant_pool_cache(CHECK);
+    }
+    skip(sizeof(u2), CHECK);                    // this_class index
+    parse_interfaces(CHECK);
+    parse_fields(CHECK);
+    parse_methods(CHECK);
+    parse_cached_class_file(CHECK);
+    log_trace(crac, class, parser)("  Instance class dump skipped");
+  }
+};
+
+void CracClassDumpParser::parse(const char *path, const ParsedHeapDump &heap_dump,
+                                ClassLoaderProvider *loader_provider,
+                                HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *iks,
+                                HeapDumpTable<ArrayKlass *, AnyObj::C_HEAP> *aks,
+                                HeapDumpTable<ClassHeapDeps, AnyObj::C_HEAP> *heap_deps, TRAPS) {
+  precond(path != nullptr && loader_provider != nullptr && iks != nullptr && aks != nullptr);
+  log_info(crac, class, parser)("Started parsing class dump %s", path);
+
+  FileBasicTypeReader reader;
+  if (!reader.open(path)) {
+    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(),
+              err_msg("Cannot open %s for reading: %s", path, os::strerror(errno)));
+  }
+
+  CracClassDumpParser dump_parser(&reader, heap_dump, loader_provider, iks, aks, heap_deps, THREAD);
+  if (HAS_PENDING_EXCEPTION) {
+    Handle cause(Thread::current(), PENDING_EXCEPTION);
+    CLEAR_PENDING_EXCEPTION;
+    THROW_MSG_CAUSE(vmSymbols::java_lang_IllegalArgumentException(),
+                    err_msg("Failed to create re-classes from dump %s", path), cause);
+  } else {
+    log_info(crac, class, parser)("Successfully parsed class dump %s", path);
+  }
+}
+
+CracClassDumpParser::CracClassDumpParser(BasicTypeReader *reader, const ParsedHeapDump &heap_dump, ClassLoaderProvider *loader_provider,
+                                         HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *iks, HeapDumpTable<ArrayKlass *, AnyObj::C_HEAP> *aks,
+                                         HeapDumpTable<ClassHeapDeps, AnyObj::C_HEAP> *heap_deps, TRAPS) :
+    ClassDumpReader(reader), _heap_dump(heap_dump), _loader_provider(loader_provider), _iks(iks), _aks(aks), _heap_deps(heap_deps) {
+  if (Arguments::is_dumping_archive()) {
+    // TODO should do something like ClassLoader::record_result() after loading each class
+    log_warning(crac, class, parser, cds)("Classes restored by CRaC will not be included into the CDS archive");
+  }
+  parse_header(CHECK);
+  parse_primitive_array_classes(CHECK);
+  {
+    ResourceMark rm;
+    const GrowableArray<Pair<HeapDump::ID, InterclassRefs>> &interclass_refs = parse_instance_and_obj_array_classes(CHECK);
+    for (const Pair<HeapDump::ID, InterclassRefs> &id_to_refs : interclass_refs) {
+      CracClassStateRestorer::fill_interclass_references(*_iks->get(id_to_refs.first), *_iks, *_aks, id_to_refs.second);
+    }
+  }
+  parse_initiating_loaders(CHECK);
+};
+
+void CracClassDumpParser::parse_header(TRAPS) {
+  constexpr char HEADER_STR[] = "CRAC CLASS DUMP 0.1";
+
+  char header_str[sizeof(HEADER_STR)];
+  read_raw(header_str, sizeof(header_str), CHECK);
+  header_str[sizeof(header_str) - 1] = '\0'; // Ensure nul-terminated
+  if (strcmp(header_str, HEADER_STR) != 0) {
+    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), err_msg("Unknown header string: %s", header_str));
+  }
+
+  const auto id_size = read<u2>(CHECK);
+  set_id_size(id_size, CHECK);
+
+  const auto compressed_vm_options = read<u1>(CHECK);
+  using shifts = CracClassDumper::VMOptionShift;
+  if (compressed_vm_options >> shifts::num_vm_options != 0) {
+    THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), "Unknown VM options specified");
+  }
+
+  const bool was_sync_on_value_based_classes_diagnosed = is_set_nth_bit(compressed_vm_options, shifts::is_sync_on_value_based_classes_diagnosed_shift);
+  const bool were_all_annotation_preserved = is_set_nth_bit(compressed_vm_options, shifts::are_all_annotations_preserved_shift);
+  if ((DiagnoseSyncOnValueBasedClasses != 0) && !was_sync_on_value_based_classes_diagnosed) {
+    if (!were_all_annotation_preserved) {
+      // TODO either save the InstanceKlass::is_value_based() flag regardless
+      //  of that option (like CDS does via
+      //  Klass::has_value_based_class_annotation()) or parse annotations of
+      //  each class to recompute InstanceKlass::is_value_based()
+      log_warning(crac, class, parser)("Checkpointed VM wasn't diagnosing syncronization on value-based classes, but this VM is requested to (by the corresponding option). "
+                                        "This will not be fulfullied for the restored classes.");
+    } else {
+      log_warning(crac, class, parser)("Checkpointed VM wasn't diagnosing syncronization on value-based classes, but this VM is requested to (by the corresponding option). "
+                                        "This will not be fulfullied for the restored classes because the checkpointed VM also preserved RuntimeInvisibleAnnotations "
+                                        "making them indistinguishable from RuntimeVisibleAnnotations.");
+    }
+  }
+  if (were_all_annotation_preserved != PreserveAllAnnotations) {
+    log_warning(crac, class, parser)("Checkpointed VM %s, but this VM is requested to %s them (by the corresponding option). "
+                                      "This will not be fulfullied for the restored classes.",
+                                      were_all_annotation_preserved ? "preserved RuntimeInvisibleAnnotations making them indistinguishable from RuntimeVisibleAnnotations" :
+                                                                      "didn't preserve RuntimeInvisibleAnnotations",
+                                      PreserveAllAnnotations        ? "preserve" :
+                                                                      "omit");
+  }
+
+  log_debug(crac, class, parser)("Parsed class dump header: ID size = %i", id_size);
+}
+
+void CracClassDumpParser::parse_obj_array_classes(Klass *bottom_class, TRAPS) {
+  precond(bottom_class->is_instance_klass() || bottom_class->is_typeArray_klass());
+  Klass *cur_k = bottom_class;
+  const auto num_arrays = read<u1>(CHECK);
+  for (u1 i = 0; i < num_arrays; i++) {
+    const HeapDump::ID obj_array_class_id = read_id(false, CHECK);
+    ArrayKlass *const ak = cur_k->array_klass(CHECK);
+    precond(!_aks->contains(obj_array_class_id));
+    _aks->put_when_absent(obj_array_class_id, ak);
+    cur_k = ak;
+  }
+
+  if (log_is_enabled(Trace, crac, class, parser)) {
+    ResourceMark rm;
+    log_trace(crac, class, parser)("Parsed object array classes with bottom class %s", bottom_class->external_name());
+  }
+}
+
+void CracClassDumpParser::parse_primitive_array_classes(TRAPS) {
+  precond(Universe::is_fully_initialized());
+  for (u1 t = JVM_T_BOOLEAN; t <= JVM_T_LONG; t++) {
+    const HeapDump::ID prim_array_class_id = read_id(false, CHECK);
+    Klass *const tak = Universe::typeArrayKlassObj(static_cast<BasicType>(t));
+    precond(!_aks->contains(prim_array_class_id));
+    _aks->put_when_absent(prim_array_class_id, TypeArrayKlass::cast(tak));
+    parse_obj_array_classes(tak, CHECK);
+  }
+  log_debug(crac, class, parser)("Parsed primitive array classes");
+}
+
+struct CracClassDumpParser::ClassPreamble {
+  HeapDump::ID class_id = HeapDump::NULL_ID;
+  CracClassDumper::ClassLoadingKind loading_kind;
+};
+
+CracClassDumpParser::ClassPreamble CracClassDumpParser::parse_instance_class_preamble(TRAPS) {
+  const HeapDump::ID class_id = read_id(true, CHECK_({}));
+  if (class_id == HeapDump::NULL_ID) {
+    return {};
+  }
+  assert(!_iks->contains(class_id), "class " HDID_FORMAT " is repeated", class_id);
+
+  using Kind = CracClassDumper::ClassLoadingKind;
+  const auto loading_kind = read<u1>(CHECK_({}));
+  guarantee(loading_kind == Kind::NORMAL ||
+            loading_kind == Kind::NON_STRONG_HIDDEN ||
+            loading_kind == Kind::STRONG_HIDDEN,
+            "class " HDID_FORMAT " has illegal loading kind %i", class_id, loading_kind);
+
+  log_debug(crac, class, parser)("Parsed instance class preamble: ID " HDID_FORMAT ", loading kind %i",
+                                  class_id, loading_kind);
+  return {class_id, checked_cast<Kind>(loading_kind)};
+}
+
+Handle CracClassDumpParser::get_class_loader(HeapDump::ID loader_id, TRAPS) {
+  const Handle class_loader = _loader_provider->get_class_loader(loader_id, CHECK_NH);
+  postcond(class_loader.is_null() || class_loader->klass()->is_class_loader_instance_klass());
+  guarantee(!java_lang_ClassLoader::is_reflection_class_loader(class_loader()),
+            "defining loader must be a non-reflection one");
+  return class_loader;
+}
+
+// TODO should not just skip, but synchronize the state somehow, e.g. the
+//  class may be not initialized now but if it was dumped as such, we need to
+//  also mark it as initialized now. But it's unclear what to do if the state
+//  differs (e.g. it was initialized but now it is in the error state).
+InstanceKlass *CracClassDumpParser::skip_instance_class_if_exists(const HeapDump::ClassDump &class_dump,
+                                                                  const Handle &class_loader, TRAPS) {
+  // TODO What to do with hidden classes? They have uniquely-generated names,
+  //  so we won't find them by (class loader, class name) pair even if we
+  //  iterate through all CLDs of the loader and all classes recorded it these
+  //  CLD's class lists. This is a problem since we'll restore such classes
+  //  even if they exist thus duplicating them.
+  Symbol *const class_name = _heap_dump.get_class_name(class_dump.id);
+  InstanceKlass *const ik = SystemDictionary::find_instance_klass(Thread::current(), class_name, class_loader, Handle());
+  if (ik == nullptr) {
+    return nullptr;
+  }
+  guarantee(!ik->is_being_restored(), "pre-loaded classes are not restored");
+
+  CracInstanceClassDumpSkipper(id_size(), reader(), CHECK_NULL);
+  if (log_is_enabled(Debug, crac, class, parser)) {
+    ResourceMark rm;
+    log_debug(crac, class, parser)("Skipped class " HDID_FORMAT " (%s) as pre-loaded", class_dump.id, ik->external_name());
+  }
+
+  return ik;
+}
+
+InstanceKlass *CracClassDumpParser::parse_instance_class(const HeapDump::ClassDump &class_dump,
+                                                         ClassLoaderData *loader_data,
+                                                         InterclassRefs *refs_out, TRAPS) {
+  log_trace(crac, class, parser)("Parsing instance class " HDID_FORMAT, class_dump.id);
+  CracInstanceClassDumpParser ik_parser(id_size(), reader(), _heap_dump, *_iks, class_dump, loader_data, THREAD);
+  if (!HAS_PENDING_EXCEPTION) {
+    CracClassStateRestorer::apply_state(ik_parser.created_class(), ik_parser.class_state(), THREAD);
+  }
+  if (HAS_PENDING_EXCEPTION) {
+    const Handle cause(Thread::current(), PENDING_EXCEPTION);
+    CLEAR_PENDING_EXCEPTION;
+    THROW_MSG_CAUSE_(vmSymbols::java_lang_RuntimeException(), err_msg("Cannot create class " HDID_FORMAT, class_dump.id), cause, {});
+  }
+
+  precond(!_heap_deps->contains(class_dump.id));
+  if (ik_parser.class_initialization_error_id() != HeapDump::NULL_ID) {
+    _heap_deps->put_when_absent(class_dump.id, {ik_parser.class_initialization_error_id()});
+    _heap_deps->maybe_grow();
+  }
+
+  if (log_is_enabled(Debug, crac, class, parser)) {
+    ResourceMark rm;
+    log_debug(crac, class, parser)("Parsed instance class " HDID_FORMAT " (%s)", class_dump.id, ik_parser.created_class()->external_name());
+  }
+  *refs_out = ik_parser.interclass_references();
+  return ik_parser.created_class();
+}
+
+GrowableArray<Pair<HeapDump::ID, InterclassRefs>> CracClassDumpParser::parse_instance_and_obj_array_classes(TRAPS) {
+  HandleMark hm(Thread::current()); // Class loader handles
+  GrowableArray<Pair<HeapDump::ID, InterclassRefs>> interclass_refs;
+  for (ClassPreamble preamble = parse_instance_class_preamble(THREAD);
+       !HAS_PENDING_EXCEPTION && preamble.class_id != HeapDump::NULL_ID;
+       preamble = parse_instance_class_preamble(THREAD)) {
+    assert(!_iks->contains(preamble.class_id), "instance class " HDID_FORMAT " dumped multiple times", preamble.class_id);
+
+    const HeapDump::ClassDump *class_dump = _heap_dump.class_dumps.get(preamble.class_id);
+    guarantee(class_dump != nullptr, "class " HDID_FORMAT " not found in heap dump", preamble.class_id);
+
+    const Handle loader = get_class_loader(class_dump->class_loader_id, CHECK_({}));
+    InstanceKlass *ik = nullptr;
+    using Kind = CracClassDumper::ClassLoadingKind;
+    if (preamble.loading_kind == Kind::NORMAL) {
+      ik = skip_instance_class_if_exists(*class_dump, loader, CHECK_({}));
+    }
+    if (ik == nullptr) {
+      ClassLoaderData *const loader_data = SystemDictionary::register_loader(loader, preamble.loading_kind == Kind::NON_STRONG_HIDDEN);
+      InterclassRefs refs;
+      ik = parse_instance_class(*class_dump, loader_data, &refs, CHECK_({}));
+      interclass_refs.append({class_dump->id, refs});
+    }
+    _iks->put_when_absent(class_dump->id, ik);
+    _iks->maybe_grow();
+
+    parse_obj_array_classes(ik, CHECK_({}));
+  }
+  return interclass_refs;
+}
+
+void CracClassDumpParser::parse_initiating_loaders(TRAPS) {
+  for (HeapDump::ID loader_id = read_id(true, THREAD);
+        !HAS_PENDING_EXCEPTION && loader_id != HeapDump::NULL_ID;
+        loader_id = read_id(true, THREAD)) {
+    const Handle loader = get_class_loader(loader_id, CHECK);
+    const auto initiated_classes_num = read<jint>(CHECK);
+    guarantee(initiated_classes_num >= 0, "amount of initiated classes cannot be negative");
+    for (jint i = 0; i < initiated_classes_num; i++) {
+      const HeapDump::ID class_id = read_id(false, CHECK);
+      InstanceKlass **const ik = _iks->get(class_id);
+      guarantee(ik != nullptr, "unknown class " HDID_FORMAT " dumped as initiated by class loader " HDID_FORMAT, class_id, loader_id);
+      SystemDictionary::record_initiating_loader(*ik, loader, CHECK);
+    }
+  }
+  log_trace(crac, class, parser)("Parsed initiating loaders");
+}

--- a/src/hotspot/share/runtime/cracClassDumpParser.cpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.cpp
@@ -517,7 +517,8 @@ class CracInstanceClassDumpParser : public StackObj /* constructor allocates res
       switch (tag) {
         case JVM_CONSTANT_Utf8: {
           const HeapDump::ID sym_id = read_id(false, CHECK);
-          Symbol *sym = _heap_dump.get_symbol(sym_id);
+          Symbol *const sym = _heap_dump.get_symbol(sym_id);
+          sym->increment_refcount(); // Ensures it won't be destroyed together with the heap dump
           _cp->symbol_at_put(pool_i, sym);
           break;
         }

--- a/src/hotspot/share/runtime/cracClassDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.hpp
@@ -1,0 +1,90 @@
+#ifndef SHARE_RUNTIME_CRACCLASSDUMPPARSER_HPP
+#define SHARE_RUNTIME_CRACCLASSDUMPPARSER_HPP
+
+#include "memory/allocation.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "runtime/handles.hpp"
+#include "utilities/basicTypeReader.hpp"
+#include "utilities/exceptions.hpp"
+#include "utilities/growableArray.hpp"
+#include "utilities/heapDumpParser.hpp"
+#include "utilities/pair.hpp"
+
+// Objects on which an instance class depends. They are recorded because they
+// are absent at the moment of class creation and need to be filled-in later
+// after they are restored.
+struct ClassHeapDeps {
+  HeapDump::ID class_initialization_error_id;
+};
+
+// Convenience BasicTypeReader wrapper.
+class ClassDumpReader {
+ private:
+  BasicTypeReader *const _reader;
+  u2 _id_size;
+
+ protected:
+  explicit ClassDumpReader(BasicTypeReader *reader, u2 id_size = 0) : _reader(reader), _id_size(id_size) {
+    assert(_id_size == 0 /* unset */ || is_supported_id_size(id_size), "unsupported ID size");
+  };
+
+  static constexpr bool is_supported_id_size(u2 size) {
+    return size == sizeof(u8) || size == sizeof(u4) || size == sizeof(u2) || size == sizeof(u1);
+  }
+
+  BasicTypeReader *reader() { return _reader; }
+  u2 id_size() const        { precond(_id_size > 0); return _id_size; }
+  void set_id_size(u2 value, TRAPS);
+
+  void read_raw(void *buf, size_t size, TRAPS);
+  template <class T> T read(TRAPS);
+  bool read_bool(TRAPS);
+  HeapDump::ID read_id(bool can_be_null, TRAPS);
+  void skip(size_t size, TRAPS);
+};
+
+class ClassLoaderProvider;
+struct InterclassRefs;
+
+// Parses a CRaC class dump created and restores classes based on it without
+// calling their class loaders.
+//
+// Note: to improve the restoration performance it is assumed that the dump
+// comes from a trusted source and thus only basic correctness checks are
+// performed (and the VM will die if those fail).
+class CracClassDumpParser: public ClassDumpReader {
+ public:
+  static void parse(const char *path, const ParsedHeapDump &heap_dump, ClassLoaderProvider *loader_provider,
+                    HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *created_iks,
+                    HeapDumpTable<ArrayKlass *,    AnyObj::C_HEAP> *created_aks,
+                    HeapDumpTable<ClassHeapDeps,   AnyObj::C_HEAP> *heap_deps, TRAPS);
+
+ private:
+  const ParsedHeapDump &_heap_dump;
+  ClassLoaderProvider *const _loader_provider;
+
+  HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *const _iks;
+  HeapDumpTable<ArrayKlass *,    AnyObj::C_HEAP> *const _aks;
+  HeapDumpTable<ClassHeapDeps,   AnyObj::C_HEAP> *const _heap_deps;
+
+  CracClassDumpParser(BasicTypeReader *reader, const ParsedHeapDump &heap_dump, ClassLoaderProvider *loader_provider,
+                      HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *iks, HeapDumpTable<ArrayKlass *, AnyObj::C_HEAP> *aks,
+                      HeapDumpTable<ClassHeapDeps, AnyObj::C_HEAP> *heap_deps, TRAPS);
+
+  struct ClassPreamble;
+
+  void parse_header(TRAPS);
+  void parse_obj_array_classes(Klass *bottom_class, TRAPS);
+  void parse_primitive_array_classes(TRAPS);
+
+  Handle get_class_loader(HeapDump::ID loader_id, TRAPS);
+
+  ClassPreamble parse_instance_class_preamble(TRAPS);
+  InstanceKlass *skip_instance_class_if_exists(const HeapDump::ClassDump &class_dump, const Handle &class_loader, TRAPS);
+  InstanceKlass *parse_instance_class(const HeapDump::ClassDump &class_dump, ClassLoaderData *loader_data, InterclassRefs *refs_out, TRAPS);
+  GrowableArray<Pair<HeapDump::ID, InterclassRefs>> parse_instance_and_obj_array_classes(TRAPS);
+
+  void parse_initiating_loaders(TRAPS);
+};
+
+#endif // SHARE_RUNTIME_CRACCLASSDUMPPARSER_HPP

--- a/src/hotspot/share/runtime/cracClassDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.hpp
@@ -4,6 +4,7 @@
 #include "memory/allocation.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/oopsHierarchy.hpp"
+#include "runtime/cracClassDumper.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/basicTypeReader.hpp"
 #include "utilities/exceptions.hpp"
@@ -58,6 +59,11 @@ class CracClassDumpParser: public ClassDumpReader {
                     HeapDumpTable<InstanceKlass *,   AnyObj::C_HEAP> *created_iks,
                     HeapDumpTable<ArrayKlass *,      AnyObj::C_HEAP> *created_aks,
                     HeapDumpTable<UnfilledClassInfo, AnyObj::C_HEAP> *unfilled_infos, TRAPS);
+
+  // Finds a normal or a non-generic signature polymorphic method.
+  static Method *find_method(InstanceKlass *holder,
+                             Symbol *name, Symbol *signature, CracClassDump::MethodKind kind,
+                             bool lookup_signature_polymorphic, TRAPS);
 
  private:
   const ParsedHeapDump &_heap_dump;

--- a/src/hotspot/share/runtime/cracClassDumper.cpp
+++ b/src/hotspot/share/runtime/cracClassDumper.cpp
@@ -96,6 +96,7 @@ class ClassDumpWriter : public KlassClosure, public CLDClosure {
     if (io_error_msg() == nullptr)      ClassLoaderDataGraph::cld_do(this);
     if (io_error_msg() == nullptr)      write_end_sentinel();
     log_debug(crac, class, dump)("Wrote initiating class loaders info");
+    // TODO write class loading constraints
   }
 
  private:

--- a/src/hotspot/share/runtime/cracClassDumper.cpp
+++ b/src/hotspot/share/runtime/cracClassDumper.cpp
@@ -229,6 +229,12 @@ class ClassDumpWriter : public KlassClosure, public CLDClosure {
       WRITE_CLASS_ID(*tak);
       DO_CHECKED(write_obj_array_class_ids(tak));
     }
+    {
+      log_trace(crac, class, dump)("Writing filler array class ID");
+      Klass *const tak = Universe::fillerArrayKlassObj();
+      WRITE_CLASS_ID(*tak);
+      DO_CHECKED(write_obj_array_class_ids(tak));
+    }
     log_debug(crac, class, dump)("Wrote primitive array IDs");
   }
 

--- a/src/hotspot/share/runtime/cracClassDumper.cpp
+++ b/src/hotspot/share/runtime/cracClassDumper.cpp
@@ -992,15 +992,15 @@ class ClassDumpWriter : public KlassClosure, public CLDClosure {
       DO_CHECKED(write_uint_array_data(cmethod.method_annotations()->data(), cmethod.method_annotations_length()));
     }
     if (cmethod.has_parameter_annotations()) { // Runtime(In)VisibleParameterAnnotations
-      assert(!cmethod.method_annotations()->is_empty(), "existing method annotations cannot be empty");
-      DO_CHECKED(write_uint_array_data(cmethod.parameter_annotations()->data(), cmethod.method_annotations_length()));
+      assert(!cmethod.parameter_annotations()->is_empty(), "existing parameter annotations cannot be empty");
+      DO_CHECKED(write_uint_array_data(cmethod.parameter_annotations()->data(), cmethod.parameter_annotations_length()));
     }
     if (cmethod.has_type_annotations()) { // Runtime(In)VisibleTypeAnnotations
-      assert(!cmethod.method_annotations()->is_empty(), "existing method annotations cannot be empty");
+      assert(!cmethod.type_annotations()->is_empty(), "existing type annotations cannot be empty");
       DO_CHECKED(write_uint_array_data(cmethod.type_annotations()->data(), cmethod.type_annotations_length()));
     }
     if (cmethod.has_default_annotations()) { // AnnotationDefault
-      assert(!cmethod.method_annotations()->is_empty(), "existing method annotations cannot be empty");
+      assert(!cmethod.default_annotations()->is_empty(), "existing default annotations cannot be empty");
       DO_CHECKED(write_uint_array_data(cmethod.default_annotations()->data(), cmethod.default_annotations_length()));
     }
     // Synthetic attribute is stored in access flags, others are not available

--- a/src/hotspot/share/runtime/cracClassDumper.cpp
+++ b/src/hotspot/share/runtime/cracClassDumper.cpp
@@ -1,0 +1,1220 @@
+#include "precompiled.hpp"
+#include "classfile/classLoaderDataGraph.hpp"
+#include "classfile/dictionary.hpp"
+#include "classfile/javaClasses.hpp"
+#include "classfile/resolutionErrors.hpp"
+#include "classfile/vmClasses.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "classfile_constants.h"
+#include "interpreter/bytecode.hpp"
+#include "interpreter/bytecodeStream.hpp"
+#include "interpreter/bytecodes.hpp"
+#include "logging/log.hpp"
+#include "memory/allocation.hpp"
+#include "memory/iterator.hpp"
+#include "memory/resourceArea.hpp"
+#include "memory/universe.hpp"
+#include "metaprogramming/enableIf.hpp"
+#include "oops/annotations.hpp"
+#include "oops/array.hpp"
+#include "oops/constMethod.hpp"
+#include "oops/constantPool.hpp"
+#include "oops/cpCache.hpp"
+#include "oops/cpCache.inline.hpp"
+#include "oops/fieldInfo.hpp"
+#include "oops/instanceKlass.hpp"
+#include "oops/instanceKlassFlags.hpp"
+#include "oops/klass.hpp"
+#include "oops/method.hpp"
+#include "oops/methodFlags.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "oops/recordComponent.hpp"
+#include "oops/resolvedFieldEntry.hpp"
+#include "oops/resolvedIndyEntry.hpp"
+#include "oops/symbol.hpp"
+#include "prims/jvmtiExport.hpp"
+#include "prims/jvmtiRedefineClasses.hpp"
+#include "runtime/arguments.hpp"
+#include "runtime/cracClassDumper.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/handles.hpp"
+#include "runtime/os.hpp"
+#include "runtime/safepoint.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/accessFlags.hpp"
+#include "utilities/basicTypeWriter.hpp"
+#include "utilities/bytes.hpp"
+#include "utilities/constantTag.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/growableArray.hpp"
+#include "utilities/heapDumpParser.hpp"
+#include "utilities/macros.hpp"
+#include "utilities/resizeableResourceHash.hpp"
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#ifdef INCLUDE_JVMCI
+#include "jvmci/jvmci_globals.hpp"
+#endif
+#ifdef ASSERT
+#include "jvm_constants.h"
+#endif // ASSERT
+
+// Write IDs the same way HPROF heap dumper does.
+static bool write_symbol_id(BasicTypeWriter *writer, const Symbol *s) {
+  return writer->write(reinterpret_cast<uintptr_t>(s));
+}
+static bool write_object_id(BasicTypeWriter *writer, const oop o) {
+  return writer->write(cast_from_oop<uintptr_t>(o));
+}
+static bool write_class_id(BasicTypeWriter *writer, const Klass &k) {
+  assert(cast_from_oop<uintptr_t>(k.java_mirror()) != HeapDump::NULL_ID, "footer assumption");
+  return write_object_id(writer, k.java_mirror());
+}
+
+class ClassDumpWriter : public KlassClosure, public CLDClosure {
+ friend ClassLoaderDataGraph; // Provide access to do_klass()
+ private:
+  BasicTypeWriter *_writer;
+  const char *_io_error_msg = nullptr;
+  ResizeableResourceHashtable<const InstanceKlass *, bool> _dumped_classes{107, 1228891};
+
+ public:
+  explicit ClassDumpWriter(BasicTypeWriter *writer) : _writer(writer) {}
+
+  const char *io_error_msg() const { return _io_error_msg; }
+
+  void write_dump() {
+    precond(io_error_msg() == nullptr); write_header();
+    if (io_error_msg() == nullptr)      write_primitive_array_class_ids();
+    // Instance and object array classes. Not using loaded_classes_do() because
+    // our filter should be quicker.
+    if (io_error_msg() == nullptr)      ClassLoaderDataGraph::classes_do(this);
+    if (io_error_msg() == nullptr)      write_end_sentinel();
+    log_debug(crac, class, dump)("Wrote instance and object array classes");
+    if (io_error_msg() == nullptr)      ClassLoaderDataGraph::cld_do(this);
+    if (io_error_msg() == nullptr)      write_end_sentinel();
+    log_debug(crac, class, dump)("Wrote initiating class loaders info");
+  }
+
+ private:
+  // ###########################################################################
+  // Helpers
+  // ###########################################################################
+
+#define WRITE(value)           do { if (!_writer->write(value))           { _io_error_msg = os::strerror(errno); return; } } while (false)
+#define WRITE_SYMBOL_ID(value) do { if (!write_symbol_id(_writer, value)) { _io_error_msg = os::strerror(errno); return; } } while (false)
+#define WRITE_OBJECT_ID(value) do { if (!write_object_id(_writer, value)) { _io_error_msg = os::strerror(errno); return; } } while (false)
+#define WRITE_CLASS_ID(value)  do { if (!write_class_id(_writer, value))  { _io_error_msg = os::strerror(errno); return; } } while (false)
+#define WRITE_RAW(buf, size)   do { if (!_writer->write_raw(buf, size))   { _io_error_msg = os::strerror(errno); return; } } while (false)
+#define DO_CHECKED(expr)       do { expr; if (_io_error_msg != nullptr) return;                                            } while (false)
+
+  void write_obj_array_class_ids(Klass *bottom_class) {
+    ResourceMark rm;
+    GrowableArray<const ObjArrayKlass *> oaks;
+    for (auto *ak = bottom_class->array_klass_or_null();
+         ak != nullptr;
+         ak = ak->array_klass_or_null()) {
+      oaks.append(ObjArrayKlass::cast(ak));
+    }
+
+    assert(oaks.length() + (bottom_class->is_array_klass() ? ArrayKlass::cast(bottom_class)->dimension() : 0) <= 255,
+           "arrays can have up to 255 dimensions");
+    WRITE(checked_cast<u1>(oaks.length()));
+    for (const ObjArrayKlass *oak : oaks) {
+      WRITE_CLASS_ID(*oak);
+    }
+  }
+
+  template <class UINT_T, ENABLE_IF(std::is_same<UINT_T, u1>::value || std::is_same<UINT_T, u2>::value ||
+                                    std::is_same<UINT_T, u4>::value || std::is_same<UINT_T, u8>::value)>
+  void write_uint_array_data(const UINT_T *data, size_t length) {
+    if (Endian::is_Java_byte_ordering_different() && sizeof(UINT_T) > 1) { // Have to convert
+      for (size_t i = 0; i < length; i++) {
+        WRITE(data[i]);
+      }
+    } else { // Can write as is
+      WRITE_RAW(data, length * sizeof(UINT_T));
+    }
+  }
+
+  template <class UINT_T>
+  void write_uint_array(const Array<UINT_T> *arr) {
+    STATIC_ASSERT(std::numeric_limits<decltype(arr->length())>::max() < CracClassDumper::NO_ARRAY_SENTINEL);
+    if (arr != nullptr) {
+      WRITE(checked_cast<u4>(arr->length()));
+      write_uint_array_data(arr->data(), arr->length());
+    } else {
+      WRITE(CracClassDumper::NO_ARRAY_SENTINEL);
+    }
+  }
+
+  // ###########################################################################
+  // Sections
+  // ###########################################################################
+
+  // Creates a bit mask with VM options/capabilities that influence data stored
+  // in classes.
+  static u1 compress_class_related_vm_options() {
+    // Warn about options/capabilities that may lead to unrecoverable data loss
+    // TODO make HotSpot retain this data if a portable checkpoint was requested
+    if (!JvmtiExport::can_get_source_debug_extension()) {
+      // ClassFileParser skips SourceDebugExtension class attribute in such case
+      log_warning(crac, class, dump, jvmti)("SourceDebugExtension class attribute will not be dumped: JVM TI's 'can_get_source_debug_extension' capability is unsupported");
+    }
+    if (JvmtiExport::has_redefined_a_class() && !JvmtiExport::can_maintain_original_method_order() && !Arguments::is_dumping_archive()) {
+      // ClassFileParser doesn't save the original method order in such case
+      log_warning(crac, class, dump, jvmti, cds)("Original method order of classes redefined via JVM TI will not be dumped: neither JVM TI's 'can_maintain_original_method_order' capability is supported, nor a CDS archive is to be created");
+    }
+    if (!vmClasses::Parameter_klass_loaded()) {
+      // ClassFileParser doesn't save MethodParameters method attribute in such case
+      // TODO Why can ClassFileParser do this safely? What if j.l.reflect.Parameter gets loaded after a class is loaded?
+      ResourceMark rm;
+      log_warning(crac, class, dump, jvmti, cds)("MethodParameters method attribute will not be dumped: parameter reflection hasn't been used (%s is not loaded)", vmSymbols::java_lang_reflect_Parameter()->as_klass_external_name());
+    }
+
+    // Check development options -- these should have the expected values in
+    // product builds, so no warnings
+    guarantee(LoadLineNumberTables, "line number tables cannot be dumped");
+    guarantee(LoadLocalVariableTables, "local variable tables cannot be dumped");
+    guarantee(LoadLocalVariableTypeTables, "local variable type tables cannot be dumped");
+    // BinarySwitchThreshold is also used (in bytecode rewriting) but there is no meaningful value to assert the equality
+
+    // Return options/capabilities that may lead to recoverable data loss
+    // - Not including InstanceKlass::is_finalization_enabled() even though
+    //   it influences JVM_ACC_HAS_FINALIZER flag (internal in Klass) since it's
+    //   easily recomputed when parsing methods
+    using offsets = CracClassDumper::VMOptionShift;
+    return
+      // If false JVM_ACC_IS_VALUE_BASED_CLASS flags (internal in Klass'es access_flags) isn't set
+      static_cast<u1>(DiagnoseSyncOnValueBasedClasses != 0) << offsets::is_sync_on_value_based_classes_diagnosed_shift |
+      // If false runtime-invisible annotations are preserved are lost (otherwise they become indistinguishable from the visible ones)
+      static_cast<u1>(PreserveAllAnnotations)               << offsets::are_all_annotations_preserved_shift;
+  }
+
+  void write_header() {
+    constexpr char HEADER_STR[] = "CRAC CLASS DUMP 0.1";
+    WRITE_RAW(HEADER_STR, sizeof(HEADER_STR));
+    WRITE(checked_cast<u2>(oopSize));
+    WRITE(compress_class_related_vm_options()); // Also prints warnings if needed
+    log_debug(crac, class, dump)("Wrote class dump header");
+  }
+
+  void write_primitive_array_class_ids() {
+    precond(Universe::is_fully_initialized());
+    for (u1 t = JVM_T_BOOLEAN; t <= JVM_T_LONG; t++) {
+      log_trace(crac, class, dump)("Writing primitive array class ID for %s", type2name(static_cast<BasicType>(t)));
+      Klass *const tak = Universe::typeArrayKlassObj(static_cast<BasicType>(t));
+      WRITE_CLASS_ID(*tak);
+      DO_CHECKED(write_obj_array_class_ids(tak));
+    }
+    log_debug(crac, class, dump)("Wrote primitive array IDs");
+  }
+
+  void do_klass(Klass *k) override {
+    if (_io_error_msg != nullptr || !k->is_instance_klass()) return;
+
+    InstanceKlass *const ik = InstanceKlass::cast(k);
+    if (ik->is_loaded() && !ik->is_scratch_class()) {
+      dump_class_hierarchy(ik);
+    }
+  }
+
+  void write_end_sentinel() {
+    // 1. No class would have this ID, so it marks the end of the series of
+    //    class info dumps.
+    // 2. The bootstrap loader is the loader with null ID and we don't write it
+    //    as an initiating loader, so it marks the end of the series of
+    //    initiating loader info dumps.
+    WRITE(HeapDump::NULL_ID);
+  }
+
+  // ###########################################################################
+  // General instance class data
+  // ###########################################################################
+
+  static CracClassDumper::ClassLoadingKind loading_kind(const InstanceKlass &ik) {
+    using Kind = CracClassDumper::ClassLoadingKind;
+    if (!ik.is_hidden()) {
+      return Kind::NORMAL;
+    }
+    if (ik.is_non_strong_hidden()) {
+      return Kind::NON_STRONG_HIDDEN;
+    }
+    return Kind::STRONG_HIDDEN;
+  }
+
+  // Writes access flags defined in the class file format as well as internal
+  // Klass and InstanceKlass flags.
+  void write_class_flags(const InstanceKlass &ik) {
+    // Access flags defined in class file + internal flags defined in Klass
+    u4 access_flags = ik.access_flags().as_int();
+    // Fix an VM-options-dependent flag if we have CDS
+    // TODO make has_value_based_class_annotation also available with CRaC
+    if (ik.has_value_based_class_annotation() /* only set when CDS included */) {
+      access_flags |= JVM_ACC_IS_VALUE_BASED_CLASS;
+    }
+    WRITE(access_flags);
+
+    InstanceKlassFlags internal_flags = ik.internal_flags().drop_nonportable_flags(); // Copy to be mutated
+    // Internal semi-immutable flags defined in InstanceKlass:
+    // - Flags dependent on CDS archive dumping have been cleared by
+    //   drop_nonportable_flags() -- they need to be set when restoring based on
+    //   the VM options
+    postcond(!internal_flags.shared_loading_failed() && internal_flags.is_shared_unregistered_class());
+    // Note: should_verify_class flag has a complex dependency on multiple CLI
+    // arguments and thus is not exactly portable. But it seems logical to
+    // just save/restore its value as is (i.e. the dumping VM decides whether to
+    // verify or not), even though it contradicts the general VM options policy
+    // to change the behaviour according to the options of the restoring VM.
+    WRITE(internal_flags.flags());
+    // Internal mutable flags (aka statuses) defined in InstanceKlass -- remove
+    // all but has_resolved_methods and has_been_redefined:
+    // - is_being_redefined -- we are on safepoint, so this status being true
+    //   means that the class either haven't started being redefined yet or has
+    //   been redefined already, and since we won't restore the state of the
+    //   redefinition code (which is native), we drop the flag
+    internal_flags.set_is_being_redefined(false);
+    // - is_scratch_class -- we skip these for the same reason as written above
+    assert(!internal_flags.is_scratch_class(), "should have skipped it");
+    // - is_marked_dependent -- is JIT-compilation-related and we don't dump
+    //   such data (at least for now)
+    internal_flags.set_is_marked_dependent(false);
+    // - is_being_restored -- should not see these on a safepoint
+    assert(!internal_flags.is_being_restored(), "should not appear on safepoint");
+    WRITE(internal_flags.status());
+  }
+
+  void write_nest_host_attr(const InstanceKlass &ik) {
+    // Nest host index from the class file (0 iff none).
+    // Resolution error (if any) is dumped with the constant pool.
+    WRITE(ik.nest_host_index());
+
+    // Have to additionally write the resolved class for hidden classes because
+    // it can be a dynamic nest host which may be not the class pointed to by
+    // the nest host index
+    const InstanceKlass *resolved_nest_host = ik.nest_host_noresolve();
+    if (resolved_nest_host != nullptr && ik.is_hidden()) {
+      WRITE_CLASS_ID(*resolved_nest_host);
+    } else {
+      WRITE_OBJECT_ID(nullptr);
+    }
+  }
+
+  void write_source_debug_extension_attr(const char *source_debug_extension_str) {
+    WRITE(static_cast<u1>(source_debug_extension_str != nullptr));
+    if (source_debug_extension_str != nullptr) {
+      const u4 len = checked_cast<u4>(strlen(source_debug_extension_str));
+      WRITE(len);
+      WRITE_RAW(source_debug_extension_str, len);
+    }
+  }
+
+  void write_record_attr(const Array<RecordComponent *> *record_components) {
+    WRITE(static_cast<u1>(record_components != nullptr));
+    if (record_components == nullptr) {
+      return;
+    }
+
+    const u2 record_components_num = checked_cast<u2>(record_components->length());
+    WRITE(record_components_num); // u2 components_count
+    for (int comp_i = 0; comp_i < record_components_num; comp_i++) {
+      const RecordComponent &component = *record_components->at(comp_i);
+      WRITE(component.name_index());
+      WRITE(component.descriptor_index());
+      WRITE(component.attributes_count());
+      WRITE(component.generic_signature_index());                 // Signature, 0 iff unspecified
+      DO_CHECKED(write_uint_array(component.annotations()));      // Runtime(In)VisibleAnnotations
+      DO_CHECKED(write_uint_array(component.type_annotations())); // Runtime(In)VisibleTypeAnnotations
+    }
+  }
+
+  void write_class_attrs(const InstanceKlass &ik) {
+    WRITE(ik.source_file_name_index());                        // SourceFile (0 iff none)
+    WRITE(ik.generic_signature_index());                       // Signature (0 iff none)
+    DO_CHECKED(write_nest_host_attr(ik));
+    DO_CHECKED(write_uint_array(ik.nest_members() != Universe::the_empty_short_array() ? ik.nest_members() : nullptr));   // NestMembers (sentinel iff none)
+    DO_CHECKED(write_uint_array(ik.inner_classes() != Universe::the_empty_short_array() ? ik.inner_classes() : nullptr)); // InnerClasses, possibly concatenated with EnclosingMethod (sentinel iff none)
+    DO_CHECKED(write_source_debug_extension_attr(ik.source_debug_extension()));
+    DO_CHECKED(write_uint_array(ik.constants()->operands()));  // BootstrapMethods (null if none)
+    DO_CHECKED(write_record_attr(ik.record_components()));
+    DO_CHECKED(write_uint_array(ik.permitted_subclasses() != Universe::the_empty_short_array() ? ik.permitted_subclasses() : nullptr)); // PermittedSubclasses
+    DO_CHECKED(write_uint_array(ik.class_annotations()));      // Runtime(In)VisibleAnnotations (null if none)
+    DO_CHECKED(write_uint_array(ik.class_type_annotations())); // Runtime(In)VisibleTypeAnnotations (null if none)
+    // Synthetic attribute is stored in access flags, others are not available
+  }
+
+  void write_resolution_error_symbols(const ResolutionErrorEntry &entry) {
+    WRITE_SYMBOL_ID(entry.error());       // not null unless a special nest host error case
+    WRITE_SYMBOL_ID(entry.message());     // null if no message
+    WRITE_SYMBOL_ID(entry.cause());       // null if no cause
+    if (entry.cause() != nullptr) {
+      WRITE_SYMBOL_ID(entry.cause_msg()); // null if no cause message
+    } else {
+      assert(entry.cause_msg() == nullptr, "must be null if there is no cause");
+    }
+  }
+
+  // For non-nest-host resolution errors.
+  void write_resolution_error(const ConstantPool &cp, int err_table_index) {
+    constantPoolHandle cph(Thread::current(), const_cast<ConstantPool *>(&cp));
+
+    // Not using SystemDictionary::find_resolution_error() to get around the mutex used there (we're on safepoint)
+    const ResolutionErrorEntry *entry = ResolutionErrorTable::find_entry(cph, err_table_index);
+    assert(entry != nullptr, "no resolution error recorded for %i", err_table_index);
+    assert(entry->error() != nullptr , "recorded resolution error cannot be null for a non-nest-host error");
+    assert(entry->nest_host_error() == nullptr, "not for nest host errors");
+
+    write_resolution_error_symbols(*entry);
+  }
+
+  // For nest host resolution errors.
+  void write_nest_host_resolution_error_if_exists(const ConstantPool &cp) {
+    const u2 nest_host_i = cp.pool_holder()->nest_host_index();
+    constantPoolHandle cph(Thread::current(), const_cast<ConstantPool *>(&cp));
+
+    const ResolutionErrorEntry *entry = ResolutionErrorTable::find_entry(cph, nest_host_i);
+    WRITE(static_cast<u1>(entry != nullptr));
+    if (entry == nullptr) {
+      return;
+    }
+
+    write_resolution_error_symbols(*entry);
+
+    assert(entry->nest_host_error() != nullptr, "nest host error always has this");
+    const auto nest_host_err_len = checked_cast<u4>(strlen(entry->nest_host_error()));
+    WRITE(nest_host_err_len);
+    WRITE_RAW(entry->nest_host_error(), nest_host_err_len);
+  }
+
+  // Writes constant pool contents, including resolved classes and resolution
+  // errors and excluding constant pool cache and indy resolution errors.
+  void write_constant_pool(const ConstantPool &cp) {
+    auto &cp_ = const_cast<ConstantPool &>(cp); // FIXME a ton of ConstantPool's methods that could've been const are not marked as such
+    WRITE(checked_cast<u2>(cp.length()));
+    WRITE(checked_cast<u2>(cp.resolved_klasses()->length())); // To avoid multiple passes during parsing
+    for (int pool_i = 1 /* index 0 is unused */; pool_i < cp.length(); pool_i++) {
+      const u1 tag = cp.tag_at(pool_i).value();
+      WRITE(tag);
+      switch (tag) {
+        // Fundamental structures
+        case JVM_CONSTANT_Utf8:
+          WRITE_SYMBOL_ID(cp.symbol_at(pool_i));
+          break;
+        case JVM_CONSTANT_NameAndType:
+          WRITE(cp_.name_ref_index_at(pool_i));
+          WRITE(cp_.signature_ref_index_at(pool_i));
+          break;
+
+        // Static constants
+        case JVM_CONSTANT_Integer: WRITE(cp_.int_at(pool_i));      break;
+        case JVM_CONSTANT_Float:   WRITE(cp_.float_at(pool_i));    break;
+        case JVM_CONSTANT_Long:    WRITE(cp_.long_at(pool_i++));   break; // Next index is unused, so skip it
+        case JVM_CONSTANT_Double:  WRITE(cp_.double_at(pool_i++)); break; // Next index is unused, so skip it
+        case JVM_CONSTANT_String:
+          // String entries are also kind of resolved, even though they are not
+          // considered symbolic references (JVMS §5.1):
+          // a) until a string is queried the first time, only a Symbol* is stored
+          WRITE_SYMBOL_ID(cp_.unresolved_string_at(pool_i)); // always not null
+          // b) when the string is queried, a j.l.String object is created for it,
+          //    and all the later queries should return this same object -- a
+          //    reference to this object is stored in the reolved references array
+          //    of the cache (it is null until resolved)
+          break;
+
+        // Symbolic references
+        case JVM_CONSTANT_Class:
+        case JVM_CONSTANT_UnresolvedClass:
+        case JVM_CONSTANT_UnresolvedClassInError:
+          // Static data
+          WRITE(checked_cast<u2>(cp.klass_name_index_at(pool_i)));
+          // Resolution state info
+          if (tag == JVM_CONSTANT_Class) {
+            // Not ConstantPool::resolved_klass_at() to get around a redundant aquire (no concurrency on safepoint)
+            Klass *resolved_class = cp.resolved_klasses()->at(cp.klass_slot_at(pool_i).resolved_klass_index());
+            assert(resolved_class != nullptr, "Unresolved class in JVM_CONSTANT_Class slot");
+            WRITE_CLASS_ID(*resolved_class);
+            // NestHost resolution error may happen even if the referenced class itself was successfully resolved
+            if (pool_i == cp.pool_holder()->nest_host_index()) {
+              DO_CHECKED(write_nest_host_resolution_error_if_exists(cp));
+            }
+          } else if (tag == JVM_CONSTANT_UnresolvedClassInError) {
+            DO_CHECKED(write_resolution_error(cp, pool_i));
+          }
+          break;
+        case JVM_CONSTANT_Fieldref:
+        case JVM_CONSTANT_Methodref:
+        case JVM_CONSTANT_InterfaceMethodref:
+          // Static data
+          WRITE(cp_.uncached_klass_ref_index_at(pool_i));
+          WRITE(cp_.uncached_name_and_type_ref_index_at(pool_i));
+          // Field/method resolution ussually consists of:
+          // 1. Holder class resolution --- we record results of these during
+          //    JVM_CONSTANT_(Unresolved)Class(InError) dump, so Klass* is
+          //    obtainable from the class reference dumped above.
+          // 2. Field/method lookup + access control --- this should produce the
+          //    same result given the same (Klass*, mathod/field name, signature)
+          //    combination, and the last two parts are obtainable via the
+          //    NameAndType reference dumped above.
+          // In such cases we don't need to record any resolution data.
+          //
+          // But there is also a special case of signature-polymorphic
+          // invokevirtual calls the resolution process of which is more like it
+          // of InvokeDynamic resulting into an adapter method (stored in the
+          // cache itself) and "appendix" object (stored in resolved references
+          // array of the cache) being resolved.
+          break;
+        case JVM_CONSTANT_MethodType:
+        case JVM_CONSTANT_MethodTypeInError:
+          // Static data
+          WRITE(checked_cast<u2>(cp_.method_type_index_at(pool_i)));
+          // Resolution state info
+          if (tag == JVM_CONSTANT_MethodTypeInError) {
+            DO_CHECKED(write_resolution_error(cp, pool_i));
+          } else {
+            // MethodType object is stored in the resolved references array of the
+            // cache (null if unresolved)
+          }
+          break;
+        case JVM_CONSTANT_MethodHandle:
+        case JVM_CONSTANT_MethodHandleInError:
+          // Static data
+          WRITE(checked_cast<u1>(cp_.method_handle_ref_kind_at(pool_i)));
+          WRITE(checked_cast<u2>(cp_.method_handle_index_at(pool_i)));
+          // Resolution state info
+          if (tag == JVM_CONSTANT_MethodHandleInError) {
+            DO_CHECKED(write_resolution_error(cp, pool_i));
+          } else {
+            // MethodHandle object is stored in the resolved references array of
+            // the cache (null if unresolved)
+          }
+          break;
+        case JVM_CONSTANT_Dynamic:
+        case JVM_CONSTANT_DynamicInError:
+        case JVM_CONSTANT_InvokeDynamic:
+          // Static data
+          WRITE(cp_.bootstrap_methods_attribute_index(pool_i));
+          WRITE(cp_.bootstrap_name_and_type_ref_index_at(pool_i));
+          // Resolution state info
+          if (tag == JVM_CONSTANT_DynamicInError) {
+            DO_CHECKED(write_resolution_error(cp, pool_i));
+          } else {
+            // Dynamic: computed constants are stored in the resolved references
+            // array of the cache (null if unresolved, primitives are boxed).
+            //
+            // InvokeDynamic:
+            // 1. One InvokeDynamic constant pool entry can correspond to multiple
+            //    cache entries: one for each indy instruction in the class --
+            //    their info is stored in a special constant pool cache array,
+            //    appendices are stored in the resolved references array of the
+            //    cache.
+            // 2. Error messages, if any, are written as part of cache dump.
+          }
+          break;
+
+        default: // Module tags and internal pool-construction-time tags
+          ShouldNotReachHere();
+      }
+    }
+
+    // - Not writing flags since they are either trivial to obtain from the data
+    //   written above (has_dynamic_constant), are handeled while working with
+    //   holder's methods (has_preresolution, on_stack) or are CDS-related and
+    //   thus JVM-instance-dependent (on_stack, is_shared)
+    // - Generic signature index, source file name index and operands are written
+    //   as the corresponding class attributes
+  }
+
+  // Writes data from the constant pool cache.check won't crash with NPE when there is no
+  //  fields/indys.
+  void write_constant_pool_cache(const ConstantPoolCache &cp_cache) {
+    // TODO simplify lengths calculations below by making
+    // resolved_*_entries_length() return 0 when resolved_*_entries == nullptr
+    // Write lengths of the main arrays first to be able to outright allocate
+    // the cache when parsing:
+    // 1. Field entries:  u2 -- same amount as of Fieldrefs.
+    const bool has_fields = const_cast<ConstantPoolCache &>(cp_cache).resolved_field_entries() != nullptr;
+    assert(!has_fields || cp_cache.resolved_field_entries_length() > 0, "allocated resolved fields array is always non-empty");
+    const u2 field_entries_len = has_fields ? cp_cache.resolved_field_entries_length() : 0;
+    WRITE(field_entries_len);
+    // 2. Method entries: jint -- can be twice as much as methods (one per
+    //    Methodref, one or two per InterfaceMethodref) for which we need u2.
+    WRITE(checked_cast<jint>(cp_cache.length()));
+    // 3. Indy entries: jint -- one per indy, and there may be a lot of those in
+    //    the class, but the array is int-indexed.
+    const bool has_indys = const_cast<ConstantPoolCache &>(cp_cache).resolved_indy_entries() != nullptr;
+    assert(!has_indys || cp_cache.resolved_indy_entries_length() > 0, "allocated resolved indys array is always non-empty");
+    const jint indy_entries_len = has_indys ? cp_cache.resolved_indy_entries_length() : 0;
+    WRITE(indy_entries_len);
+    // 4. Resolved references: doesn't influence cache allocation, so don't need
+    //    its length here.
+
+    for (int field_i = 0; field_i < field_entries_len; field_i++) {
+      const ResolvedFieldEntry &field_info = *cp_cache.resolved_field_entry_at(field_i);
+
+      assert(field_info.constant_pool_index() > 0, "uninitialized field entry");
+      WRITE(field_info.constant_pool_index());
+
+      const u1 get_code = field_info.get_code();
+      const u1 put_code = field_info.put_code();
+      assert(!(get_code == 0 && put_code != 0), "if resolved for put, must be resolved for get as well");
+      WRITE(get_code);
+      WRITE(put_code);
+
+      if (get_code != 0) { // If resolved, write the data
+        assert(field_info.field_holder() != nullptr, "must be resolved");
+        // field_offset is omitted since it depends on VM options and the platform
+        WRITE_CLASS_ID(*field_info.field_holder());
+        WRITE(field_info.field_index());
+        WRITE(field_info.tos_state());
+        WRITE(field_info.flags());
+      }
+    }
+
+    // Resolved methods are still stored as generic cache entries, but these
+    // aren't used for anything else anymore (fields and indys got moved to
+    // separate arrays). The upcoming cache changes will simplify this code.
+    for (int cache_i = 0; cache_i < cp_cache.length(); cache_i++) {
+      const ConstantPoolCacheEntry &info = *cp_cache.entry_at(cache_i);
+
+      assert(info.constant_pool_index() > 0, "uninitialized cache entry");
+      WRITE(checked_cast<u2>(info.constant_pool_index()));
+
+      const Bytecodes::Code bytecode1 = info.bytecode_1();
+      const Bytecodes::Code bytecode2 = info.bytecode_2();
+      WRITE(checked_cast<u1>(bytecode1));
+      WRITE(checked_cast<u1>(bytecode2));
+
+      // This will be simplified when ResolvedMethodEntry replaces ConstantPoolCacheEntry
+      if (bytecode1 > 0 || bytecode2 > 0) { // If resolved, write the data
+        assert(info.is_method_entry(), "not used for field entries anymore");
+        assert(bytecode1 != Bytecodes::_invokedynamic, "not used for indys anymore");
+        // Flags go first since they, together with the bytecodes, define the contents of f1 and f2
+        using shifts = CracClassDumper::ResolvedMethodEntryFlagShift;
+        WRITE(checked_cast<u1>(info.has_local_signature() << shifts::has_local_signature_shift |
+                               info.has_appendix()        << shifts::has_appendix_shift        |
+                               info.is_forced_virtual()   << shifts::is_forced_virtual_shift   |
+                               info.is_final()            << shifts::is_final_shift            |
+                               info.is_vfinal()           << shifts::is_vfinal_shift));
+        WRITE(checked_cast<u1>(info.flag_state())); // ToS state
+        WRITE(checked_cast<u1>(info.parameter_size()));
+        // f1
+        switch (bytecode1) {
+          case Bytecodes::_invokestatic:
+          case Bytecodes::_invokespecial:
+          case Bytecodes::_invokehandle: {
+            const Method *method = info.f1_as_method(); // Resolved method for non-virtual calls or adapter method for invokehandle
+            assert(method != nullptr, "must be resolved");
+            assert(!method->is_old(), "cache never contains old methods"); // Lets us omit holder's redefinition version
+            WRITE_CLASS_ID(*method->method_holder());
+            WRITE(method->method_idnum());
+            break;
+          }
+          case Bytecodes::_invokeinterface:
+            if (!info.is_forced_virtual()) {
+              const Klass *klass = info.f1_as_klass(); // Resolved interface class
+              assert(klass != nullptr, "must be resolved");
+              WRITE_CLASS_ID(*klass);
+              break;
+            }
+            // Fallthrough
+          case 0: // bytecode1 is not set
+            assert(info.f1_ord() == 0, "f1 must be unused");
+            break;
+          default:
+            ShouldNotReachHere();
+        }
+        // f2
+        if (info.is_vfinal() || (bytecode1 == Bytecodes::_invokeinterface && !info.is_forced_virtual())) {
+          assert(bytecode1 == Bytecodes::_invokeinterface || bytecode2 == Bytecodes::_invokevirtual, "must be");
+          assert(bytecode1 != Bytecodes::_invokestatic && bytecode1 != Bytecodes::_invokehandle, "these cannot share an entry with invokevirtual");
+          const Method *method = info.is_vfinal() ? info.f2_as_vfinal_method() : info.f2_as_interface_method(); // Resolved final or interface method
+          assert(method != nullptr, "must be resolved");
+          assert(!method->is_old(), "cache never contains old methods"); // Lets us omit holder's redefinition version
+          WRITE_CLASS_ID(*method->method_holder());
+          WRITE(method->method_idnum());
+        } else if (bytecode1 == Bytecodes::_invokeinterface || bytecode2 == Bytecodes::_invokevirtual ||
+                  (bytecode1 == Bytecodes::_invokehandle && info.has_appendix())) {
+          assert(bytecode1 != Bytecodes::_invokestatic, "invokestatic cannot share an entry with invokevirtual");
+          WRITE(checked_cast<jint>(info.f2_as_index())); // vtable/itable index for virtual/interface calls or appendix index (if any) for invokehandle
+        } else {
+          // f2 is unused
+        }
+      }
+    }
+
+    for (int indy_i = 0; indy_i < indy_entries_len; indy_i++) {
+      const ResolvedIndyEntry &indy_info = *cp_cache.resolved_indy_entry_at(indy_i);
+
+      assert(indy_info.constant_pool_index() > 0, "uninitialized indy entry");
+      WRITE(indy_info.constant_pool_index());
+      WRITE(indy_info.resolved_references_index()); // Why is this u2? Should be int to index the whole resolved references for all indys which are int-indexed themselves.
+      WRITE(checked_cast<u1>(indy_info.flags() | indy_info.is_resolved() << ResolvedIndyEntry::num_flags));
+      assert((indy_info.is_resolved() && !indy_info.resolution_failed()) ||
+             (!indy_info.is_resolved() && !indy_info.has_appendix()), "illegal state");
+
+      if (indy_info.is_resolved()) {
+        assert(!indy_info.resolution_failed(), "cannot be failed if succeeded");
+        const Method *adapter = indy_info.method();
+        assert(adapter != nullptr, "must be resolved");
+        assert(!adapter->is_old(), "cache never contains old methods"); // Lets us omit holder's redefinition version
+        // Uniquely identify the adapter method
+        WRITE_CLASS_ID(*adapter->method_holder());
+        WRITE(adapter->method_idnum());
+        // The rest of the data
+        WRITE(indy_info.num_parameters());
+        WRITE(indy_info.return_type());
+      } else if (indy_info.resolution_failed()) {
+        const int indy_res_err_i = ResolutionErrorTable::encode_cpcache_index(ConstantPool::encode_invokedynamic_index(indy_i));
+        DO_CHECKED(write_resolution_error(*cp_cache.constant_pool(), indy_res_err_i));
+      }
+    }
+
+    // Resolved references:
+    // - String objects created when a String constant pool entry is queried the
+    //   first time and interned
+    // - MethodHandle objects for resolved MethodHandle constant pool entries
+    // - MethodType objects for resolved MethodType constant pool entries
+    // - Appendix objects created for each invokedynamic/invokehandle bytecode,
+    //   as well as for Dynamic constant pool entries
+    //
+    // The array itself is dumped as part of HPROF, so only write the mapping
+    // from indices of the first part of resolved references (i.e. excluding
+    // appendices) to constant pool indices:
+    DO_CHECKED(write_uint_array(cp_cache.reference_map())); // u2 is enough for length (not larger than the constant pool), but using u4 for the null array sentinel
+  }
+
+  void write_interfaces(const Array<InstanceKlass *> &interfaces) {
+    WRITE(checked_cast<u2>(interfaces.length()));
+    for (int index = 0; index < interfaces.length(); index++) {
+      WRITE_CLASS_ID(*interfaces.at(index));
+    }
+  }
+
+  // ###########################################################################
+  // Fields
+  // ###########################################################################
+
+  void write_fields(const InstanceKlass &ik) {
+    // Cannot write the field info stream as is, even though it is in a portable
+    // UNSIGNED5 encoding, because it contains field offsets which aren't
+    // portable (depend on the platform and the specified VM options) and
+    // UNSIGNED5 doesn't allow content updates, so we cannot change the offsets
+    // without re-encoding the whole stream
+    // TODO measure if re-encoding will actually be slower
+    ResourceMark rm;
+    int java_fields_count;
+    int injected_fields_count;
+    const GrowableArray<FieldInfo> &infos = *FieldInfoStream::create_FieldInfoArray(ik.fieldinfo_stream(), &java_fields_count, &injected_fields_count);
+
+    // Field statuses (mutable VM-internal field data)
+    const Array<FieldStatus> &statuses = *ik.fields_status();
+
+    const Array<AnnotationArray *> *annotations = ik.fields_annotations();
+    const Array<AnnotationArray *> *type_annotations = ik.fields_type_annotations();
+
+    assert(java_fields_count + injected_fields_count == ik.total_fields_count() &&
+           infos.length() == ik.total_fields_count() &&
+           statuses.length() == ik.total_fields_count() &&
+           (annotations == nullptr || annotations->length() == java_fields_count) &&
+           (type_annotations == nullptr || type_annotations->length() == java_fields_count), "must be");
+    WRITE(checked_cast<u2>(java_fields_count));
+    WRITE(checked_cast<u2>(injected_fields_count));
+    for (int i = 0; i < infos.length(); i++) {
+      const FieldInfo &field_info = infos.at(i);
+      WRITE(field_info.name_index());
+      WRITE(field_info.signature_index());
+      assert((field_info.access_flags().as_int() & JVM_RECOGNIZED_FIELD_MODIFIERS) == field_info.access_flags().as_int(), "illegal field flags");
+      WRITE(field_info.access_flags().as_short()); // Includes Synthetic attribute
+      WRITE(checked_cast<u1>(field_info.field_flags().as_uint()));
+      WRITE(field_info.initializer_index());       // ConstantValue attribute
+      WRITE(field_info.generic_signature_index()); // Signature attribute
+      WRITE(field_info.contention_group());
+
+      WRITE(statuses.at(i).as_uint()); // Includes JVM TI's access/modification watch flags
+
+      assert(field_info.field_flags().is_injected() == (i >= java_fields_count), "injected fields go last");
+      if (i < java_fields_count) {
+        // Runtime(In)Visible(Type)Annotations attributes: only non-injected fields have them
+        DO_CHECKED(write_uint_array(annotations != nullptr      ? annotations->at(i)      : nullptr));
+        DO_CHECKED(write_uint_array(type_annotations != nullptr ? type_annotations->at(i) : nullptr));
+      }
+    }
+
+    // Static fields' values aren't written since they are part of the heap dump
+  }
+
+  // ###########################################################################
+  // Methods
+  // ###########################################################################
+
+  // Removes non-portable elements from method statuses (aka mutable internal
+  // flags).
+  static int filter_method_statuses(MethodFlags statuses /* copy to mutate */, bool has_annotations) {
+    // Clear the JIT-related bits
+    statuses.set_queued_for_compilation(false);
+    statuses.set_is_not_c1_compilable(false);
+    statuses.set_is_not_c2_compilable(false);
+    statuses.set_is_not_c2_osr_compilable(false);
+
+    if (JVMCI_ONLY(UseJVMCICompiler) NOT_JVMCI(false) && statuses.dont_inline()) {
+      // dont_inline status may be set not only via the corresponding
+      // annotation, but also by JVMCI -- in the latter case it becomes
+      // compiler-dependent and should not be dumped (at least until we also
+      // support JIT dumping)
+      if (has_annotations) {
+        // TODO need to parse RuntimeVisibleAnnotations to see if DontInline is
+        //  there and also check if the holder class can access VM annotations.
+        //  If PreserveAllAnnotations is set need to do something not to look
+        //  into RuntimeInvisibleAnnotations.
+        ResourceMark rm;
+        log_warning(crac, class, dump, jvmci)("Method marked 'don't inline' which is ambiguos when JVM CI JIT is used");
+      } else {
+        // No RuntimeVisibleAnnotations, so it must have been set by JVMCI
+        statuses.set_dont_inline(false);
+      }
+    }
+
+    return statuses.as_int();
+  }
+
+  static jint get_linenumber_table_size(const ConstMethod &cmethod) {
+    precond(cmethod.has_linenumber_table());
+    CompressedLineNumberReadStream stream(cmethod.compressed_linenumber_table());
+    while (stream.read_pair()) {}
+    const jint size = stream.position();
+    assert(size > 0, "existing line number table cannot be empty");
+    return size;
+  }
+
+  // Writes method's bytecodes. Internal bytecodes the usage of which is
+  // (mostly) platform-independent are preserved (Zero interpreter will still
+  // need some rewriting -- see the related comments below).
+  void write_bytecodes(const Method &method) {
+    if (!method.method_holder()->is_rewritten()) {
+      // Can just write the whole code buffer as is
+      assert(method.number_of_breakpoints() == 0, "class must be linked (and thus rewritten) for breakpoints to exist");
+      WRITE_RAW(method.code_base(), method.code_size());
+      return;
+    }
+    // Else, have to partially revert the rewriting to make the code portable:
+    // - Bytecode rewriting done for interpreter optimization (both by the
+    //   interpreters themselves and the rewriter) depends on the interpreter
+    //   (e.g. Zero currently doesn't support some fast* internal bytecodes),
+    //   so have to revert these
+    // - Constant pool indices of get/put, ldc and invoke instructions are
+    //   rewritten into native byte order by the rewriter, so need to rewrite
+    //   them back if native endianness differs from Java's
+    // TODO decide what to do with breakpoints (for now they are cleared)
+
+    // BytecodeStream reverts internal bytecodes and breakpoints for us
+    BytecodeStream stream(methodHandle(Thread::current(), const_cast<Method *>(&method)));
+    for (Bytecodes::Code code = stream.next(); code >= 0; code = stream.next()) {
+      const Bytecodes::Code raw_code = stream.raw_code(); // Possibly internal code but not a breakpoint
+      precond(raw_code != Bytecodes::_breakpoint);
+
+      if (Bytecodes::is_field_code(code) || Bytecodes::is_invoke(code)) {
+        // If this is actualy an invokehandle write it since it is portable
+        WRITE(checked_cast<u1>(raw_code != Bytecodes::_invokehandle ? code : Bytecodes::_invokehandle));
+        // Convert index byte order: u4 for invokedynamic, u2 for others
+        if (code == Bytecodes::_invokedynamic) {
+          WRITE(Bytes::get_native_u4(stream.bcp() + 1));
+        } else {
+          WRITE(Bytes::get_native_u2(stream.bcp() + 1));
+          // invokeinterface has two additional bytes untoched by the rewriter
+          if (code == Bytecodes::_invokeinterface) {
+            WRITE_RAW(stream.bcp() + 3, 2);
+          }
+        }
+        continue;
+      }
+      if (raw_code == Bytecodes::_fast_aldc || raw_code == Bytecodes::_fast_aldc_w) {
+        // These rewritten versions of ldc and ldc_w are portable, so write them directly
+        WRITE(checked_cast<u1>(raw_code));
+        if (raw_code == Bytecodes::_fast_aldc) {
+          WRITE(checked_cast<u1>(*(stream.bcp() + 1)));
+        } else {
+          // Also, the index needs to be converted from the native byte order
+          WRITE(Bytes::get_native_u2(stream.bcp() + 1));
+        }
+        continue;
+      }
+      postcond(!Bytecodes::native_byte_order(code));
+
+      if (code == Bytecodes::_lookupswitch) {
+        // Template interpreters expect this to always be rewritten. Zero, on
+        // the other hand, currently doesn't support the fast versions. So we do
+        // the rewriter's job to keep this uniform across all interpreters. The
+        // template interpreters' way is chosen to restore faster for them.
+#ifdef ZERO
+        assert(raw_code == code, "Zero doesn't support the rewriting");
+        Bytecode_lookupswitch switch_inspector(const_cast<Method *>(&method), stream.bcp());
+        // The threshold is fixed in product builds, so this should be portable
+        const Bytecodes::Code rewritten = switch_inspector.number_of_pairs() < BinarySwitchThreshold ? Bytecodes::_fast_linearswitch
+                                                                                                     : Bytecodes::_fast_binaryswitch;
+#else // ZERO
+        assert(raw_code != code, "must be already rewritten");
+        const Bytecodes::Code rewritten = raw_code;
+#endif // ZERO
+        WRITE(checked_cast<u1>(rewritten));
+      } else if (raw_code == Bytecodes::_return_register_finalizer) {
+        // This special case of return is portable, so write it as is
+        WRITE(checked_cast<u1>(raw_code));
+      } else {
+        // Otherwise, write the code as converted and its parameters as raw
+        WRITE(checked_cast<u1>(stream.is_wide() ? Bytecodes::_wide : code));
+      }
+      WRITE_RAW(stream.bcp() + 1, stream.instruction_size() - 1); // Parameters
+    }
+
+    DEBUG_ONLY(ResourceMark rm;)
+    assert(stream.is_last_bytecode(), "error reading bytecodes of %s at index %i", method.external_name(), stream.bci());
+  }
+
+  void write_code_attr(const Method &method, u4 linenumber_table_size /* costly to recalculate */) {
+    const ConstMethod &cmethod = *method.constMethod();
+    precond(cmethod.code_size() > 0); // Code size is dumped with the rest of the embedded method data sizes
+
+    WRITE(cmethod.max_stack());
+    WRITE(cmethod.max_locals());
+
+    DO_CHECKED(write_bytecodes(method)); // Bytecodes with some of the internal ones preserved
+
+    if (cmethod.has_exception_table()) {
+      // Length is dumped with the rest of the embedded method data sizes
+      precond(method.exception_table_length() > 0);
+      STATIC_ASSERT(sizeof(ExceptionTableElement) == 4 * sizeof(u2)); // Check no padding
+      const size_t len = method.exception_table_length() * sizeof(ExceptionTableElement) / sizeof(u2);
+      write_uint_array_data(reinterpret_cast<u2 *>(method.exception_table_start()), len);
+    }
+
+    if (cmethod.has_linenumber_table()) {
+      // Table size is dumped with the rest of the embedded method data sizes
+      precond(linenumber_table_size > 0);
+      // Linenumber table is stored in a portable compressed format (a series of
+      // single-byte elements and UNSIGNED5-encoded ints from 0 to 65535), so can
+      // be dumped as is
+      WRITE_RAW(cmethod.compressed_linenumber_table(), linenumber_table_size);
+    }
+    if (cmethod.has_localvariable_table()) { // LocalVariableTable and LocalVariableTypeTable
+      precond(cmethod.localvariable_table_length() > 0);
+      // Length is dumped with the rest of the embedded method data sizes
+      STATIC_ASSERT(sizeof(LocalVariableTableElement) == 6 * sizeof(u2)); // Check no padding
+      const size_t len = cmethod.localvariable_table_length() * sizeof(LocalVariableTableElement) / sizeof(u2);
+      write_uint_array_data(reinterpret_cast<u2 *>(cmethod.localvariable_table_start()), len);
+    }
+    { // StackMapTable
+      assert(cmethod.stackmap_data() == nullptr || !cmethod.stackmap_data()->is_empty(), "must be non-empty if exists");
+      DO_CHECKED(write_uint_array(cmethod.stackmap_data())); // Null if not specified
+    }
+    // Other code attributes are not available
+  }
+
+  void write_method(const Method &method) {
+    const ConstMethod &cmethod = *method.constMethod();
+
+    // Internal method ID
+    WRITE(cmethod.method_idnum());
+    WRITE(cmethod.orig_method_idnum());
+
+    // Access flags defined in class file, fits in u2 according to JVMS
+    assert(method.access_flags().as_int() == (method.access_flags().get_flags() & JVM_RECOGNIZED_METHOD_MODIFIERS), "only method-related flags should be present");
+    WRITE(checked_cast<u2>(method.access_flags().get_flags()));
+    // Immutable internal flags
+    WRITE(checked_cast<jint>(cmethod.flags()));
+    // Mutable internal flags (statuses)
+    WRITE(checked_cast<jint>(filter_method_statuses(method.statuses(), cmethod.has_method_annotations())));
+
+    WRITE(cmethod.name_index());
+    WRITE(cmethod.signature_index());
+
+    // Write lengths/sizes of all embedded data first to allow the method to be
+    // allocated (allocating memory for the data) before reading the data
+    WRITE(cmethod.code_size()); // u2 is enough (code_length is limited to 65535 even though occupies u4)
+    assert(cmethod.code_size() > 0 || // code_size == 0 iff no Code was specified
+          (!cmethod.has_exception_table() && !cmethod.has_linenumber_table() && !cmethod.has_localvariable_table()),
+          "being parts of Code attribute they cannot exist without it");
+    const jint linenumber_table_size = cmethod.has_linenumber_table() ? get_linenumber_table_size(cmethod) : 0;
+    if (cmethod.has_exception_table())       WRITE(cmethod.exception_table_length());
+    if (cmethod.has_linenumber_table())      WRITE(linenumber_table_size);
+    if (cmethod.has_localvariable_table())   WRITE(cmethod.localvariable_table_length());
+    if (cmethod.has_checked_exceptions())    WRITE(cmethod.checked_exceptions_length());
+    if (cmethod.has_method_parameters())     WRITE(checked_cast<u1>(cmethod.method_parameters_length())); // u1 is enough as specified in the class file format
+    if (cmethod.has_generic_signature())     WRITE(cmethod.generic_signature_index()); // Signature attribute, participates in the method allocation size calculation
+    if (cmethod.has_method_annotations())    WRITE(checked_cast<jint>(cmethod.method_annotations_length()));
+    if (cmethod.has_parameter_annotations()) WRITE(checked_cast<jint>(cmethod.parameter_annotations_length()));
+    if (cmethod.has_type_annotations())      WRITE(checked_cast<jint>(cmethod.type_annotations_length()));
+    if (cmethod.has_default_annotations())   WRITE(checked_cast<jint>(cmethod.default_annotations_length()));
+
+    // Now write the data (i.e. method attributes), omitting their lengths/sizes
+    if (cmethod.code_size() > 0)             DO_CHECKED(write_code_attr(method, linenumber_table_size));
+    if (cmethod.has_checked_exceptions()) {
+      assert(cmethod.checked_exceptions_length() > 0, "existing stackmap table cannot be empty");
+      STATIC_ASSERT(sizeof(CheckedExceptionElement) == sizeof(u2)); // Check no padding
+      const size_t len = cmethod.checked_exceptions_length() * sizeof(CheckedExceptionElement) / sizeof(u2);
+      DO_CHECKED(write_uint_array_data(reinterpret_cast<u2 *>(cmethod.checked_exceptions_start()), len));
+    }
+    if (cmethod.has_method_parameters()) { // Does not imply method_parameters_length > 0
+      STATIC_ASSERT(sizeof(MethodParametersElement) == 2 * sizeof(u2)); // Check no padding
+      const size_t len = cmethod.method_parameters_length() * sizeof(MethodParametersElement) / sizeof(u2);
+      DO_CHECKED(write_uint_array_data(reinterpret_cast<u2 *>(cmethod.method_parameters_start()), len));
+    }
+    if (cmethod.has_method_annotations()) { // Runtime(In)VisibleAnnotations
+      assert(!cmethod.method_annotations()->is_empty(), "existing method annotations cannot be empty");
+      DO_CHECKED(write_uint_array_data(cmethod.method_annotations()->data(), cmethod.method_annotations_length()));
+    }
+    if (cmethod.has_parameter_annotations()) { // Runtime(In)VisibleParameterAnnotations
+      assert(!cmethod.method_annotations()->is_empty(), "existing method annotations cannot be empty");
+      DO_CHECKED(write_uint_array_data(cmethod.parameter_annotations()->data(), cmethod.method_annotations_length()));
+    }
+    if (cmethod.has_type_annotations()) { // Runtime(In)VisibleTypeAnnotations
+      assert(!cmethod.method_annotations()->is_empty(), "existing method annotations cannot be empty");
+      DO_CHECKED(write_uint_array_data(cmethod.type_annotations()->data(), cmethod.type_annotations_length()));
+    }
+    if (cmethod.has_default_annotations()) { // AnnotationDefault
+      assert(!cmethod.method_annotations()->is_empty(), "existing method annotations cannot be empty");
+      DO_CHECKED(write_uint_array_data(cmethod.default_annotations()->data(), cmethod.default_annotations_length()));
+    }
+    // Synthetic attribute is stored in access flags, others are not available
+
+    // TODO examine if any other intrinsics should be dumped
+    WRITE(checked_cast<u1>(method.is_compiled_lambda_form())); // ClassFileParser sets this intrinsic based on an annotation
+  }
+
+  void write_methods(const InstanceKlass &ik) {
+    // Normal methods, including overpasses
+    const Array<Method *> &methods = *ik.methods();
+    const Array<int> &original_ordering = *ik.method_ordering();
+    assert(&original_ordering == Universe::the_empty_int_array() || methods.length() == original_ordering.length(), "must be");
+    WRITE(checked_cast<u2>(methods.length()));
+    for (int i = 0; i < methods.length(); i++) {
+      // Original index of this method in class file
+      if (&original_ordering != Universe::the_empty_int_array()) {
+        WRITE(checked_cast<u2>(original_ordering.at(i)));
+      } else {
+        assert(!JvmtiExport::can_maintain_original_method_order() && !Arguments::is_dumping_archive(), "original method ordering must be available");
+        WRITE(checked_cast<u2>(i)); // Pretend this is the original ordering
+      }
+      DO_CHECKED(write_method(*methods.at(i)));
+    }
+
+    // Descriptions of the default methods, if any
+    const Array<Method *> *defaults = ik.default_methods();
+    if (defaults != nullptr) {
+      assert(ik.has_nonstatic_concrete_methods(), "must be");
+      assert(defaults->length() > 0, "must not be allocated if there are no defaults");
+      WRITE(checked_cast<u2>(defaults->length()));
+      for (int i = 0; i < defaults->length(); i++) {
+        const Method &method = *defaults->at(i);
+        assert(!method.is_old(), "default methods must not be old"); // Lets us omit holder's redefinition version
+        WRITE_CLASS_ID(*method.method_holder());
+        WRITE(method.method_idnum());
+      }
+    } else {
+      WRITE(checked_cast<u2>(0));
+    }
+
+    // TODO If the class has been linked, write its vtable/itable and the
+    //  corresponding method indices. These indices are actually already saved
+    //  as part of resolved method entries of constant pool cache.
+  }
+
+  // ###########################################################################
+  // JVM TI-related data
+  // ###########################################################################
+
+  // JVM TI RetransformClasses support.
+  void write_cached_class_file(JvmtiCachedClassFileData *cached_class_file) {
+    if (cached_class_file == nullptr) {
+      WRITE(CracClassDumper::NO_CACHED_CLASS_FILE_SENTINEL);
+      return;
+    }
+
+    guarantee(cached_class_file->length >= 0, "length cannot be negative");
+    WRITE(cached_class_file->length);
+    WRITE_RAW(cached_class_file->data, cached_class_file->length);
+  }
+
+  // JVM TI RedefineClasses support.
+  void write_previous_versions(InstanceKlass *ik) {
+    if (!ik->has_been_redefined()) {
+      assert(ik->previous_versions() == nullptr, "only redefined class can have previous versions");
+      return;
+    }
+
+    InstanceKlass::purge_previous_versions(ik); // Remove redundant previous versions
+    if (ik->previous_versions() != nullptr) {
+      // TODO implement previous versions dumping (and fail on restore if the
+      //  restoring VM won't have JVM TI included)
+      ResourceMark rm;
+      log_error(crac, class, dump)("Old versions of redefined %s's methods are still executing", ik->external_name());
+      Unimplemented();
+    }
+  }
+
+  // ###########################################################################
+  // Instance and object array classes dumping
+  // ###########################################################################
+
+  void write_instance_class_data(InstanceKlass *ik) {
+    precond(ik != nullptr);
+    if (log_is_enabled(Trace, crac, class, dump)) {
+      ResourceMark rm;
+      log_trace(crac, class, dump)("Writing instance class data: %s (ID " UINTX_FORMAT ")",
+                                   ik->external_name(), cast_from_oop<uintptr_t>(ik->java_mirror()));
+    }
+
+    WRITE_CLASS_ID(*ik);
+    WRITE(checked_cast<u1>(loading_kind(*ik)));
+
+    assert(ik->is_loaded(), "too young, must've been filtered out");
+    assert(!ik->is_being_linked() && !ik->is_being_initialized(), "should've failed during stack dumping (linking thread must have an in-VM frame)");
+    WRITE(checked_cast<u1>(ik->init_state()));
+    if (ik->is_in_error_state()) {
+      WRITE_OBJECT_ID(ik->get_initialization_error()); // Can be null
+    }
+
+    WRITE(ik->minor_version());
+    WRITE(ik->major_version());
+    WRITE(checked_cast<jint>(ik->constants()->version())); // Version of redefined classes (0 if not redefined), may be negative
+
+    DO_CHECKED(write_class_flags(*ik));
+
+    DO_CHECKED(write_class_attrs(*ik)); // Consatant pool parsing depends on NestHost attribute
+
+    DO_CHECKED(write_constant_pool(*ik->constants()));
+    if (ik->is_rewritten()) {
+      precond(ik->constants()->cache() != nullptr);
+      DO_CHECKED(write_constant_pool_cache(*ik->constants()->cache()));
+    }
+
+    WRITE(ik->this_class_index());
+    DO_CHECKED(write_interfaces(*ik->local_interfaces()));
+
+    DO_CHECKED(write_fields(*ik));
+
+    DO_CHECKED(write_methods(*ik));
+
+    DO_CHECKED(write_cached_class_file(ik->get_cached_class_file()));
+    DO_CHECKED(write_previous_versions(ik));
+
+    // TODO save and restore CDS-related stuff (if there is any that is portable)
+  }
+
+  // Dumps instance class and its array classes, ensuring its ancestors are
+  // dumped first in the required order.
+  void dump_class_hierarchy(InstanceKlass *ik) {
+    precond(ik != nullptr);
+
+    bool not_dumped_yet;
+    _dumped_classes.put_if_absent(ik, &not_dumped_yet);
+    if (!not_dumped_yet) {
+      assert(ik->is_class_loader_instance_klass() ||
+             ik->is_subtype_of(vmClasses::ProtectionDomain_klass()) ||
+             ik->subklass() != nullptr || ik->is_interface(),
+             "shouldn't have been dumped yet");
+      return;
+    }
+    _dumped_classes.maybe_grow();
+
+    if (ik->class_loader() != nullptr) {
+      const oop loader_parent = java_lang_ClassLoader::parent(ik->class_loader());
+      if (loader_parent != nullptr) {
+        DO_CHECKED(dump_class_hierarchy(InstanceKlass::cast(loader_parent->klass())));
+      }
+      DO_CHECKED(dump_class_hierarchy(InstanceKlass::cast(ik->class_loader()->klass())));
+    } else {
+      assert(ik->class_loader_data()->is_boot_class_loader_data(), "must be");
+    }
+
+    if (ik->java_super() != nullptr) {
+      DO_CHECKED(dump_class_hierarchy(ik->java_super()));
+    }
+
+    const Array<InstanceKlass *> &interfaces = *ik->local_interfaces();
+    for (int i = 0; i < interfaces.length(); i++) {
+      DO_CHECKED(dump_class_hierarchy(interfaces.at(i)));
+    }
+
+    DO_CHECKED(write_instance_class_data(ik));
+    DO_CHECKED(write_obj_array_class_ids(ik));
+  }
+
+  // ###########################################################################
+  // Initiating class loaders info
+  // ###########################################################################
+
+  void do_cld(ClassLoaderData *cld) override {
+    if (cld->is_the_null_class_loader_data()) {
+      // Bootstrap loader never delegates, so if it is an initiating loader than
+      // it is also the defining one, and the defining loaders are known from
+      // the heap dump
+#ifdef ASSERT
+      struct : public KlassClosure {
+        void do_klass(Klass *k) override {
+          assert(k->class_loader() == nullptr, "must be defined by the boot loader");
+        }
+      } asserter;
+      cld->dictionary()->all_entries_do(&asserter);
+#endif // ASSERT
+      return;
+    }
+    if (cld->has_class_mirror_holder()) {
+      // These CLDs are exclusive to the holder
+      guarantee(cld->dictionary() == nullptr, "CLDs with mirror holder have no dictionaries");
+      return;
+    }
+    postcond(cld->class_loader() != nullptr && cld->dictionary() != nullptr);
+    assert(java_lang_ClassLoader::loader_data(cld->class_loader()) == cld,
+           "must be true for CLD without a mirror holder");
+
+    ResourceMark rm;
+    GrowableArray<const InstanceKlass *> initiated_classes;
+    // Find all classes known to the class loader but not defined by it.
+    struct InitiatedKlassCollector : public KlassClosure {
+      const ClassLoaderData &cld;
+      GrowableArray<const InstanceKlass *> &iks;
+      InitiatedKlassCollector(const ClassLoaderData &cld, GrowableArray<const InstanceKlass *> *iks) :
+        cld(cld), iks(*iks) {}
+      void do_klass(Klass *k) override {
+        precond(k->is_instance_klass());
+        if (k->class_loader_data() != &cld) {
+          InstanceKlass *const ik = InstanceKlass::cast(k);
+          assert(!ik->is_hidden(), "hidden classes cannot be seen outside of the defining loader");
+          iks.append(ik);
+        }
+      }
+    } collector(*cld, &initiated_classes);
+    cld->dictionary()->all_entries_do(&collector);
+
+    if (!initiated_classes.is_empty()) {
+      WRITE_OBJECT_ID(cld->class_loader());
+      WRITE(checked_cast<jint>(initiated_classes.length()));
+      for (const InstanceKlass *ik : initiated_classes) {
+        WRITE_CLASS_ID(*ik);
+      }
+    }
+  }
+
+#undef DO_CHECKED
+#undef WRITE_RAW
+#undef WRITE_CLASS_ID
+#undef WRITE_OBJECT_ID
+#undef WRITE_SYMBOL_ID
+#undef WRITE
+};
+
+const char *CracClassDumper::dump(const char *path, bool overwrite) {
+  guarantee(SafepointSynchronize::is_at_safepoint(), "need safepoint to ensure classes are not modified concurrently");
+  log_info(crac, class, dump)("Dumping classes into %s", path);
+
+  FileBasicTypeWriter file_writer;
+  if (!file_writer.open(path, overwrite)) {
+    return os::strerror(errno);
+  }
+
+  ClassDumpWriter dump_writer(&file_writer);
+  dump_writer.write_dump();
+  return dump_writer.io_error_msg();
+}

--- a/src/hotspot/share/runtime/cracClassDumper.hpp
+++ b/src/hotspot/share/runtime/cracClassDumper.hpp
@@ -1,0 +1,61 @@
+#ifndef SHARE_RUNTIME_CRACCLASSDUMPER_HPP
+#define SHARE_RUNTIME_CRACCLASSDUMPER_HPP
+
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Dumps runtime class data for CRaC portable mode.
+//
+// The dump is expected to be accompanied by an HPROF heap dump from the
+// heapDumper, hence IDs used are the same as heapDumper uses and some class
+// data available from there is not duplicated.
+//
+// First, after the header, IDs of primitive array classes are dumped, followed
+// by dumps of instance classes.
+//
+// Instance classes are sorted so that for any instance class C the following
+// instance classes are dumped ahead of C:
+// 1. Class of C's class loader.
+// 2. Class of C's class loader's parent.
+// 3. C's super class.
+// 4. Interfaces implemented by C.
+// This ordering makes it easier to load classes as the dump is being parsed.
+//
+// Each primitive-array and instance class is followed by IDs of object array
+// classes sorted by ascending dimensionality.
+struct CracClassDumper : public AllStatic {
+  // Kinds of classes with regards to how they were loaded.
+  enum ClassLoadingKind : u1 {
+    NORMAL            = 0,
+    NON_STRONG_HIDDEN = 1,
+    STRONG_HIDDEN     = 2
+  };
+  // Bit positions in compressed VM options.
+  enum VMOptionShift : u1 {
+    is_sync_on_value_based_classes_diagnosed_shift = 0,
+    are_all_annotations_preserved_shift            = 1,
+    num_vm_options,
+  };
+  // Bit positions of in resolved method entries' flags.
+  enum ResolvedMethodEntryFlagShift : u1 {
+    is_vfinal_shift           = 0,
+    is_final_shift            = 1,
+    is_forced_virtual_shift   = 2,
+    has_appendix_shift        = 3,
+    has_local_signature_shift = 4,
+    num_method_entry_flags,
+  };
+  // For null class metadata arrays.
+  static constexpr u4 NO_ARRAY_SENTINEL = 0xFFFFFFFF;
+  // For null cached class file.
+  static constexpr jint NO_CACHED_CLASS_FILE_SENTINEL = -1;
+
+  // Dumps the data into the specified file, possibly overwriting it if the
+  // corresponding parameter is set to true, Returns nullptr on success, or a
+  // pointer to a static IO error message otherwise.
+  //
+  // Must be called on a safepoint.
+  static const char *dump(const char *path, bool overwrite = false);
+};
+
+#endif // SHARE_RUNTIME_CRACCLASSDUMPER_HPP

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -205,8 +205,8 @@ InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *creat
       ResourceMark rm;
       const char *current_state_name = (defined_ik->is_rewritten() && !defined_ik->is_linked())             ? "rewritten" : defined_ik->init_state_name();
       const char *target_state_name =  (created_ik->is_rewritten() && target_state < InstanceKlass::linked) ? "rewritten" : InstanceKlass::state_name(target_state);
-      log_debug(crac, class)("Using pre-defined version of %s (current state = %s, target state = %s)",
-                             defined_ik->external_name(), current_state_name, target_state_name);
+      log_debug(crac, class)("Using pre-defined %s (current state = %s, target state = %s) - defined by %s",
+                             defined_ik->external_name(), current_state_name, target_state_name, defined_ik->class_loader_data()->loader_name_and_id());
     }
     assert(created_ik->access_flags().as_int() == defined_ik->access_flags().as_int(),
            "pre-defined %s has different access flags: " INT32_FORMAT_X " (dumped) != " INT32_FORMAT_X " (pre-defined)",
@@ -230,6 +230,12 @@ InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *creat
     }
 
     created_ik->class_loader_data()->add_to_deallocate_list(created_ik);
+  } else if (log_is_enabled(Debug, crac, class)) {
+    ResourceMark rm;
+    const char *current_state_name = (defined_ik->is_rewritten() && !defined_ik->is_linked())             ? "rewritten" : defined_ik->init_state_name();
+    const char *target_state_name =  (created_ik->is_rewritten() && target_state < InstanceKlass::linked) ? "rewritten" : InstanceKlass::state_name(target_state);
+    log_debug(crac, class)("Using newly defined %s (current state = %s, target state = %s) - defined by %s",
+                           defined_ik->external_name(), current_state_name, target_state_name, defined_ik->class_loader_data()->loader_name_and_id());
   }
 
   if (target_state < InstanceKlass::linked) {

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -1,0 +1,227 @@
+#include "precompiled.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "oops/arrayKlass.hpp"
+#include "oops/cpCache.hpp"
+#include "oops/cpCache.inline.hpp"
+#include "oops/instanceKlass.hpp"
+#include "oops/klass.hpp"
+#include "oops/klassVtable.hpp"
+#include "oops/method.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "oops/resolvedFieldEntry.hpp"
+#include "oops/resolvedIndyEntry.hpp"
+#include "runtime/cracClassStateRestorer.hpp"
+#include "runtime/javaThread.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/exceptions.hpp"
+
+#ifdef ASSERT
+struct ExtendedClassState {
+  InstanceKlass::ClassState state;
+  bool is_interface;
+  bool is_rewritten;
+  bool has_nonstatic_concrete_methods;
+};
+
+static void assert_has_consistent_state(const InstanceKlass &super_or_interface, const ExtendedClassState &child_state) {
+  switch (child_state.state) {
+    case InstanceKlass::loaded:
+      if (!child_state.is_rewritten) {
+        assert(super_or_interface.is_loaded(), "supers/interfaces of loaded class/interface must be loaded, but %s is not",
+               super_or_interface.external_name());
+        return;
+      } else { // Intermediate state between loaded and linked
+        assert(super_or_interface.is_linked(), "supers/interfaces of rewritten class/interface must be loaded, but %s is not",
+               super_or_interface.external_name());
+        return;
+      }
+    case InstanceKlass::linked:
+      assert(super_or_interface.is_linked(), "supers/interfaces of linked class/interface must be linked, but %s is not",
+             super_or_interface.external_name());
+      return;
+    case InstanceKlass::fully_initialized:
+      if (!child_state.is_interface && (!super_or_interface.is_interface() || child_state.has_nonstatic_concrete_methods)) {
+        assert(super_or_interface.is_initialized(), "supers and interfaces with default methods of initialized class must be initialized, but %s is not",
+               super_or_interface.external_name());
+        return;
+      } else {
+        assert(super_or_interface.is_linked(), "supers/interfaces of initialized class/interface must be linked, but %s is not",
+               super_or_interface.external_name());
+        return;
+      }
+    case InstanceKlass::initialization_error:
+      if (!child_state.is_interface && (!super_or_interface.is_interface() || child_state.has_nonstatic_concrete_methods)) {
+        assert(super_or_interface.is_initialized() || super_or_interface.is_in_error_state(),
+               "supers and interfaces with default methods of class that attempted initialization must also have attempted initialization, but %s has not",
+               super_or_interface.external_name());
+        return;
+      } else {
+        assert(super_or_interface.is_linked(), "supers/interfaces of class/interface that attempted initialization must be linked, but %s is not",
+               super_or_interface.external_name());
+        return;
+      }
+    case InstanceKlass::allocated:         // Too young, not dumped
+    case InstanceKlass::being_linked:      // Restoring these is not yet implemented (thus not dumped)
+    case InstanceKlass::being_initialized: // Restoring these is not yet implemented (thus not dumped)
+    default:
+      assert(false, "illegal class state: %i", child_state.state);
+      return;
+  }
+}
+
+static void check_hirarchy_state_consistency(const InstanceKlass *super, const Array<InstanceKlass *> &local_interfaces,
+                                             ExtendedClassState child_state) {
+  if (super != nullptr) {
+    assert_has_consistent_state(*super, child_state);
+  }
+  for (int i = 0; i < local_interfaces.length(); i++) {
+    const InstanceKlass &interface = *local_interfaces.at(i);
+    assert_has_consistent_state(interface, child_state);
+  }
+}
+#endif // ASSERT
+
+// TODO the code below does not take concurrency into account (see TODOs below)
+void CracClassStateRestorer::apply_state(InstanceKlass *ik, InstanceKlass::ClassState state, TRAPS) {
+  precond(ik->is_being_restored());
+  precond(!ik->is_loaded());
+  assert(state >= InstanceKlass::ClassState::loaded, "too young, checked before");
+  DEBUG_ONLY(check_hirarchy_state_consistency(ik->java_super(), *ik->local_interfaces(),
+                                              {state, ik->is_rewritten(), ik->has_nonstatic_concrete_methods()}));
+
+  // TODO insure the class has not been loaded/defined concurrently -- need to
+  //  follow the complex class loading and definition procedures implemented in
+  //  SystemDictionary and not mark the class as being restored if someone else
+  //  beats us.
+  SystemDictionary::define_recreated_instance_class(ik, CHECK);
+  postcond(ik->is_loaded());
+
+  JavaThread *const thread = JavaThread::current();
+
+  assert(state != InstanceKlass::ClassState::being_linked, "not supported, checked before");
+  if (state >= InstanceKlass::ClassState::linked) {
+    assert(ik->is_rewritten(), "checked before");                   // Protects non-repeatable linkage steps
+    assert(!ik->is_shared(), "classes just created aren't shared"); // vtable/itable won't be initialized for shared classes
+    // Do what InstanceKlass::link_class() does after rewriting for
+    // non-shared classes, ommiting:
+    // 1. vtable/itable constraint checks because they should've been done
+    //    already by the dumping VM, so we hope everything is correct.
+    // 2. Posting "class prepare" event for JVM TI because we want to make
+    //    it seem like the class was already loaded.
+    InstanceKlass::LockLinkState init_lock(ik, thread);
+    guarantee(ik->is_being_linked() && ik->is_init_thread(thread), "concurrent usage of the class being restored");
+    ik->link_methods(CHECK);
+    ik->vtable().initialize_vtable(nullptr);
+    ik->itable().initialize_itable(nullptr);
+    DEBUG_ONLY(ik->vtable().verify(tty, true));
+    ik->set_initialization_state_and_notify(InstanceKlass::ClassState::linked, thread);
+    postcond(ik->is_linked());
+  }
+
+  assert(state != InstanceKlass::ClassState::being_initialized, "not supported, checked before");
+  if (state >= InstanceKlass::ClassState::fully_initialized) {
+    precond(ik->is_linked());
+    // Fields and initialization errors will be filled later, after all dumped
+    // classes have been created and objects can be allocated. We just set the
+    // state to hand it over to the rest of the restoration code together
+    // with the created class.
+    {
+      MutexLocker ml(thread, ik->init_monitor());
+      guarantee(ik->init_state() == InstanceKlass::ClassState::linked, "concurrent usage of the class being restored");
+      ik->set_init_state(InstanceKlass::ClassState::being_initialized);
+      ik->set_init_thread(thread);
+    }
+    ik->set_initialization_state_and_notify(state, thread); // Either initialized or errored
+  }
+
+  // TODO must ensure the class won't be used concurrently until it's fully
+  //  restored -- need to hold init locks of all classes being restored?
+}
+
+void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
+                                                        const HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> &iks,
+                                                        const HeapDumpTable<ArrayKlass *, AnyObj::C_HEAP> &aks,
+                                                        const InterclassRefs &refs) {
+  if (refs.dynamic_nest_host != HeapDump::NULL_ID) {
+    InstanceKlass **const host = iks.get(refs.dynamic_nest_host);
+    guarantee(host != nullptr, "unknown class " HDID_FORMAT " referenced as a dynamic nest host of %s",
+              refs.dynamic_nest_host, ik->external_name());
+    ik->set_nest_host(*host);
+  }
+
+  ConstantPool *const cp = ik->constants();
+  for (const InterclassRefs::ClassRef &class_ref : *refs.cp_class_refs) {
+    Klass *k;
+    InstanceKlass **const ik_ptr = iks.get(class_ref.class_id);
+    if (ik_ptr != nullptr) {
+      k = *ik_ptr;
+    } else {
+      ArrayKlass **const ak_ptr = aks.get(class_ref.class_id);
+      guarantee(ak_ptr != nullptr, "unknown class " HDID_FORMAT " referenced by Class constant pool entry #%i of %s",
+                class_ref.class_id, class_ref.index, ik->external_name());
+      k = *ak_ptr;
+    }
+    cp->klass_at_put(class_ref.index, k);
+  }
+
+  ConstantPoolCache *const cp_cache = cp->cache();
+  if (cp_cache == nullptr) {
+    assert(refs.field_refs->is_empty() && refs.method_refs->is_empty() && refs.indy_refs->is_empty(),
+          "class %s has unfilled references for its absent constant pool cache", ik->external_name());
+    return;
+  }
+
+  for (const InterclassRefs::ClassRef &field_ref : *refs.field_refs) {
+    InstanceKlass **const holder = iks.get(field_ref.class_id);
+    guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by resolved field entry #%i of %s",
+              field_ref.class_id, field_ref.index, ik->external_name());
+    ResolvedFieldEntry &field_entry = *cp_cache->resolved_field_entry_at(field_ref.index);
+    field_entry.fill_in_holder(*holder);
+  }
+
+  for (const InterclassRefs::MethodRefs &method_ref : *refs.method_refs) {
+    ConstantPoolCacheEntry &cache_entry = *cp_cache->entry_at(method_ref.cache_index);
+    if (method_ref.f1_class_id != HeapDump::NULL_ID) {
+      InstanceKlass **const holder = iks.get(method_ref.f1_class_id);
+      guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by field 1 of resolved method entry #%i of %s",
+                method_ref.f1_class_id, method_ref.cache_index, ik->external_name());
+      if (method_ref.f1_is_method) {
+        Method *const method = (*holder)->method_with_idnum(method_ref.f1_method_idnum);
+        guarantee(method != nullptr, "class %s has resolved method entry #%i with field 1 referencing method with ID %i of %s "
+                  "but the latter does not have such method", ik->external_name(), method_ref.cache_index,
+                  method_ref.f1_method_idnum, (*holder)->external_name());
+        cache_entry.set_f1(method);
+      } else {
+        cache_entry.set_f1(*holder);
+      }
+    }
+    if (method_ref.f2_class_id != HeapDump::NULL_ID) {
+      InstanceKlass **const holder = iks.get(method_ref.f2_class_id);
+      guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by field 2 of resolved method entry #%i of %s",
+                method_ref.f2_class_id, method_ref.cache_index, ik->external_name());
+      Method *const method = (*holder)->method_with_idnum(method_ref.f2_method_idnum);
+      guarantee(method != nullptr, "class %s has resolved method entry #%i with field 2 referencing method with ID %i of %s "
+                "but the latter does not have such method", ik->external_name(), method_ref.cache_index,
+                method_ref.f2_method_idnum, (*holder)->external_name());
+      cache_entry.set_f2(reinterpret_cast<intx>(method));
+    }
+  }
+
+  for (const InterclassRefs::IndyAdapterRef &indy_ref : *refs.indy_refs) {
+    InstanceKlass **const holder = iks.get(indy_ref.holder_id);
+    guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by resolved invokedynamic entry #%i of %s",
+              indy_ref.holder_id, indy_ref.indy_index, ik->external_name());
+    Method *const method = (*holder)->method_with_idnum(indy_ref.method_idnum);
+    guarantee(method != nullptr, "class %s has resolved invokedynamic entry #%i referencing method with ID %i of %s "
+              "but the latter does not have such method", ik->external_name(), indy_ref.indy_index,
+              indy_ref.method_idnum, (*holder)->external_name());
+    ResolvedIndyEntry &indy_entry = *cp_cache->resolved_indy_entry_at(indy_ref.indy_index);
+    indy_entry.adjust_method_entry(method);
+  }
+}
+
+void CracClassStateRestorer::fill_initialization_error(InstanceKlass *ik, Handle error) {
+  precond(ik->get_initialization_error() == nullptr);
+  ik->put_initializetion_error(JavaThread::current(), error);
+}

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -169,6 +169,9 @@ InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *creat
       ResourceMark rm;
       log_debug(crac, class)("Using pre-defined version of %s", defined_ik->external_name());
     }
+    assert(created_ik->access_flags().as_int() == defined_ik->access_flags().as_int(),
+           "pre-defined %s has different access flags: " INT32_FORMAT_X " (dumped) != " INT32_FORMAT_X " (pre-defined)",
+           created_ik->external_name(), created_ik->access_flags().as_int(), defined_ik->access_flags().as_int());
     DEBUG_ONLY(assert_constants_match(*created_ik->constants(), *defined_ik->constants()));
     DEBUG_ONLY(assert_fields_match(*created_ik, *defined_ik));
     DEBUG_ONLY(assert_methods_match(*created_ik, *defined_ik));

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -1,149 +1,168 @@
 #include "precompiled.hpp"
+#include "classfile/classLoaderData.hpp"
+#include "classfile/dictionary.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "logging/log.hpp"
+#include "memory/resourceArea.hpp"
 #include "oops/arrayKlass.hpp"
+#include "oops/constantPool.hpp"
 #include "oops/cpCache.hpp"
 #include "oops/cpCache.inline.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.hpp"
-#include "oops/klassVtable.hpp"
 #include "oops/method.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "oops/resolvedFieldEntry.hpp"
 #include "oops/resolvedIndyEntry.hpp"
 #include "runtime/cracClassStateRestorer.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/javaThread.inline.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/constantTag.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/exceptions.hpp"
 
+static void move_constant_pool_cache(ConstantPool *from, ConstantPool *to) {
+  guarantee(to->cache() == nullptr, "destination class already has a constant pool cache");
+  guarantee(from->length() == to->length(), "not the same class");
 #ifdef ASSERT
-struct ExtendedClassState {
-  InstanceKlass::ClassState state;
-  bool is_interface;
-  bool is_rewritten;
-  bool has_nonstatic_concrete_methods;
-};
-
-static void assert_has_consistent_state(const InstanceKlass &super_or_interface, const ExtendedClassState &child_state) {
-  switch (child_state.state) {
-    case InstanceKlass::loaded:
-      if (!child_state.is_rewritten) {
-        assert(super_or_interface.is_loaded(), "supers/interfaces of loaded class/interface must be loaded, but %s is not",
-               super_or_interface.external_name());
-        return;
-      } else { // Intermediate state between loaded and linked
-        assert(super_or_interface.is_linked(), "supers/interfaces of rewritten class/interface must be loaded, but %s is not",
-               super_or_interface.external_name());
-        return;
-      }
-    case InstanceKlass::linked:
-      assert(super_or_interface.is_linked(), "supers/interfaces of linked class/interface must be linked, but %s is not",
-             super_or_interface.external_name());
-      return;
-    case InstanceKlass::fully_initialized:
-      if (!child_state.is_interface && (!super_or_interface.is_interface() || child_state.has_nonstatic_concrete_methods)) {
-        assert(super_or_interface.is_initialized(), "supers and interfaces with default methods of initialized class must be initialized, but %s is not",
-               super_or_interface.external_name());
-        return;
-      } else {
-        assert(super_or_interface.is_linked(), "supers/interfaces of initialized class/interface must be linked, but %s is not",
-               super_or_interface.external_name());
-        return;
-      }
-    case InstanceKlass::initialization_error:
-      if (!child_state.is_interface && (!super_or_interface.is_interface() || child_state.has_nonstatic_concrete_methods)) {
-        assert(super_or_interface.is_initialized() || super_or_interface.is_in_error_state(),
-               "supers and interfaces with default methods of class that attempted initialization must also have attempted initialization, but %s has not",
-               super_or_interface.external_name());
-        return;
-      } else {
-        assert(super_or_interface.is_linked(), "supers/interfaces of class/interface that attempted initialization must be linked, but %s is not",
-               super_or_interface.external_name());
-        return;
-      }
-    case InstanceKlass::allocated:         // Too young, not dumped
-    case InstanceKlass::being_linked:      // Restoring these is not yet implemented (thus not dumped)
-    case InstanceKlass::being_initialized: // Restoring these is not yet implemented (thus not dumped)
-    default:
-      assert(false, "illegal class state: %i", child_state.state);
-      return;
+  for (int i = 1; i < from->length(); i++) {
+    assert(from->tag_at(i).external_value() == to->tag_at(i).external_value(),
+           "incompatible constant pool tags at slot #%i: %s and %s",
+           i, from->tag_at(i).internal_name(), to->tag_at(i).internal_name());
   }
-}
-
-static void check_hirarchy_state_consistency(const InstanceKlass *super, const Array<InstanceKlass *> &local_interfaces,
-                                             ExtendedClassState child_state) {
-  if (super != nullptr) {
-    assert_has_consistent_state(*super, child_state);
-  }
-  for (int i = 0; i < local_interfaces.length(); i++) {
-    const InstanceKlass &interface = *local_interfaces.at(i);
-    assert_has_consistent_state(interface, child_state);
-  }
-}
 #endif // ASSERT
+  ConstantPoolCache *const cache = from->cache();
+  to->set_cache(cache);
+  cache->set_constant_pool(to);
+  from->set_cache(nullptr);
+}
 
-// TODO the code below does not take concurrency into account (see TODOs below)
-void CracClassStateRestorer::apply_state(InstanceKlass *ik, InstanceKlass::ClassState state, TRAPS) {
-  precond(ik->is_being_restored());
-  precond(!ik->is_loaded());
-  assert(state >= InstanceKlass::ClassState::loaded, "too young, checked before");
-  DEBUG_ONLY(check_hirarchy_state_consistency(ik->java_super(), *ik->local_interfaces(),
-                                              {state, ik->is_rewritten(), ik->has_nonstatic_concrete_methods()}));
+static void swap_methods(InstanceKlass *ik1, InstanceKlass *ik2) {
+  guarantee(ik1->methods()->length() == ik2->methods()->length(), "not the same class");
+  auto *const methods1 = ik1->methods();
+  auto *const methods2 = ik2->methods();
+  ik1->set_methods(methods2);
+  ik2->set_methods(methods1);
+  for (int i = 0; i < methods1->length(); i++) {
+    Method *const method1 = methods1->at(i); // Moving from ik1 into ik2
+    Method *const method2 = methods2->at(i); // Moving from ik2 into ik1
+    guarantee(method1->name_index() == method2->name_index() && method1->signature_index() == method2->signature_index(),
+              "not the same method: %s and %s", method1->name_and_sig_as_C_string(), method2->name_and_sig_as_C_string());
+    assert(method1->name() == method2->name() && method1->signature() == method2->signature(), // Checks the actual CP contents
+           "not the same method: %s and %s", method1->name_and_sig_as_C_string(), method2->name_and_sig_as_C_string());
+    method1->set_constants(ik2->constants());
+    method2->set_constants(ik1->constants());
+  }
+}
 
-  // TODO insure the class has not been loaded/defined concurrently -- need to
-  //  follow the complex class loading and definition procedures implemented in
-  //  SystemDictionary and not mark the class as being restored if someone else
-  //  beats us.
-  SystemDictionary::define_recreated_instance_class(ik, CHECK);
-  postcond(ik->is_loaded());
+InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *created_ik, InstanceKlass::ClassState target_state, TRAPS) {
+  precond(created_ik != nullptr && created_ik->is_being_restored() && !created_ik->is_loaded());
 
+  // May get another class if one has been defined already:
+  // - created_ik -- what we have parsed from the dump
+  // - defined_ik -- what we should use
+  // If created_ik != defined_ik the former will be deallocated.
+  InstanceKlass *const defined_ik = SystemDictionary::find_or_define_recreated_class(created_ik, CHECK_NULL);
+  postcond(defined_ik->is_loaded());
+
+  const bool was_predefined = defined_ik != created_ik;
+  assert(!(was_predefined && defined_ik->is_being_restored()), "pre-defined classes must be unmarked");
+  // TODO We assume the pre-defined class was created from the same class file
+  //  as the freshly created class was which may not be true. E.g. it could've
+  //  been redefined or just loaded from a different class file.
+
+  // Ensure the class won't be used by other threads until it is restored. We do
+  // this even if the class was only loaded at the dump time to be able to set
+  // resolved class references which may appear during verification (even if it
+  // failed in the end). In higher dumped states this also saves other threads
+  // from using unfilled CP cache entries, unrestored resolved references array
+  // and unrestored static fields. But if the pre-defined class is has already
+  // attempted initialization, this won't save from anything.
   JavaThread *const thread = JavaThread::current();
-
-  assert(state != InstanceKlass::ClassState::being_linked, "not supported, checked before");
-  if (state >= InstanceKlass::ClassState::linked) {
-    assert(ik->is_rewritten(), "checked before");                   // Protects non-repeatable linkage steps
-    assert(!ik->is_shared(), "classes just created aren't shared"); // vtable/itable won't be initialized for shared classes
-    // Do what InstanceKlass::link_class() does after rewriting for
-    // non-shared classes, ommiting:
-    // 1. vtable/itable constraint checks because they should've been done
-    //    already by the dumping VM, so we hope everything is correct.
-    // 2. Posting "class prepare" event for JVM TI because we want to make
-    //    it seem like the class was already loaded.
-    InstanceKlass::LockLinkState init_lock(ik, thread);
-    guarantee(ik->is_being_linked() && ik->is_init_thread(thread), "concurrent usage of the class being restored");
-    ik->link_methods(CHECK);
-    ik->vtable().initialize_vtable(nullptr);
-    ik->itable().initialize_itable(nullptr);
-    DEBUG_ONLY(ik->vtable().verify(tty, true));
-    ik->set_initialization_state_and_notify(InstanceKlass::ClassState::linked, thread);
-    postcond(ik->is_linked());
-  }
-
-  assert(state != InstanceKlass::ClassState::being_initialized, "not supported, checked before");
-  if (state >= InstanceKlass::ClassState::fully_initialized) {
-    precond(ik->is_linked());
-    // Fields and initialization errors will be filled later, after all dumped
-    // classes have been created and objects can be allocated. We just set the
-    // state to hand it over to the rest of the restoration code together
-    // with the created class.
-    {
-      MutexLocker ml(thread, ik->init_monitor());
-      guarantee(ik->init_state() == InstanceKlass::ClassState::linked, "concurrent usage of the class being restored");
-      ik->set_init_state(InstanceKlass::ClassState::being_initialized);
-      ik->set_init_thread(thread);
+  {
+    MonitorLocker ml(defined_ik->init_monitor());
+    const bool want_to_initialize = target_state >= InstanceKlass::fully_initialized;
+    while (defined_ik->is_being_linked() || defined_ik->is_being_initialized()) {
+      if (want_to_initialize) {
+        thread->set_class_to_be_initialized(defined_ik);
+      }
+      ml.wait();
+      if (want_to_initialize) {
+        thread->set_class_to_be_initialized(nullptr);
+      }
     }
-    ik->set_initialization_state_and_notify(state, thread); // Either initialized or errored
+    if (defined_ik->init_state() < InstanceKlass::fully_initialized) {
+      defined_ik->set_is_being_restored(true);
+      if ((created_ik->is_rewritten() && !(was_predefined && defined_ik->is_rewritten())) ||
+          (target_state >= InstanceKlass::linked && !defined_ik->is_linked())) {
+        defined_ik->set_init_state(InstanceKlass::being_linked);
+        defined_ik->set_init_thread(thread);
+      } else if (want_to_initialize && defined_ik->init_state() < InstanceKlass::fully_initialized) {
+        defined_ik->set_init_state(InstanceKlass::being_initialized);
+        defined_ik->set_init_thread(thread);
+      }
+    }
+  }
+  postcond(!defined_ik->is_init_thread(thread) || defined_ik->is_being_restored());
+  postcond(!defined_ik->is_init_thread(thread) || defined_ik->init_state() < InstanceKlass::fully_initialized);
+
+  if (was_predefined) {
+    if (created_ik->is_rewritten() && !defined_ik->is_rewritten()) {
+      precond(defined_ik->is_init_thread(thread));
+      // Apply the rewritten state:
+      // 1. Save the constant pool cache created by us to restore it later.
+      move_constant_pool_cache(created_ik->constants(), defined_ik->constants());
+      // 2. Save the rewritten methods, deallocate the non-rewritten ones.
+      swap_methods(created_ik, defined_ik);
+      defined_ik->set_rewritten();
+      if (log_is_enabled(Debug, crac, class)) {
+        ResourceMark rm;
+        log_debug(crac, class)("Moved dumped rewritten state into pre-defined %s", defined_ik->external_name());
+      }
+    }
+    created_ik->class_loader_data()->add_to_deallocate_list(created_ik);
   }
 
-  // TODO must ensure the class won't be used concurrently until it's fully
-  //  restored -- need to hold init locks of all classes being restored?
+  if (target_state < InstanceKlass::linked) {
+    assert(target_state != InstanceKlass::being_linked, "not supported, shouldn't be dumped");
+    return defined_ik;
+  }
+  postcond(defined_ik->is_rewritten());
+  if (!defined_ik->is_linked()) {
+    precond(defined_ik->is_being_linked() && defined_ik->is_init_thread(thread));
+    // Omitting vtable/itable constraints check since it was done before the dump
+    defined_ik->finish_linking(false, CHECK_NULL);
+  }
+
+  if (target_state < InstanceKlass::fully_initialized) {
+    assert(target_state != InstanceKlass::being_initialized, "not supported, shouldn't be dumped");
+    precond(!defined_ik->is_being_initialized());
+    return defined_ik;
+  }
+  precond(defined_ik->init_state() >= InstanceKlass::fully_initialized || defined_ik->is_init_thread(thread));
+  guarantee(!(target_state == InstanceKlass::fully_initialized && defined_ik->is_in_error_state()) &&
+            !(target_state == InstanceKlass::initialization_error && defined_ik->is_initialized()),
+            "%s is dumped %s, but its initialization has already been re-attempted and %s",
+            target_state == InstanceKlass::fully_initialized ? "as successfully initialized" : "with an initialization error",
+            defined_ik->is_initialized() ? "succeeded" : "failed", defined_ik->external_name());
+  // Static fields and resolution exception object will be set during heap restoration
+  return defined_ik;
 }
 
 void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
                                                         const HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> &iks,
                                                         const HeapDumpTable<ArrayKlass *, AnyObj::C_HEAP> &aks,
                                                         const InterclassRefs &refs) {
+  if (log_is_enabled(Trace, crac, class)) {
+    ResourceMark rm;
+    log_trace(crac, class)("Filling interclass references of %s", ik->external_name());
+  }
+
   if (refs.dynamic_nest_host != HeapDump::NULL_ID) {
+    assert(ik->is_being_restored() && !ik->is_linked(),
+           "only hidden classes have dynamic nest hosts and for now we re-create them all");
     InstanceKlass **const host = iks.get(refs.dynamic_nest_host);
     guarantee(host != nullptr, "unknown class " HDID_FORMAT " referenced as a dynamic nest host of %s",
               refs.dynamic_nest_host, ik->external_name());
@@ -162,26 +181,47 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
                 class_ref.class_id, class_ref.index, ik->external_name());
       k = *ak_ptr;
     }
-    cp->klass_at_put(class_ref.index, k);
+    // Put the class ensuring we don't overwrite a pre-resolved class/error
+    const Klass *k_set = cp->klass_at_put_and_get(class_ref.index, k);
+    if (k_set != k) {
+      if (k_set == nullptr) {
+        guarantee(false, "incompatible state of pre-defined class %s: its constant pool slot #%i has class resolution error, "
+                  "but it was successfully resolved to %s at class dump time", ik->external_name(), class_ref.index, k->external_name());
+      } else {
+        guarantee(false, "incompatible state of pre-defined class %s: its constant pool slot #%i is resolved to class %s when %s was expected",
+                  ik->external_name(), class_ref.index, k_set->external_name(), k->external_name());
+      }
+    }
   }
 
-  ConstantPoolCache *const cp_cache = cp->cache();
-  if (cp_cache == nullptr) {
-    assert(refs.field_refs->is_empty() && refs.method_refs->is_empty() && refs.indy_refs->is_empty(),
-          "class %s has unfilled references for its absent constant pool cache", ik->external_name());
+  // Restore constant pool cache only if it was created by us because unresolved
+  // entries are expected to be partially filled
+  // TODO restore constant pool cache even if it was pre-created: check the
+  //  resolved entries have the expected values, fill the unresolved ones
+  if (ik->is_linked() /*pre-linked*/ || (ik->is_shared() && ik->is_rewritten() /*pre-rewritten*/)) {
     return;
   }
+  guarantee(ik->is_being_restored(), "all uninitialized classes being restored must be marked");
 
+  // Non-rewritten classes don't have a constant pool cache to restore
+  if (!ik->is_rewritten()) {
+    assert(!ik->is_init_thread(JavaThread::current()), "no need for this");
+    assert(refs.field_refs->is_empty() && refs.method_refs->is_empty() && refs.indy_refs->is_empty(),
+           "class %s has unfilled references for its absent constant pool cache", ik->external_name());
+    return;
+  }
+  assert(ik->is_being_linked() && ik->is_init_thread(JavaThread::current()), "must be rewriting the class");
+
+  ConstantPoolCache &cp_cache = *cp->cache();
   for (const InterclassRefs::ClassRef &field_ref : *refs.field_refs) {
     InstanceKlass **const holder = iks.get(field_ref.class_id);
     guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by resolved field entry #%i of %s",
               field_ref.class_id, field_ref.index, ik->external_name());
-    ResolvedFieldEntry &field_entry = *cp_cache->resolved_field_entry_at(field_ref.index);
+    ResolvedFieldEntry &field_entry = *cp_cache.resolved_field_entry_at(field_ref.index);
     field_entry.fill_in_holder(*holder);
   }
-
   for (const InterclassRefs::MethodRefs &method_ref : *refs.method_refs) {
-    ConstantPoolCacheEntry &cache_entry = *cp_cache->entry_at(method_ref.cache_index);
+    ConstantPoolCacheEntry &cache_entry = *cp_cache.entry_at(method_ref.cache_index);
     if (method_ref.f1_class_id != HeapDump::NULL_ID) {
       InstanceKlass **const holder = iks.get(method_ref.f1_class_id);
       guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by field 1 of resolved method entry #%i of %s",
@@ -207,7 +247,6 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
       cache_entry.set_f2(reinterpret_cast<intx>(method));
     }
   }
-
   for (const InterclassRefs::IndyAdapterRef &indy_ref : *refs.indy_refs) {
     InstanceKlass **const holder = iks.get(indy_ref.holder_id);
     guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by resolved invokedynamic entry #%i of %s",
@@ -216,12 +255,106 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
     guarantee(method != nullptr, "class %s has resolved invokedynamic entry #%i referencing method with ID %i of %s "
               "but the latter does not have such method", ik->external_name(), indy_ref.indy_index,
               indy_ref.method_idnum, (*holder)->external_name());
-    ResolvedIndyEntry &indy_entry = *cp_cache->resolved_indy_entry_at(indy_ref.indy_index);
+    ResolvedIndyEntry &indy_entry = *cp_cache.resolved_indy_entry_at(indy_ref.indy_index);
     indy_entry.adjust_method_entry(method);
   }
 }
 
-void CracClassStateRestorer::fill_initialization_error(InstanceKlass *ik, Handle error) {
-  precond(ik->get_initialization_error() == nullptr);
-  ik->put_initializetion_error(JavaThread::current(), error);
+void CracClassStateRestorer::apply_init_state(InstanceKlass *ik, InstanceKlass::ClassState state, Handle init_error) {
+  precond(ik->is_loaded() && ik->is_being_restored());
+  precond(init_error.is_null() || state == InstanceKlass::initialization_error);
+  ik->set_is_being_restored(false); // Other threads will remain waiting for the state change if needed
+
+  JavaThread *const thread = JavaThread::current();
+  if (!ik->is_init_thread(thread)) {
+    return;
+  }
+  postcond(ik->is_rewritten());
+
+  if (ik->is_being_linked()) {
+    if (state == InstanceKlass::loaded) {
+      // We've rewritten the class but don't want to finish linking it
+      ik->set_initialization_state_and_notify(InstanceKlass::loaded, thread);
+      return;
+    }
+    if (state == InstanceKlass::linked) {
+      // We've linked the class
+      ik->set_initialization_state_and_notify(InstanceKlass::linked, thread);
+      return;
+    }
+    precond(state == InstanceKlass::fully_initialized || state == InstanceKlass::initialization_error);
+    // We've linked the class but also initialized it
+    ik->set_linked_to_be_initialized_state_and_notify(thread);
+  }
+  postcond(ik->is_linked());
+
+  precond(ik->is_being_initialized() && ik->is_init_thread(thread));
+  if (state == InstanceKlass::initialization_error) {
+    ik->put_initializetion_error(thread, init_error);
+  }
+  ik->set_initialization_state_and_notify(state, thread);
+  postcond(ik->is_initialized() || ik->is_in_error_state());
 }
+
+#ifdef ASSERT
+
+static void assert_has_consistent_state(const InstanceKlass &base, const InstanceKlass &derived) {
+  switch (derived.init_state()) {
+    case InstanceKlass::allocated:
+      ShouldNotReachHere(); // Too young
+      return;
+    case InstanceKlass::loaded:
+      if (!derived.is_rewritten()) {
+        assert(base.is_loaded(), "supers/interfaces of loaded class/interface must be loaded, but %s is not",
+               base.external_name());
+        return;
+      } else { // Intermediate state between loaded and linked
+        assert(base.is_linked(), "supers/interfaces of rewritten class/interface must be loaded, but %s is not",
+               base.external_name());
+        return;
+      }
+    case InstanceKlass::being_linked:
+      assert(const_cast<InstanceKlass &>(derived).is_init_thread(JavaThread::current()), "restoring thread must hold init states of classes being restored");
+    case InstanceKlass::linked:
+      assert(base.is_linked(), "supers/interfaces of linked class/interface must be linked, but %s is not",
+             base.external_name());
+      return;
+    case InstanceKlass::being_initialized:
+      assert(const_cast<InstanceKlass &>(derived).is_init_thread(JavaThread::current()), "restoring thread must hold init states of classes being restored");
+    case InstanceKlass::fully_initialized:
+      if (!derived.is_interface() && (!base.is_interface() || derived.has_nonstatic_concrete_methods())) {
+        assert(base.is_initialized(), "supers and interfaces with default methods of initialized class must be initialized, but %s is not",
+               base.external_name());
+        return;
+      } else {
+        assert(base.is_linked(), "supers/interfaces of initialized class/interface must be linked, but %s is not",
+               base.external_name());
+        return;
+      }
+    case InstanceKlass::initialization_error:
+      if (!derived.is_interface() && (!base.is_interface() || derived.has_nonstatic_concrete_methods())) {
+        assert(base.is_initialized() || base.is_in_error_state(),
+               "supers and interfaces with default methods of class that attempted initialization must also have attempted initialization, but %s has not",
+               base.external_name());
+        return;
+      } else {
+        assert(base.is_linked(), "supers/interfaces of class/interface that attempted initialization must be linked, but %s is not",
+               base.external_name());
+        return;
+      }
+    default:
+      ShouldNotReachHere();
+  }
+}
+
+void CracClassStateRestorer::assert_hierarchy_init_states_are_consistent(const InstanceKlass &ik) {
+  if (ik.java_super() != nullptr) {
+    assert_has_consistent_state(*ik.java_super(), ik);
+  }
+  for (int i = 0; i < ik.local_interfaces()->length(); i++) {
+    const InstanceKlass &interface = *ik.local_interfaces()->at(i);
+    assert_has_consistent_state(interface, ik);
+  }
+}
+
+#endif // ASSERT

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -2,8 +2,10 @@
 #include "classfile/classLoaderData.hpp"
 #include "classfile/dictionary.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "interpreter/linkResolver.hpp"
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
+#include "oops/array.hpp"
 #include "oops/arrayKlass.hpp"
 #include "oops/constantPool.hpp"
 #include "oops/cpCache.hpp"
@@ -14,6 +16,8 @@
 #include "oops/oopsHierarchy.hpp"
 #include "oops/resolvedFieldEntry.hpp"
 #include "oops/resolvedIndyEntry.hpp"
+#include "prims/methodHandles.hpp"
+#include "runtime/cracClassDumper.hpp"
 #include "runtime/cracClassStateRestorer.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/javaThread.inline.hpp"
@@ -22,17 +26,109 @@
 #include "utilities/constantTag.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/exceptions.hpp"
+#include "utilities/heapDumpParser.hpp"
+#include "utilities/macros.hpp"
+
+#ifdef ASSERT
+
+#include "oops/fieldStreams.hpp"
+#include "oops/fieldStreams.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+static int count_overpasses(const Array<Method *> &methods) {
+  int num_overpasses = 0;
+  for (int i = 0; i < methods.length(); i++) {
+    if (methods.at(i)->is_overpass()) {
+      num_overpasses++;
+    }
+  }
+  return num_overpasses;
+}
+
+static void assert_constants_match(const ConstantPool &cp1, const ConstantPool &cp2) {
+  assert(cp1.length() == cp2.length(), "number of constants differs: %i != %i", cp1.length(), cp2.length());
+
+  // Constant pool consists of two parts: the first one comes from the class
+  // file while the second one is appended when generating overpass methods. We
+  // can only compare the first one because the second is not portable: the
+  // order in which overpasses are generated, and thus in which the their
+  // constants are appended, depends on methods in supers and interfaces which
+  // depends on the layout of method name symbols in memory).
+  const int num_overpasses = count_overpasses(*cp1.pool_holder()->methods());
+  assert(num_overpasses == count_overpasses(*cp2.pool_holder()->methods()), "number of overpass methods differ");
+  // An overpass method may need up to this many new constants:
+  // 1. 2 for method's name and type.
+  // 2. 8 for method's code (see BytecodeAssembler::assemble_method_error()):
+  //     new           <error's Class>           +2: UTF8 for class'es name, Class itself
+  //     dup
+  //     ldc(_w)       <error's msg String>      +2: UTF8, String
+  //     invokespecial <error's init Methodref>  +4: 2 UTF8s for init's name and type, NameAndType, Methodref (its Class is the one already added by new)
+  //     athrow
+  // In the worst case the 1st overpass will add all entries listed above:
+  static constexpr int max_cp_entries_first_overpass = 10;
+  // All overpasses use <init>(Ljava/lang/String;)V in invoke special, hence
+  // its 2 UTF8s and a NameAndType will only be added by the 1st overpass:
+  static constexpr int max_cp_entries_second_overpass = 7;
+  // There are only two error classes used in overpasses -- their UTF8 names,
+  // Class entries and init Methodref entries are already accounted for by the
+  // 1st and 2nd overpasses above:
+  static constexpr int max_cp_entries_other_overpass = 4;
+  // This is a conservative estimation of the length of the comparable part: its
+  // actual length is not less than this
+  const int comparable_cp_length = MAX2(0, cp1.length() - (num_overpasses >= 1 ? max_cp_entries_first_overpass : 0)
+                                                        - (num_overpasses >= 2 ? max_cp_entries_second_overpass : 0)
+                                                        - MAX2(0, num_overpasses - 2) * max_cp_entries_other_overpass);
+
+  for (int i = 1; i < comparable_cp_length; i++) {
+    // Compare resolved and unresolved versions of the same tag as equal since
+    // the version re-created from the dump may have more entries resolved than
+    // the pre-defined one (or vise versa)
+    assert(cp1.tag_at(i).external_value() == cp2.tag_at(i).external_value(),
+           "incompatible constant pool tags at slot #%i: %s and %s",
+           i, cp1.tag_at(i).internal_name(), cp2.tag_at(i).internal_name());
+  }
+}
+
+static void assert_fields_match(const InstanceKlass &ik1, const InstanceKlass &ik2) {
+  AllFieldStream fs1(&ik1);
+  AllFieldStream fs2(&ik2);
+  assert(fs1.num_total_fields() == fs2.num_total_fields(), "number of fields differs: %i != %i",
+         fs1.num_total_fields(), fs2.num_total_fields());
+  for (; !fs1.done() && !fs2.done(); fs1.next(), fs2.next()) {
+    assert(fs1.index() == fs2.index(), "must be");
+    assert(fs1.name() == fs2.name() && fs1.signature() == fs2.signature(), "field %i differs: %s %s and %s %s",
+           fs1.index(), fs1.signature()->as_C_string(), fs1.name()->as_C_string(), fs2.signature()->as_C_string(), fs2.name()->as_C_string());
+    assert(fs1.access_flags().get_flags() == fs2.access_flags().get_flags(), "different access flags of field %i: " INT32_FORMAT_X " != " INT32_FORMAT_X,
+           fs1.index(), fs1.access_flags().get_flags(), fs2.access_flags().get_flags());
+    assert(fs1.field_flags().as_uint() == fs2.field_flags().as_uint(), "different internal flags of field %i (%s %s): " UINT32_FORMAT_X " != " UINT32_FORMAT_X,
+           fs1.index(), fs1.signature()->as_C_string(), fs1.name()->as_C_string(), fs1.field_flags().as_uint(), fs2.field_flags().as_uint());
+  }
+  postcond(fs1.done() && fs2.done());
+}
+
+static void assert_methods_match(const InstanceKlass &ik1, const InstanceKlass &ik2) {
+  const Array<Method *> &methods1 = *ik1.methods();
+  const Array<Method *> &methods2 = *ik2.methods();
+  assert(methods1.length() == methods2.length(), "number of methods differs: %i != %i",
+         methods1.length(), methods2.length());
+  for (int i = 0; i < methods1.length(); i++) {
+    const Method &method1 = *methods1.at(i);
+    // Cannot just get by index because the order of methods with the same name may differ
+    const Method *method2 = ik2.find_local_method(method1.name(), method1.signature(),
+                                                  method1.is_overpass() ? Klass::OverpassLookupMode::find : Klass::OverpassLookupMode::skip,
+                                                  method1.is_static() ? Klass::StaticLookupMode::find : Klass::StaticLookupMode::skip,
+                                                  Klass::PrivateLookupMode::find);
+    assert(method2 != nullptr, "%s not found in the second class", method1.name_and_sig_as_C_string());
+    assert(method1.access_flags().get_flags() == method2->access_flags().get_flags(), "different flags of method %s: " INT32_FORMAT_X " != " INT32_FORMAT_X,
+           method1.name_and_sig_as_C_string(), method1.access_flags().get_flags(), method2->access_flags().get_flags());
+  }
+}
+
+#endif // ASSERT
 
 static void move_constant_pool_cache(ConstantPool *from, ConstantPool *to) {
   guarantee(to->cache() == nullptr, "destination class already has a constant pool cache");
   guarantee(from->length() == to->length(), "not the same class");
-#ifdef ASSERT
-  for (int i = 1; i < from->length(); i++) {
-    assert(from->tag_at(i).external_value() == to->tag_at(i).external_value(),
-           "incompatible constant pool tags at slot #%i: %s and %s",
-           i, from->tag_at(i).internal_name(), to->tag_at(i).internal_name());
-  }
-#endif // ASSERT
   ConstantPoolCache *const cache = from->cache();
   to->set_cache(cache);
   cache->set_constant_pool(to);
@@ -48,10 +144,9 @@ static void swap_methods(InstanceKlass *ik1, InstanceKlass *ik2) {
   for (int i = 0; i < methods1->length(); i++) {
     Method *const method1 = methods1->at(i); // Moving from ik1 into ik2
     Method *const method2 = methods2->at(i); // Moving from ik2 into ik1
-    guarantee(method1->name_index() == method2->name_index() && method1->signature_index() == method2->signature_index(),
-              "not the same method: %s and %s", method1->name_and_sig_as_C_string(), method2->name_and_sig_as_C_string());
-    assert(method1->name() == method2->name() && method1->signature() == method2->signature(), // Checks the actual CP contents
-           "not the same method: %s and %s", method1->name_and_sig_as_C_string(), method2->name_and_sig_as_C_string());
+    // Can only compare names because methods with equal names can be reordered
+    assert(method1->name() == method2->name(), "method #%i of %s has different names: %s and %s",
+           i, ik1->external_name(), method1->name()->as_C_string(), method2->name()->as_C_string());
     method1->set_constants(ik2->constants());
     method2->set_constants(ik1->constants());
   }
@@ -69,9 +164,15 @@ InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *creat
 
   const bool was_predefined = defined_ik != created_ik;
   assert(!(was_predefined && defined_ik->is_being_restored()), "pre-defined classes must be unmarked");
-  // TODO We assume the pre-defined class was created from the same class file
-  //  as the freshly created class was which may not be true. E.g. it could've
-  //  been redefined or just loaded from a different class file.
+  if (was_predefined) {
+    if (log_is_enabled(Debug, crac, class)) {
+      ResourceMark rm;
+      log_debug(crac, class)("Using pre-defined version of %s", defined_ik->external_name());
+    }
+    DEBUG_ONLY(assert_constants_match(*created_ik->constants(), *defined_ik->constants()));
+    DEBUG_ONLY(assert_fields_match(*created_ik, *defined_ik));
+    DEBUG_ONLY(assert_methods_match(*created_ik, *defined_ik));
+  }
 
   // Ensure the class won't be used by other threads until it is restored. We do
   // this even if the class was only loaded at the dump time to be able to set
@@ -151,10 +252,26 @@ InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *creat
   return defined_ik;
 }
 
+static Method *find_possibly_sig_poly_method(InstanceKlass *holder, Symbol *name, Symbol *signature, CracClassDump::MethodKind kind, TRAPS) {
+  precond(holder != nullptr);
+  if (MethodHandles::is_signature_polymorphic_intrinsic_name(holder, name)) {
+    // Signature polymorphic methods' specializations are dynamically generated,
+    // but we only need to treat the basic (non-generic, intrinsic) ones
+    // specially because the rest are generated as classes that should be in the
+    // dump
+    return LinkResolver::resolve_intrinsic_polymorphic_method(holder, name, signature, THREAD);
+  }
+  return holder->find_local_method(name, signature,
+                                   CracClassDump::as_overpass_lookup_mode(kind),
+                                   CracClassDump::as_static_lookup_mode(kind),
+                                   Klass::PrivateLookupMode::find);
+}
+
 void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
+                                                        const ParsedHeapDump &heap_dump,
                                                         const HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> &iks,
                                                         const HeapDumpTable<ArrayKlass *, AnyObj::C_HEAP> &aks,
-                                                        const InterclassRefs &refs) {
+                                                        const InterclassRefs &refs, TRAPS) {
   if (log_is_enabled(Trace, crac, class)) {
     ResourceMark rm;
     log_trace(crac, class)("Filling interclass references of %s", ik->external_name());
@@ -220,17 +337,19 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
     ResolvedFieldEntry &field_entry = *cp_cache.resolved_field_entry_at(field_ref.index);
     field_entry.fill_in_holder(*holder);
   }
-  for (const InterclassRefs::MethodRefs &method_ref : *refs.method_refs) {
+  for (const InterclassRefs::MethodRef &method_ref : *refs.method_refs) {
     ConstantPoolCacheEntry &cache_entry = *cp_cache.entry_at(method_ref.cache_index);
     if (method_ref.f1_class_id != HeapDump::NULL_ID) {
       InstanceKlass **const holder = iks.get(method_ref.f1_class_id);
-      guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by field 1 of resolved method entry #%i of %s",
+      guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by f1 in resolved method entry #%i of %s",
                 method_ref.f1_class_id, method_ref.cache_index, ik->external_name());
       if (method_ref.f1_is_method) {
-        Method *const method = (*holder)->method_with_idnum(method_ref.f1_method_idnum);
-        guarantee(method != nullptr, "class %s has resolved method entry #%i with field 1 referencing method with ID %i of %s "
-                  "but the latter does not have such method", ik->external_name(), method_ref.cache_index,
-                  method_ref.f1_method_idnum, (*holder)->external_name());
+        Symbol *const name = heap_dump.get_symbol(method_ref.f1_method_desc.name_id);
+        Symbol *const sig = heap_dump.get_symbol(method_ref.f1_method_desc.sig_id);
+        Method *const method = find_possibly_sig_poly_method(*holder, name, sig, method_ref.f1_method_desc.kind, CHECK);
+        guarantee(method != nullptr, "class %s has a resolved method entry #%i with f1 referencing %s method %s that cannot be found",
+                  ik->external_name(), method_ref.cache_index, CracClassDump::method_kind_name(method_ref.f1_method_desc.kind),
+                  Method::name_and_sig_as_C_string(*holder, name, sig));
         cache_entry.set_f1(method);
       } else {
         cache_entry.set_f1(*holder);
@@ -238,12 +357,14 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
     }
     if (method_ref.f2_class_id != HeapDump::NULL_ID) {
       InstanceKlass **const holder = iks.get(method_ref.f2_class_id);
-      guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by field 2 of resolved method entry #%i of %s",
+      guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by f2 in resolved method entry #%i of %s",
                 method_ref.f2_class_id, method_ref.cache_index, ik->external_name());
-      Method *const method = (*holder)->method_with_idnum(method_ref.f2_method_idnum);
-      guarantee(method != nullptr, "class %s has resolved method entry #%i with field 2 referencing method with ID %i of %s "
-                "but the latter does not have such method", ik->external_name(), method_ref.cache_index,
-                method_ref.f2_method_idnum, (*holder)->external_name());
+      Symbol *const name = heap_dump.get_symbol(method_ref.f2_method_desc.name_id);
+      Symbol *const sig = heap_dump.get_symbol(method_ref.f2_method_desc.sig_id);
+      Method *const method = find_possibly_sig_poly_method(*holder, name, sig, method_ref.f2_method_desc.kind, CHECK);
+      guarantee(method != nullptr, "class %s has a resolved method entry #%i with f2 referencing %s method %s that cannot be found",
+                ik->external_name(), method_ref.cache_index, CracClassDump::method_kind_name(method_ref.f2_method_desc.kind),
+                Method::name_and_sig_as_C_string(*holder, name, sig));
       cache_entry.set_f2(reinterpret_cast<intx>(method));
     }
   }
@@ -251,10 +372,15 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
     InstanceKlass **const holder = iks.get(indy_ref.holder_id);
     guarantee(holder != nullptr, "unknown class " HDID_FORMAT " referenced by resolved invokedynamic entry #%i of %s",
               indy_ref.holder_id, indy_ref.indy_index, ik->external_name());
-    Method *const method = (*holder)->method_with_idnum(indy_ref.method_idnum);
-    guarantee(method != nullptr, "class %s has resolved invokedynamic entry #%i referencing method with ID %i of %s "
-              "but the latter does not have such method", ik->external_name(), indy_ref.indy_index,
-              indy_ref.method_idnum, (*holder)->external_name());
+    Symbol *const name = heap_dump.get_symbol(indy_ref.method_desc.name_id);
+    Symbol *const sig = heap_dump.get_symbol(indy_ref.method_desc.sig_id);
+    Method *const method = (*holder)->find_local_method(name, sig,
+                                                        CracClassDump::as_overpass_lookup_mode(indy_ref.method_desc.kind),
+                                                        CracClassDump::as_static_lookup_mode(indy_ref.method_desc.kind),
+                                                        Klass::PrivateLookupMode::find);
+    guarantee(method != nullptr, "class %s has a resolved invokedynamic entry #%i referencing %s method %s that cannot be found",
+              ik->external_name(), indy_ref.indy_index, CracClassDump::method_kind_name(indy_ref.method_desc.kind),
+              Method::name_and_sig_as_C_string(*holder, name, sig));
     ResolvedIndyEntry &indy_entry = *cp_cache.resolved_indy_entry_at(indy_ref.indy_index);
     indy_entry.adjust_method_entry(method);
   }

--- a/src/hotspot/share/runtime/cracClassStateRestorer.hpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.hpp
@@ -1,0 +1,62 @@
+#ifndef SHARE_UTILITIES_CRACCLASSSTATERESTORER_HPP
+#define SHARE_UTILITIES_CRACCLASSSTATERESTORER_HPP
+
+#include "memory/allStatic.hpp"
+#include "memory/allocation.hpp"
+#include "oops/arrayKlass.hpp"
+#include "oops/instanceKlass.hpp"
+#include "utilities/exceptions.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/growableArray.hpp"
+#include "utilities/heapDumpParser.hpp"
+
+// Class may reference other classes and while the class dump format guarantees
+// that some of such references (class loader class, super class, etc.) will be
+// created before the class itself, there is no such guarantee for all class
+// references (since there may be cycles). Thus some interclass references can
+// only be filled-in after all classes have been created.
+struct InterclassRefs : public ResourceObj {
+  // Restoring just the constant pool reference to the nest host is insufficient
+  // if it is a dynamic nest host which does not come from the constant pool
+  HeapDump::ID dynamic_nest_host;
+
+  struct ClassRef {
+    u2 index;                     // Contents depend on the context (see below)
+    HeapDump::ID class_id;
+  };
+  struct MethodRefs {
+    int cache_index;
+    bool f1_is_method;
+    HeapDump::ID f1_class_id;     // Null ID if unset
+    u2 f1_method_idnum;           // Undefined if f1_is_method == false
+    HeapDump::ID f2_class_id;     // Null ID if unset
+    u2 f2_method_idnum;           // Undefined if f2_class_id is unset
+  };
+  struct IndyAdapterRef {
+    int indy_index;
+    HeapDump::ID holder_id;
+    u2 method_idnum;
+  };
+
+  // Constant pool class references. Index is the constant pool index.
+  GrowableArray<ClassRef> *cp_class_refs = new GrowableArray<ClassRef>();
+  // Holders of resolved fields. Index is the resolved fields index.
+  GrowableArray<ClassRef> *field_refs = new GrowableArray<ClassRef>();
+  // Class/method references from resolved methods.
+  GrowableArray<MethodRefs> *method_refs = new GrowableArray<MethodRefs>();
+  // Adapter method references from resolved invokedynamics.
+  GrowableArray<IndyAdapterRef> *indy_refs = new GrowableArray<IndyAdapterRef>();
+};
+
+struct CracClassStateRestorer : public AllStatic {
+  // Defines the class and brings it up to the requested state.
+  static void apply_state(InstanceKlass *ik, InstanceKlass::ClassState state, TRAPS);
+  // Fills the specified interclass references of the class.
+  static void fill_interclass_references(InstanceKlass *ik,
+                                         const HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> &iks,
+                                         const HeapDumpTable<ArrayKlass *, AnyObj::C_HEAP> &aks,
+                                         const InterclassRefs &refs);
+  static void fill_initialization_error(InstanceKlass *ik, Handle error);
+};
+
+#endif // SHARE_UTILITIES_CRACCLASSSTATERESTORER_HPP

--- a/src/hotspot/share/runtime/cracHeapRestorer.cpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.cpp
@@ -1,0 +1,1075 @@
+#include "precompiled.hpp"
+#include "classfile/javaClasses.hpp"
+#include "classfile/systemDictionary.hpp"
+#include "classfile/vmClasses.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "logging/log.hpp"
+#include "memory/oopFactory.hpp"
+#include "memory/resourceArea.hpp"
+#include "oops/arrayKlass.hpp"
+#include "oops/instanceKlass.hpp"
+#include "oops/instanceKlass.inline.hpp"
+#include "oops/oopsHierarchy.hpp"
+#include "oops/symbol.hpp"
+#include "runtime/cracClassDumpParser.hpp"
+#include "runtime/cracClassStateRestorer.hpp"
+#include "runtime/cracHeapRestorer.hpp"
+#include "runtime/cracStackDumpParser.hpp"
+#include "runtime/handles.hpp"
+#include "runtime/jniHandles.hpp"
+#include "runtime/jniHandles.inline.hpp"
+#include "runtime/reflectionUtils.hpp"
+#include "runtime/signature.hpp"
+#include "runtime/thread.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/exceptions.hpp"
+#include "utilities/formatBuffer.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/growableArray.hpp"
+#include "utilities/heapDumpClasses.hpp"
+#include "utilities/heapDumpParser.hpp"
+#include "utilities/hprofTag.hpp"
+#include "utilities/macros.hpp"
+
+// #############################################################################
+// WellKnownObjects implementation
+// #############################################################################
+
+void WellKnownObjects::find_well_known_class_loaders(const ParsedHeapDump &heap_dump, TRAPS) {
+  heap_dump.load_classes.iterate([&](HeapDump::ID _, const HeapDump::LoadClass &lc) -> bool {
+    const Symbol *name = heap_dump.get_symbol(lc.class_name_id);
+    if (name == vmSymbols::jdk_internal_loader_ClassLoaders()) {
+      lookup_builtin_class_loaders(heap_dump, lc);
+    } else if (name == vmSymbols::java_lang_ClassLoader()) {
+      lookup_actual_system_class_loader(heap_dump, lc);
+    }
+    return (_platform_loader_id == HeapDump::NULL_ID && _builtin_system_loader_id == HeapDump::NULL_ID) ||
+           _actual_system_loader_id == HeapDump::NULL_ID;
+  });
+
+  const bool platform_found = _platform_loader_id != HeapDump::NULL_ID;
+  const bool builtin_sys_found = _builtin_system_loader_id != HeapDump::NULL_ID;
+  const bool actual_sys_found = _actual_system_loader_id != HeapDump::NULL_ID;
+  guarantee(!actual_sys_found || (platform_found && builtin_sys_found),
+            "system class loader cannot be present when built-in class loaders are absent");
+  guarantee(!builtin_sys_found || platform_found,
+            "built-in system class loader cannot be present when the platform class loader is absent");
+  guarantee(!platform_found || (_platform_loader_id != _builtin_system_loader_id &&
+                                _platform_loader_id != _actual_system_loader_id),
+            "platform and system class loaders cannot be the same instance");
+
+  // If there is a diviation, abort the restoration
+  if (builtin_sys_found && SystemDictionary::java_system_loader() != nullptr) {
+    const bool is_dumped_actual_sys_builtin = _builtin_system_loader_id == _actual_system_loader_id;
+    const bool is_current_actual_sys_builtin = SystemDictionary::java_system_loader()->klass() == vmClasses::jdk_internal_loader_ClassLoaders_AppClassLoader_klass();
+    if (is_dumped_actual_sys_builtin != is_current_actual_sys_builtin) {
+      THROW_MSG(vmSymbols::java_lang_UnsupportedOperationException(),
+                err_msg("Dumped system class loader is%s the built-in one while in the current VM it is%s",
+                        is_dumped_actual_sys_builtin ? "" : " not", is_current_actual_sys_builtin ? "" : " not"));
+    }
+  }
+
+  log_info(crac)("Found well known class loaders' IDs: platform - "         HDID_FORMAT ", "
+                                                      "built-in system - "  HDID_FORMAT ", "
+                                                      "actual system - "    HDID_FORMAT,
+                 _platform_loader_id, _builtin_system_loader_id, _actual_system_loader_id);
+}
+
+// This relies on the ClassLoader.get*ClassLoader() implementation detail: the
+// built-in platform and system class loaders are stored in
+// PLATFORM_LOADER/APP_LOADER static fields of jdk.internal.loader.ClassLoaders.
+void WellKnownObjects::lookup_builtin_class_loaders(const ParsedHeapDump &heap_dump,
+                                                    const HeapDump::LoadClass &jdk_internal_loader_ClassLoaders) {
+  static constexpr char PLATFORM_LOADER_FIELD_NAME[] = "PLATFORM_LOADER";
+  static constexpr char APP_LOADER_FIELD_NAME[] = "APP_LOADER";
+  precond(heap_dump.get_symbol(jdk_internal_loader_ClassLoaders.class_name_id) ==
+          vmSymbols::jdk_internal_loader_ClassLoaders());
+
+  // We have a jdk.internal.loader.ClassLoaders but is this the internal one (i.e. boot-loaded)?
+  const HeapDump::ClassDump &dump = heap_dump.get_class_dump(jdk_internal_loader_ClassLoaders.class_id);
+  if (dump.class_loader_id != HeapDump::NULL_ID) {
+    return;
+  }
+  // From now on we know we have THE jdk.internal.loader.ClassLoaders
+
+  guarantee(_platform_loader_id == HeapDump::NULL_ID && _builtin_system_loader_id == HeapDump::NULL_ID,
+            "class %s dumped multiple times", vmSymbols::jdk_internal_loader_ClassLoaders()->as_klass_external_name());
+  for (u2 i = 0; i < dump.static_fields.size(); i++) {
+    const HeapDump::ClassDump::Field &field_dump = dump.static_fields[i];
+    if (field_dump.info.type != HPROF_NORMAL_OBJECT) {
+      continue;
+    }
+    const Symbol *field_name = heap_dump.get_symbol(field_dump.info.name_id);
+    if (field_name->equals(PLATFORM_LOADER_FIELD_NAME)) {
+      guarantee(_platform_loader_id == HeapDump::NULL_ID,
+                "static field %s is repeated in %s dump " HDID_FORMAT, PLATFORM_LOADER_FIELD_NAME,
+                vmClasses::jdk_internal_loader_ClassLoaders_klass()->external_name(), dump.id);
+      _platform_loader_id = field_dump.value.as_object_id;       // Can be null if VM was dumped before initializing it
+    } else if (field_name->equals(APP_LOADER_FIELD_NAME)) {
+      guarantee(_builtin_system_loader_id == HeapDump::NULL_ID,
+                "static field %s is repeated in %s dump " HDID_FORMAT, APP_LOADER_FIELD_NAME,
+                vmClasses::jdk_internal_loader_ClassLoaders_klass()->external_name(), dump.id);
+      _builtin_system_loader_id = field_dump.value.as_object_id; // Can be null if VM was dumped before initializing it
+    }
+  }
+}
+
+// This relies on ClassLoader.getSystemClassLoader() implementation detail: the
+// actual system class loader is stored in "scl" static field of j.l.ClassLoader.
+void WellKnownObjects::lookup_actual_system_class_loader(const ParsedHeapDump &heap_dump,
+                                                         const HeapDump::LoadClass &java_lang_ClassLoader) {
+  static constexpr char SCL_FIELD_NAME[] = "scl";
+  precond(heap_dump.get_symbol(java_lang_ClassLoader.class_name_id) == vmSymbols::java_lang_ClassLoader());
+
+  // We know we have THE j.l.ClassLoader because classes from java.* packages cannot be non-boot-loaded
+  const HeapDump::ClassDump &dump = heap_dump.get_class_dump(java_lang_ClassLoader.class_id);
+  guarantee(dump.class_loader_id == HeapDump::NULL_ID, "class %s can only be loaded by the bootstrap class loader",
+            vmSymbols::java_lang_ClassLoader()->as_klass_external_name());
+
+  guarantee(_actual_system_loader_id == HeapDump::NULL_ID, "class %s dumped multiple times",
+            vmSymbols::java_lang_ClassLoader()->as_klass_external_name());
+  for (u2 i = 0; i < dump.static_fields.size(); i++) {
+    const HeapDump::ClassDump::Field &field_dump = dump.static_fields[i];
+    if (field_dump.info.type != HPROF_NORMAL_OBJECT) {
+      continue;
+    }
+    const Symbol *field_name = heap_dump.get_symbol(field_dump.info.name_id);
+    if (field_name->equals(SCL_FIELD_NAME)) {
+      guarantee(_actual_system_loader_id == HeapDump::NULL_ID, "static field %s is repeated in %s dump " HDID_FORMAT,
+                SCL_FIELD_NAME, vmSymbols::java_lang_ClassLoader()->as_klass_external_name(), dump.id);
+      _actual_system_loader_id = field_dump.value.as_object_id; // Can be null if VM was dumped before initializing it
+    }
+  }
+}
+
+static oop get_builtin_system_loader() {
+  // SystemDictionary::java_system_loader() gives the actual system loader which
+  // is not necessarily the built-in one
+  const oop loader = SystemDictionary::java_system_loader();
+  if (loader != nullptr &&
+      loader->klass() != vmClasses::jdk_internal_loader_ClassLoaders_AppClassLoader_klass()) {
+    // TODO need to call into Java (ClassLoaders.appClassLoader()) or retrieve
+    // the oop from ClassLoaders::APP_LOADER manually
+    log_error(crac)("User-provided system class loader is not supported yet");
+    Unimplemented();
+  }
+  return loader;
+}
+
+void WellKnownObjects::put_into(HeapDumpTable<jobject, AnyObj::C_HEAP> *objects) const {
+  precond(objects->number_of_entries() == 0);
+  Thread *const thread = JavaThread::current();
+  if (_platform_loader_id != HeapDump::NULL_ID) {
+    const oop loader = SystemDictionary::java_platform_loader();
+    if (loader != nullptr) {
+      guarantee(loader->klass() == vmClasses::jdk_internal_loader_ClassLoaders_PlatformClassLoader_klass(), "sanity check");
+      const jobject loader_h = JNIHandles::make_global(Handle(thread, loader));
+      objects->put_when_absent(_platform_loader_id, loader_h);
+    }
+  }
+  if (_builtin_system_loader_id != HeapDump::NULL_ID) {
+    const oop loader = get_builtin_system_loader();
+    if (loader != nullptr) {
+      const jobject loader_h = JNIHandles::make_global(Handle(thread, loader));
+      objects->put_when_absent(_builtin_system_loader_id, loader_h);
+    }
+  }
+  if (_actual_system_loader_id != HeapDump::NULL_ID && _actual_system_loader_id != _builtin_system_loader_id) {
+    const oop loader = SystemDictionary::java_system_loader();
+    if (loader != nullptr) {
+      const jobject loader_h = JNIHandles::make_global(Handle(thread, loader));
+      objects->put_when_absent(_builtin_system_loader_id, loader_h);
+    }
+  }
+  objects->maybe_grow();
+}
+
+void WellKnownObjects::get_from(const HeapDumpTable<jobject, AnyObj::C_HEAP> &objects) const {
+  if (_platform_loader_id != HeapDump::NULL_ID) {
+    const jobject *restored = objects.get(_platform_loader_id);
+    if (restored != nullptr) {
+      const oop existing = SystemDictionary::java_platform_loader();
+      if (existing != nullptr) {
+        guarantee(JNIHandles::resolve_non_null(*restored) == existing,
+                  "restored platform loader must be the existing one");
+      } else {
+        log_error(crac)("Restoration of base class loaders is not implemented");
+        Unimplemented();
+      }
+    }
+  }
+  if (_builtin_system_loader_id != HeapDump::NULL_ID) {
+    const jobject *restored = objects.get(_builtin_system_loader_id);
+    if (restored != nullptr) {
+      const oop existing = get_builtin_system_loader();
+      if (existing != nullptr) {
+        guarantee(JNIHandles::resolve_non_null(*restored) == existing,
+                  "restored builtin system loader must be the existing one");
+      } else {
+        log_error(crac)("Restoration of base class loaders is not implemented");
+        Unimplemented();
+      }
+    }
+  }
+  if (_actual_system_loader_id != HeapDump::NULL_ID) {
+    const jobject *restored = objects.get(_actual_system_loader_id);
+    if (restored != nullptr) {
+      const oop existing = SystemDictionary::java_system_loader();
+      if (existing != nullptr) {
+        guarantee(JNIHandles::resolve_non_null(*restored) == existing,
+                  "restored actual system loader must be the existing one");
+      } else {
+        log_error(crac)("Restoration of base class loaders is not implemented");
+        Unimplemented();
+      }
+    }
+  }
+}
+
+// #############################################################################
+// CracHeapRestorer implementation
+// #############################################################################
+
+// Helpers
+
+InstanceKlass &CracHeapRestorer::get_instance_class(HeapDump::ID id) const {
+  InstanceKlass **const ik_ptr = _instance_classes.get(id);
+  guarantee(ik_ptr != nullptr, "unknown instance class " HDID_FORMAT " referenced", id);
+  assert(*ik_ptr != nullptr, "must be");
+  return **ik_ptr;
+}
+
+ArrayKlass &CracHeapRestorer::get_array_class(HeapDump::ID id) const {
+  ArrayKlass **const ak_ptr = _array_classes.get(id);
+  guarantee(ak_ptr != nullptr, "unknown array class " HDID_FORMAT " referenced", id);
+  assert(*ak_ptr != nullptr, "must be");
+  return **ak_ptr;
+}
+
+oop CracHeapRestorer::get_object_when_present(HeapDump::ID id) const {
+  assert(id != HeapDump::NULL_ID, "nulls are not recorded");
+  assert(_objects.contains(id), "object " HDID_FORMAT " was expected to be recorded", id);
+  return JNIHandles::resolve_non_null(*_objects.get(id));
+}
+
+oop CracHeapRestorer::get_object_if_present(HeapDump::ID id) const {
+  assert(id != HeapDump::NULL_ID, "nulls are not recorded");
+  const jobject *obj_h = _objects.get(id);
+  return obj_h != nullptr ? JNIHandles::resolve_non_null(*obj_h) : nullptr;
+}
+
+jobject CracHeapRestorer::put_object_when_absent(HeapDump::ID id, Handle obj) {
+  assert(id != HeapDump::NULL_ID && obj.not_null(), "nulls should not be recorded");
+  assert(!_objects.contains(id), "object " HDID_FORMAT " was expected to be absent", id);
+  const jobject h = JNIHandles::make_global(obj);
+  _objects.put_when_absent(id, h);
+  _objects.maybe_grow();
+  return h;
+}
+
+jobject CracHeapRestorer::put_object_when_absent(HeapDump::ID id, oop obj) {
+  return put_object_when_absent(id, Handle(Thread::current(), obj));
+}
+
+jobject CracHeapRestorer::put_object_if_absent(HeapDump::ID id, Handle obj) {
+  assert(id != HeapDump::NULL_ID && obj.not_null(), "nulls should not be recorded");
+  bool is_absent;
+  jobject *const node = _objects.put_if_absent(id, &is_absent);
+  if (is_absent) {
+    // Only allocate JNI handle if will record: it must be freed
+    *node = JNIHandles::make_global(obj);
+    _objects.maybe_grow();
+  } else {
+    assert(JNIHandles::resolve(*node) == obj(), "two different objects restored for ID " HDID_FORMAT, id);
+  }
+  return *node;
+}
+
+jobject CracHeapRestorer::put_object_if_absent(HeapDump::ID id, oop obj) {
+  assert(id != HeapDump::NULL_ID && obj != nullptr, "nulls should not be recorded");
+  bool is_absent;
+  jobject *const node = _objects.put_if_absent(id, &is_absent);
+  if (is_absent) {
+    // Only allocate JNI handle if will record: it must be freed, also don't
+    // create a usual handle if it won't be used
+    *node = JNIHandles::make_global(Handle(Thread::current(), obj));
+    _objects.maybe_grow();
+  } else {
+    guarantee(JNIHandles::resolve(*node) == obj, "two different objects restored for ID " HDID_FORMAT, id);
+  }
+  return *node;
+}
+
+#ifdef ASSERT
+static void assert_builtin_class_instance(const ParsedHeapDump &heap_dump, HeapDump::ID obj_id,
+                                          const Symbol *expected_class_name)  {
+  precond(obj_id != HeapDump::NULL_ID);
+  const HeapDump::InstanceDump &dump = heap_dump.get_instance_dump(obj_id);
+  const Symbol *class_name = heap_dump.get_class_name(dump.class_id);
+  const HeapDump::ID &class_loader_id = heap_dump.get_class_dump(dump.class_id).class_loader_id;
+  assert(class_name == expected_class_name && class_loader_id == HeapDump::NULL_ID,
+         "expected object " HDID_FORMAT " to be of the boot-loaded class %s but its class is %s loaded by " HDID_FORMAT,
+         obj_id, expected_class_name->as_klass_external_name(), class_name->as_klass_external_name(), class_loader_id);
+}
+#endif // ASSERT
+
+// Class loader preparation
+
+instanceHandle CracHeapRestorer::get_class_loader_parent(const HeapDump::InstanceDump &loader_dump, TRAPS) {
+  const HeapDump::ID parent_id = _loader_dump_reader.parent(loader_dump);
+  guarantee(parent_id != loader_dump.id, "class loader hierarchy circularity: "
+            HDID_FORMAT " references itself as its parent", loader_dump.id);
+  const instanceHandle loader = get_class_loader(parent_id, CHECK_({}));
+  return loader;
+}
+
+instanceHandle CracHeapRestorer::get_class_loader_name(const HeapDump::InstanceDump &loader_dump, bool with_id, TRAPS) {
+  const HeapDump::ID name_id = with_id ? _loader_dump_reader.nameAndId(loader_dump) : _loader_dump_reader.name(loader_dump);
+  if (name_id == HeapDump::NULL_ID) {
+    return {};
+  }
+  DEBUG_ONLY(assert_builtin_class_instance(_heap_dump, name_id, vmSymbols::java_lang_String()));
+
+  const Handle &str = restore_object(name_id, CHECK_({}));
+  guarantee(str->klass() == vmClasses::String_klass(), "class loader " HDID_FORMAT " has its '%s' field referencing a %s "
+            "but it must reference a %s", loader_dump.id, with_id ? "nameAndId" : "name",
+            str->klass()->external_name(), vmSymbols::java_lang_String()->as_klass_external_name());
+
+  return static_cast<const instanceHandle &>(str);
+}
+
+instanceHandle CracHeapRestorer::get_class_loader_unnamed_module(const HeapDump::InstanceDump &loader_dump, TRAPS) {
+  const HeapDump::ID unnamed_module_id = _loader_dump_reader.unnamedModule(loader_dump);
+  guarantee(unnamed_module_id != HeapDump::NULL_ID, "class loader " HDID_FORMAT " cannot be used to load classes: "
+            "its 'unnamedModule' field is not set", loader_dump.id);
+  DEBUG_ONLY(assert_builtin_class_instance(_heap_dump, unnamed_module_id, vmSymbols::java_lang_Module()));
+
+  const Handle &unnamed_module = restore_object(unnamed_module_id, CHECK_({}));
+  guarantee(unnamed_module->klass() == vmClasses::Module_klass(),
+            "class loader " HDID_FORMAT " has its 'unnamedModule' field referencing a %s but it must reference a %s",
+            loader_dump.id, unnamed_module->klass()->external_name(), vmSymbols::java_lang_Module()->as_klass_external_name());
+#ifdef ASSERT
+  { // Would be better to check all fields but loader are null and do it before restoring the object, but it's harder
+    assert(java_lang_Module::name(unnamed_module()) == nullptr,
+           "unnamed module of class loader " HDID_FORMAT " is not unnamed", loader_dump.id);
+    const oop loader = get_object_when_present(loader_dump.id);
+    assert(java_lang_Module::loader(unnamed_module()) == loader,
+           "unnamed module of class loader " HDID_FORMAT " belongs to a different class loader", loader_dump.id);
+  }
+#endif // ASSERT
+  return static_cast<const instanceHandle &>(unnamed_module);
+}
+
+instanceHandle CracHeapRestorer::get_class_loader_parallel_lock_map(const HeapDump::InstanceDump &loader_dump, TRAPS) {
+  const HeapDump::ID map_id = _loader_dump_reader.parallelLockMap(loader_dump);
+  if (map_id == HeapDump::NULL_ID) {
+    return {};
+  }
+  DEBUG_ONLY(assert_builtin_class_instance(_heap_dump, map_id, vmSymbols::java_util_concurrent_ConcurrentHashMap()));
+
+  // Check for null above, so it's either already created or we need to create one
+  const oop existing_map = get_object_if_present(map_id);
+  if (existing_map == nullptr) {
+    const instanceHandle map = vmClasses::ConcurrentHashMap_klass()->allocate_instance_handle(CHECK_({}));
+    put_object_when_absent(map_id, map);
+    return map;
+  }
+  guarantee(existing_map->klass() == vmClasses::ConcurrentHashMap_klass(),
+            "class loader " HDID_FORMAT " has its 'parallelLockMap' field referencing a %s but it must reference a %s",
+            loader_dump.id, existing_map->klass()->external_name(), vmClasses::ConcurrentHashMap_klass()->external_name());
+  return {Thread::current(), static_cast<instanceOop>(existing_map)};
+}
+
+// Allocates class loader and restores fields the VM may use for class loading:
+// - parent -- to set dependent classes, to get non-reflection loader
+// - name and nameAndId -- to create a CLD and print logs/errors
+// - unnamedModule -- used and partially filled when creating the CLD
+// - parallelLockMap -- defines whether the class loader is parallel capable,
+//   only need the null/not-null fact, so no need to restore its state yet
+instanceHandle CracHeapRestorer::prepare_class_loader(HeapDump::ID id, TRAPS) {
+  log_trace(crac)("Preparing class loader " HDID_FORMAT, id);
+  assert(id != HeapDump::NULL_ID, "cannot prepare the bootstrap loader");
+  const HeapDump::InstanceDump &dump = _heap_dump.get_instance_dump(id);
+  _loader_dump_reader.ensure_initialized(_heap_dump, dump.class_id);
+
+  InstanceKlass &loader_klass = get_instance_class(dump.class_id);
+  guarantee(loader_klass.is_class_loader_instance_klass(),
+            "class loader " HDID_FORMAT " is of class %s (" HDID_FORMAT ") "
+            "which does not subclass %s", id, loader_klass.external_name(), dump.class_id,
+            vmSymbols::java_lang_ClassLoader()->as_klass_external_name());
+  guarantee(!loader_klass.should_be_initialized(), "class loader " HDID_FORMAT " cannot be an instance of "
+            "uninitialized class %s (" HDID_FORMAT ")", dump.id, loader_klass.external_name(), dump.class_id);
+  loader_klass.check_valid_for_instantiation(true, CHECK_({}));
+
+  const instanceHandle loader = loader_klass.allocate_instance_handle(CHECK_({}));
+  put_object_when_absent(id, loader); // Must record right now to be able to find it when restoring unnamedModule
+  _prepared_loaders.put_when_absent(id, true);
+  _prepared_loaders.maybe_grow();
+
+  {
+    const instanceHandle parent = get_class_loader_parent(dump, CHECK_({}));
+    java_lang_ClassLoader::set_parent(loader(), parent());
+  }
+  {
+    const instanceHandle name = get_class_loader_name(dump, /* with_id = */ false, CHECK_({}));
+    java_lang_ClassLoader::set_name(loader(), name());
+  }
+  {
+    const instanceHandle name_and_id = get_class_loader_name(dump, /* with_id = */ true, CHECK_({}));
+    java_lang_ClassLoader::set_nameAndId(loader(), name_and_id());
+  }
+  {
+    const instanceHandle unnamedModule = get_class_loader_unnamed_module(dump, CHECK_({}));
+    java_lang_ClassLoader::set_unnamedModule(loader(), unnamedModule());
+  }
+  {
+    const instanceHandle parallel_lock_map = get_class_loader_parallel_lock_map(dump, CHECK_({}));
+    java_lang_ClassLoader::set_parallelLockMap(loader(), parallel_lock_map());
+  }
+
+  if (java_lang_ClassLoader::parallelCapable(loader())) { // Works because we set parallelLockMap above
+    // TODO should add it into ClassLoader$ParallelLoaders::loaderTypes array
+    log_error(crac)("Restoration of parallel-capable class loaders is not implemented");
+    Unimplemented();
+  }
+
+  if (log_is_enabled(Trace, crac)) {
+    ResourceMark rm;
+    log_trace(crac)("Prepared class loader " HDID_FORMAT " (%s)", id, loader->klass()->external_name());
+  }
+  return loader;
+}
+
+instanceHandle CracHeapRestorer::get_class_loader(HeapDump::ID id, TRAPS) {
+  if (id == HeapDump::NULL_ID) {
+    return {}; // Bootstrap loader
+  }
+
+  const oop existing_loader = get_object_if_present(id);
+  if (existing_loader != nullptr) {
+    guarantee(existing_loader->klass()->is_class_loader_instance_klass(),
+              "object " HDID_FORMAT " is not a class loader: its class %s does not subclass %s",
+              id, existing_loader->klass()->external_name(), vmSymbols::java_lang_ClassLoader()->as_klass_external_name());
+    return {Thread::current(), static_cast<instanceOop>(existing_loader)};
+  }
+
+  precond(!_prepared_loaders.contains(id));
+  const instanceHandle loader = prepare_class_loader(id, CHECK_({})); // Allocate and partially restore the loader
+  postcond(_prepared_loaders.contains(id) && get_object_when_present(id) == loader());
+  guarantee(loader.not_null() && loader->klass()->is_class_loader_instance_klass(), "must be a class loader");
+
+  return loader;
+}
+
+// Heap restoration driver
+
+void CracHeapRestorer::restore_heap(const HeapDumpTable<ClassHeapDeps, AnyObj::C_HEAP> &class_heap_deps,
+                                    const GrowableArrayView<StackTrace *> &stack_traces, TRAPS) {
+  log_info(crac)("Started heap restoration");
+  HandleMark hm(Thread::current());
+
+  // Before actually restoring anything, record existing objects so that they
+  // are not re-created
+  // TODO Currently only the mirrors themselves + contents of a few of their
+  //  fields are recorded. Ideally, we should walk recursively and record all
+  //  existing objects so that we don't re-create them, but this should be
+  //  fairly complex since the dumped and the current state may not match.
+  _heap_dump.class_dumps.iterate([&](HeapDump::ID _, const HeapDump::ClassDump &dump) -> bool {
+    find_and_record_java_class(dump, CHECK_false);
+    return true;
+  });
+  if (HAS_PENDING_EXCEPTION) {
+    return;
+  }
+
+  // TODO should also restore array and primitive mirrors?
+  _instance_classes.iterate([&](HeapDump::ID class_id, InstanceKlass *ik) -> bool {
+    if (!ik->is_being_restored()) {
+      return true; // Skip pre-created since they may already have a new state
+    }
+    restore_class_mirror(class_id, CHECK_false);
+    if (ik->is_in_error_state()) {
+      const ClassHeapDeps *deps = class_heap_deps.get(class_id);
+      if (deps != nullptr && deps->class_initialization_error_id != HeapDump::NULL_ID) {
+        const Handle init_error = restore_object(deps->class_initialization_error_id, CHECK_false);
+        guarantee(init_error->is_instance(), "initialization exception " HDID_FORMAT " of class %s is not an instance",
+                  deps->class_initialization_error_id, init_error->klass()->external_name());
+        CracClassStateRestorer::fill_initialization_error(ik, init_error);
+      }
+    }
+    ik->set_is_being_restored(false);
+    return true;
+  });
+  if (HAS_PENDING_EXCEPTION) {
+    return;
+  }
+  guarantee(_prepared_loaders.number_of_entries() == 0, "some prepared class loaders have not defined any classes");
+
+  for (const auto *trace : stack_traces) {
+    for (u4 i = 0; i < trace->frames_num(); i++) {
+      const StackTrace::Frame &frame = trace->frames(i);
+      for (u2 j = 0; j < frame.locals.size(); j++) {
+        const StackTrace::Frame::Value &value = frame.locals[j];
+        if (value.type == DumpedStackValueType::REFERENCE) {
+          restore_object(value.obj_id, CHECK);
+        }
+      }
+      for (u2 j = 0; j < frame.operands.size(); j++) {
+        const StackTrace::Frame::Value &value = frame.operands[j];
+        if (value.type == DumpedStackValueType::REFERENCE) {
+          restore_object(value.obj_id, CHECK);
+        }
+      }
+    }
+  }
+
+  _well_known_objects.get_from(_objects);
+  log_info(crac)("Finished heap restoration");
+}
+
+// Recording of existing objects
+
+// Finds j.l.Class object corresponding to the class dump and records it.
+void CracHeapRestorer::find_and_record_java_class(const HeapDump::ClassDump &class_dump, TRAPS) {
+  Thread *const current = Thread::current();
+
+  const HeapDump::InstanceDump &mirror_dump = _heap_dump.get_instance_dump(class_dump.id);
+  _mirror_dump_reader.ensure_initialized(_heap_dump, mirror_dump.class_id);
+  using MirrorType = HeapDumpClasses::java_lang_Class::Kind;
+  switch (_mirror_dump_reader.kind(mirror_dump)) {
+    case MirrorType::INSTANCE: {
+      const InstanceKlass &ik = get_instance_class(class_dump.id);
+      const instanceHandle mirror(current, static_cast<instanceOop>(ik.java_mirror()));
+      record_java_class(mirror, mirror_dump, CHECK);
+      break;
+    }
+    case MirrorType::ARRAY: {
+      const ArrayKlass &ak = get_array_class(class_dump.id);
+      const instanceHandle mirror(current, static_cast<instanceOop>(ak.java_mirror()));
+      record_java_class(mirror, mirror_dump, CHECK);
+
+      // Primitive mirrors are also recorded here because they don't have a
+      // Klass to be dumped with directly but always have a TypeArrayKlass
+      if (ak.is_typeArray_klass()) {
+        const oop prim_mirror_obj = java_lang_Class::component_mirror(mirror());
+        assert(prim_mirror_obj != nullptr, "type array's mirror must have a component mirror");
+        const instanceHandle prim_mirror(current, static_cast<instanceOop>(prim_mirror_obj));
+
+        const HeapDump::ID prim_mirror_dump_id = _mirror_dump_reader.componentType(mirror_dump);
+        guarantee(prim_mirror_dump_id != HeapDump::NULL_ID, "primitive array " HDID_FORMAT " has no component type",
+                  prim_mirror_dump_id);
+        const HeapDump::InstanceDump &prim_mirror_dump = _heap_dump.get_instance_dump(prim_mirror_dump_id);
+
+        record_java_class(prim_mirror, prim_mirror_dump, CHECK);
+      }
+      break;
+    }
+    case MirrorType::PRIMITIVE:
+      // Class dumps are only created from InstanceKlasses and ArrayKlasses
+      guarantee(false, "instance or array class " HDID_FORMAT " has a primitive type mirror", class_dump.id);
+  }
+}
+
+void CracHeapRestorer::record_java_class(instanceHandle mirror, const HeapDump::InstanceDump &mirror_dump, TRAPS) {
+  precond(!_objects.contains(mirror_dump.id) && mirror.not_null());
+  const jobject recorded_mirror = put_object_when_absent(mirror_dump.id, mirror);
+
+  _mirror_dump_reader.ensure_initialized(_heap_dump, mirror_dump.class_id);
+
+#ifdef ASSERT
+  const HeapDump::ID loader_id = _heap_dump.get_class_dump(mirror_dump.id).class_loader_id;
+  assert(loader_id == HeapDump::NULL_ID || get_object_when_present(loader_id) == java_lang_Class::class_loader(mirror()),
+         "class loader must already be recorded");
+
+  const HeapDump::ID component_mirror_id = _mirror_dump_reader.componentType(mirror_dump);
+  assert(component_mirror_id == HeapDump::NULL_ID || get_object_when_present(component_mirror_id) == java_lang_Class::component_mirror(mirror()),
+         "component mirror must already be recorded");
+#endif
+
+  const HeapDump::ID module_id = _mirror_dump_reader.module(mirror_dump);
+  const oop module_obj = java_lang_Class::module(mirror());
+  assert(module_obj != nullptr, "module must be set");
+  put_object_if_absent(module_id, module_obj); // Can be pre-recorded via another class from this module
+
+  // For classes that are already in use (the pre-created ones) name can be
+  // initialized concurrently, so if it was dumped, initialize and record it
+  // eagerly
+  const HeapDump::ID name_id = _mirror_dump_reader.name(mirror_dump);
+  if (name_id != HeapDump::NULL_ID) {
+    const oop name = java_lang_Class::name(mirror, CHECK);
+    put_object_if_absent(name_id, name); // Checks it's either absent or set to the same oop
+  }
+
+  // TODO for the pre-created mirrors, should we fill the rest of the mirror
+  //  instance fields + class static fields?
+  //  - If we do, it's not straight forward because the fields may have
+  //    different values of different classes than they were when dumped
+  //  - If we don't and these values were references somewhere in the dump,
+  //    they will be restored and thus duplicated
+
+  if (log_is_enabled(Debug, crac)) {
+    log_debug(crac)("Recorded mirror " HDID_FORMAT " of %s", mirror_dump.id,
+                    java_lang_Class::as_Klass(mirror())->external_name());
+  }
+}
+
+// Actual restoration
+
+#ifdef ASSERT
+static Klass *get_ref_field_type(const FieldStream &fs) {
+  Thread *const thread = Thread::current();
+  const InstanceKlass *field_holder = fs.field_descriptor().field_holder();
+  const Handle holder_loader = Handle(thread, field_holder->class_loader());
+  return SystemDictionary::find_constrained_instance_or_array_klass(thread, fs.signature(), holder_loader);
+}
+#endif // ASSERT
+
+void CracHeapRestorer::set_field(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS) {
+  precond(obj.not_null());
+  switch (Signature::basic_type(fs.signature())) {
+    case T_OBJECT:
+    case T_ARRAY: {
+      precond(obj->obj_field(fs.offset()) == nullptr);
+      const Handle restored = restore_object(val.as_object_id, CHECK);
+#ifdef ASSERT
+      if (restored.not_null()) {
+        Klass *const field_type = get_ref_field_type(fs);
+        assert(field_type != nullptr, "field's type must be loaded since the field is assigned");
+        assert(restored->klass()->is_subtype_of(field_type), "field of type %s cannot be assigned a value of class %s",
+               fs.signature()->as_klass_external_name(), restored->klass()->external_name());
+      }
+#endif // ASSERT
+      obj->obj_field_put(fs.offset(), restored());
+      break;
+    }
+    case T_BOOLEAN: precond(obj->bool_field(fs.offset()) == false); obj->bool_field_put(fs.offset(), val.as_boolean);  break;
+    case T_CHAR:    precond(obj->char_field(fs.offset()) == 0);     obj->char_field_put(fs.offset(), val.as_char);     break;
+    case T_FLOAT:   precond(obj->float_field(fs.offset()) == 0.0F); obj->float_field_put(fs.offset(), val.as_float);   break;
+    case T_DOUBLE:  precond(obj->double_field(fs.offset()) == 0.0); obj->double_field_put(fs.offset(), val.as_double); break;
+    case T_BYTE:    precond(obj->byte_field(fs.offset()) == 0);     obj->byte_field_put(fs.offset(), val.as_byte);     break;
+    case T_SHORT:   precond(obj->short_field(fs.offset()) == 0);    obj->short_field_put(fs.offset(), val.as_short);   break;
+    case T_INT:     precond(obj->int_field(fs.offset()) == 0);      obj->int_field_put(fs.offset(), val.as_int);       break;
+    case T_LONG:    precond(obj->long_field(fs.offset()) == 0);     obj->long_field_put(fs.offset(), val.as_long);     break;
+    default:        ShouldNotReachHere();
+  }
+}
+
+// Returns true iff the field has been set.
+bool CracHeapRestorer::set_field_if_special(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS) {
+  precond(obj.not_null());
+  if (fs.access_flags().is_static()) {
+    return false;
+  }
+
+  if (obj->klass()->is_class_loader_instance_klass() && fs.field_descriptor().field_holder() == vmClasses::ClassLoader_klass()) {
+    // Skip the CLD pointer which is set when registering the loader
+    if (fs.name() == vmSymbols::loader_data_name()) {
+      return true;
+    }
+
+    // Restoration is only called for prepared or just allocated class loaders
+    // Note: don't check _prepared_loaders here because we pop the loader from
+    // there before restoring it, and also this should be more efficient
+    const bool is_prepared = java_lang_ClassLoader::unnamedModule(obj()) != nullptr;
+    if (!is_prepared) {
+      // The loader has just been allocated by us and has not been prepared, so
+      // can restore it as a general object
+      return false;
+    }
+
+    // Skip the fields already restored during the preparation
+    if (fs.name() == vmSymbols::parent_name() || fs.name() == vmSymbols::name_name() ||
+        fs.name()->equals("nameAndId") || fs.name()->equals("unnamedModule")) {
+      const HeapDump::ID obj_id = val.as_object_id;
+      assert(obj_id == HeapDump::NULL_ID && obj->obj_field(fs.offset()) == nullptr ||
+             get_object_when_present(obj_id) == obj->obj_field(fs.offset()),
+             "either null or recorded with same value");
+      return true;
+    }
+
+    // When preparing, parallelLockMap is only allocated and left unrestored, so
+    // restore it now
+    if (fs.name()->equals("parallelLockMap")) {
+      const HeapDump::ID parallel_lock_map_id = val.as_object_id;
+      const oop parallel_lock_map = obj->obj_field(fs.offset());
+      if (parallel_lock_map != nullptr) {
+        assert(parallel_lock_map->klass() == vmClasses::ConcurrentHashMap_klass(), "must be");
+        assert(get_object_when_present(parallel_lock_map_id) == parallel_lock_map, "must be recorded when preparing");
+        const HeapDump::InstanceDump &parallel_lock_map_dump = _heap_dump.get_instance_dump(parallel_lock_map_id);
+        restore_instance_fields(obj, parallel_lock_map_dump, CHECK_false);
+      } else {
+        assert(parallel_lock_map_id == HeapDump::NULL_ID, "must be");
+      }
+      return true;
+    }
+
+    // The rest of the fields are untouched by the preparation and should be
+    // restored as usual
+    return false;
+  }
+
+  if (obj->klass()->is_mirror_instance_klass()) {
+    assert(fs.field_descriptor().field_holder() == vmClasses::Class_klass(),  "the only super is j.l.Object which has no fields");
+
+    // Skip primitive fields set when creating the mirror
+    if (fs.name() == vmSymbols::klass_name() || fs.name() == vmSymbols::array_klass_name() ||
+        fs.name() == vmSymbols::oop_size_name() || fs.name() == vmSymbols::static_oop_field_count_name()) {
+      return true;
+    }
+    // Component class mirror (aka component type) is also set when creating the
+    // mirror iff it corresponds to an array class, and it must be already
+    // recorded because we pre-record all mirors
+    if (fs.name() == vmSymbols::componentType_name()) {
+#ifdef ASSERT
+      const HeapDump::ID component_mirror_id = val.as_object_id;
+      if (component_mirror_id != HeapDump::NULL_ID) {
+        assert(java_lang_Class::as_Klass(obj())->is_array_klass(),
+               "a %s<%s> object has 'componentType' dumped referencing " HDID_FORMAT " when it represents a non-array class",
+               vmSymbols::java_lang_Class()->as_klass_external_name(), java_lang_Class::as_Klass(obj())->external_name(), component_mirror_id);
+        const oop component_mirror = obj->obj_field(fs.offset());
+        assert(component_mirror != nullptr, "array class mirror must have its component mirror set");
+        assert(get_object_when_present(component_mirror_id) == component_mirror, "component class mirror must be pre-recorded");
+      } else {
+        assert(java_lang_Class::as_Klass(obj())->is_instance_klass(),
+               "a %s<%s> object has 'componentType' dumped as null when it represents an array class",
+               vmSymbols::java_lang_Class()->as_klass_external_name(), java_lang_Class::as_Klass(obj())->external_name());
+        assert(obj->obj_field(fs.offset()) == nullptr, "instance class mirror cannot have its component mirror set");
+      }
+#endif // ASSERT
+      return true;
+    }
+    // Module is also set when creating the mirror and is pre-recorded
+    if (fs.name()->equals("module")) {
+#ifdef ASSERT
+      const HeapDump::ID module_id = val.as_object_id;
+      const oop module = obj->obj_field(fs.offset());
+      assert(module_id != HeapDump::NULL_ID && module != nullptr, "mirror's module is always not null");
+      assert(_objects.contains(module_id) && JNIHandles::resolve_non_null(*_objects.get(module_id)) == module,
+             "mirror's module must be pre-recorded");
+#endif // ASSERT
+      return true;
+    }
+
+    // If the defining loader is a prepared one we should restore the fields
+    // unfilled by its preparation, and unmark the loader as prepared so that
+    // this won't be repeated when restoring other classes defined by the loader
+    if (fs.name() == vmSymbols::classLoader_name()) {
+      const HeapDump::ID loader_id = val.as_object_id;
+      assert(_objects.contains(loader_id), "used loaders must already be recorded");
+      if (_prepared_loaders.remove(loader_id)) { // If the loader is prepared
+        const oop loader = obj->obj_field(fs.offset());
+        precond(java_lang_ClassLoader::is_instance(loader));
+        const instanceHandle loader_h(Thread::current(), static_cast<instanceOop>(loader));
+        // We use this fact to distinguish prepared loaders from the unprepared
+        // ones when restoring them
+        assert(java_lang_ClassLoader::unnamedModule(loader) != nullptr, "preparation must set the unnamed module");
+        restore_instance_fields(loader_h, _heap_dump.get_instance_dump(loader_id), CHECK_false);
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  if (obj->klass() == vmClasses::String_klass()) {
+    assert(fs.field_descriptor().field_holder() == vmClasses::String_klass(), "the only super is j.l.Object which has no fields");
+    // TODO ensure interned strings are indeed interned when restoring them
+    //  (e.g. constant pool strings and j.l.Class::name are always interned)
+
+    // Flags are internal and depend on VM options. They will be set as needed,
+    // so just ignore them.
+    if (fs.name() == vmSymbols::flags_name()) {
+      return true;
+    }
+  }
+
+  // TODO other special cases (need to check all classes from javaClasses)
+  return false;
+}
+
+// TODO use other means to iterate over fields: FieldStream performs a linear
+//  search for each field
+
+void CracHeapRestorer::restore_instance_fields(instanceHandle obj, const HeapDump::InstanceDump &dump, TRAPS) {
+  precond(obj.not_null());
+  FieldStream fs(InstanceKlass::cast(obj->klass()), false, true); // Includes supers' fields but not interfaces' since those are static
+  u4 dump_offset = 0;
+  for (; !fs.eos() && dump_offset < dump.fields_data.size(); fs.next()) {
+    if (fs.access_flags().is_static()) {
+      continue;
+    }
+
+    const BasicType type = Signature::basic_type(fs.signature());
+    const u4 type_size = (is_java_primitive(type) ? type2aelembytes(type) : _heap_dump.id_size);
+    guarantee(dump_offset + type_size < dump.fields_data.size(),
+              "object " HDID_FORMAT " has less non-static fields' data dumped than needed by its class %s and its super classes: "
+              "read " UINT32_FORMAT " bytes and expect at least " UINT32_FORMAT " more for %s value, but only " UINT32_FORMAT " bytes left",
+              dump.id, obj->klass()->external_name(), dump_offset, type_size, type2name(type), dump.fields_data.size() - dump_offset);
+    const HeapDump::BasicValue val = dump.read_field(dump_offset, type, _heap_dump.id_size);
+
+    const bool is_special = set_field_if_special(obj, fs, val, CHECK);
+    if (!is_special) {
+      set_field(obj, fs, val, CHECK);
+    }
+
+    dump_offset += type_size;
+  }
+
+#ifdef ASSERT
+  u4 unfilled_bytes = 0;
+  for (; !fs.eos(); fs.next()) {
+    if (!fs.access_flags().is_static()) {
+      const BasicType type = Signature::basic_type(fs.signature());
+      unfilled_bytes += (is_java_primitive(type) ? type2aelembytes(type) : _heap_dump.id_size);
+    }
+  }
+  assert(unfilled_bytes == 0 || dump_offset == dump.fields_data.size(), "must be");
+  assert(unfilled_bytes > 0,
+         "object " HDID_FORMAT " has less non-static fields' data dumped than needed by its class %s and its super classes: "
+         "only " UINT32_FORMAT " bytes dumped, but additional " UINT32_FORMAT " bytes are expected",
+         dump.id, obj->klass()->external_name(), dump.fields_data.size(), unfilled_bytes);
+  assert(dump_offset < dump.fields_data.size(),
+         "object " HDID_FORMAT " has more non-static fields' data dumped than needed by its class %s and its super classes: "
+         UINT32_FORMAT " bytes dumped, but only " UINT32_FORMAT " expected",
+         dump.id, obj->klass()->external_name(), dump.fields_data.size(), dump_offset);
+#endif // ASSERT
+}
+
+static void set_resolved_references(InstanceKlass *ik, Handle resolved_refs) {
+  // If resolved references are dumped, they should not be null
+  guarantee(ik->is_rewritten(), "class %s cannot have resolved references because it has not been rewritten",
+            ik->external_name());
+  guarantee(resolved_refs.not_null(), "rewritten class %s has null resolved references dumped",
+            ik->external_name());
+  guarantee(resolved_refs->klass()->is_objArray_klass() &&
+            ObjArrayKlass::cast(resolved_refs->klass())->element_klass() == vmClasses::Object_klass(),
+            "class %s has resolved references of illegal type", ik->external_name());
+
+  assert(ik->constants()->cache() != nullptr, "rewritten class must have a CP cache");
+  if (ik->constants()->resolved_references() == nullptr) {
+    ik->constants()->cache()->set_resolved_references(ik->class_loader_data()->add_handle(resolved_refs));
+    return;
+  }
+
+  for (InstanceKlass *prev_ver = ik->previous_versions(); prev_ver != nullptr; prev_ver = prev_ver->previous_versions()) {
+    guarantee(prev_ver->is_rewritten(), "there are more resolved references dumped for %s than expected",
+              prev_ver->external_name());
+    assert(prev_ver->constants()->cache() != nullptr, "rewritten class must have a CP cache");
+    if (prev_ver->constants()->resolved_references() == nullptr) {
+      prev_ver->constants()->cache()->set_resolved_references(prev_ver->class_loader_data()->add_handle(resolved_refs));
+      return;
+    }
+  }
+
+  guarantee(false, "there are more resolved references dumped for %s than expected", ik->external_name());
+  ShouldNotReachHere();
+}
+
+void CracHeapRestorer::restore_static_fields(InstanceKlass *ik, const HeapDump::ClassDump &dump, TRAPS) {
+  instanceHandle mirror(Thread::current(), static_cast<instanceOop>(ik->java_mirror()));
+  FieldStream fs(ik, true, true); // Iterates only over fields declared in this class/interface directly
+  u2 static_i = 0;
+  while (!fs.eos() && static_i < dump.static_fields.size()) {
+    if (!fs.access_flags().is_static()) {
+      fs.next();
+      continue;
+    }
+
+    const HeapDump::ClassDump::Field &field = dump.static_fields[static_i++];
+    const Symbol *field_name = _heap_dump.get_symbol(field.info.name_id);
+
+    // HeapDumper includes constant pool's resolved references as static fields
+    if (field_name == vmSymbols::resolved_references_name()) {
+      guarantee(field.info.type == HPROF_ARRAY_OBJECT,
+                "resolved references must be stored in an array "
+                "but they are dumped as a %s in class %s (ID " HDID_FORMAT ") as static field #%i",
+                type2name(HeapDump::htype2btype(field.info.type)), ik->external_name(), dump.id, static_i);
+      const Handle restored = restore_object(field.value.as_object_id, CHECK);
+      set_resolved_references(ik, restored);
+      continue; // No fs.next() because there is no actual field for this
+    }
+
+    guarantee(fs.name() == field_name && Signature::basic_type(fs.signature()) == HeapDump::htype2btype(field.info.type),
+              "expected static field #%i of class %s (ID " HDID_FORMAT ") to be %s %s but it is %s %s in the dump",
+              static_i, ik->external_name(), dump.id,
+              type2name(Signature::basic_type(fs.signature())), fs.name()->as_C_string(),
+              type2name(HeapDump::htype2btype(field.info.type)), field_name->as_C_string());
+    set_field(mirror, fs, field.value, CHECK);
+
+    fs.next();
+  }
+
+#ifdef ASSERT
+  u2 unfilled_fields_num = 0;
+  for (; !fs.eos(); fs.next()) {
+    if (fs.access_flags().is_static()) {
+      unfilled_fields_num++;
+    }
+  }
+  assert(unfilled_fields_num == 0 || static_i == dump.static_fields.size(), "must be");
+  assert(unfilled_fields_num == 0,
+         "class %s (ID " HDID_FORMAT ") has not enough static fields dumped: expected %i more",
+         ik->external_name(), dump.id, unfilled_fields_num);
+  assert(static_i == dump.static_fields.size(),
+         "class %s (ID " HDID_FORMAT ") has too many static fields dumped: expected %i, got %i",
+         ik->external_name(), dump.id, static_i, dump.static_fields.size());
+#endif // ASSERT
+}
+
+void CracHeapRestorer::restore_class_mirror(HeapDump::ID id, TRAPS) {
+  if (log_is_enabled(Trace, crac)) {
+    ResourceMark rm;
+    const char *type_name;
+    const HeapDump::LoadClass *lc = _heap_dump.load_classes.get(id);
+    if (lc != nullptr) {
+      type_name = _heap_dump.get_symbol(lc->class_name_id)->as_klass_external_name();
+    } else {
+      type_name = "a primitive type";
+    }
+    log_trace(crac)("Restoring mirror " HDID_FORMAT " of %s", id, type_name);
+  }
+
+  // Instance mirrors must be pre-recorded
+  instanceHandle mirror;
+  {
+    const oop mirror_obj = get_object_when_present(id);
+    assert(mirror_obj->is_instance(), "mirrors are instances");
+    mirror = instanceHandle(Thread::current(), static_cast<instanceOop>(mirror_obj));
+  }
+
+  // Side-effect: finishes restoration of the class loader if only prepared
+  const HeapDump::InstanceDump &mirror_dump = _heap_dump.get_instance_dump(id);
+  restore_instance_fields(mirror, mirror_dump, CHECK);
+
+  Klass *const mirrored_k = java_lang_Class::as_Klass(mirror());
+  if (mirrored_k != nullptr && mirrored_k->is_instance_klass()) {
+    const HeapDump::ClassDump &dump = _heap_dump.get_class_dump(id);
+    // Side-effect: restores resolved references array of the constant pool
+    restore_static_fields(InstanceKlass::cast(mirrored_k), dump, CHECK);
+  }
+
+  if (log_is_enabled(Trace, crac)) {
+    ResourceMark rm;
+    const char *type_name;
+    if (mirrored_k != nullptr) {
+      type_name = mirrored_k->external_name();
+    } else {
+      type_name = type2name(java_lang_Class::as_BasicType(mirror()));
+    }
+    log_trace(crac)("Restored mirror " HDID_FORMAT " of %s", id, type_name);
+  }
+}
+
+Handle CracHeapRestorer::restore_object(HeapDump::ID id, TRAPS) {
+  if (id == HeapDump::NULL_ID) {
+    return {};
+  }
+  const jobject *ready = _objects.get(id);
+  if (ready != nullptr) {
+    return {Thread::current(), JNIHandles::resolve(*ready)};
+  }
+
+  const HeapDump::InstanceDump *instance_dump = _heap_dump.instance_dumps.get(id);
+  if (instance_dump != nullptr) {
+    assert(!_instance_classes.contains(id) && !_array_classes.contains(id), "unrecorded class mirror " HDID_FORMAT, id);
+    assert(!_heap_dump.obj_array_dumps.contains(id) && !_heap_dump.prim_array_dumps.contains(id),
+           "object " HDID_FORMAT " duplicated in multiple dump categories: instance and some kind of array", id);
+    return restore_instance(*instance_dump, CHECK_NH);
+  }
+
+  const HeapDump::ObjArrayDump  *obj_array_dump  = _heap_dump.obj_array_dumps.get(id);
+  if (obj_array_dump != nullptr) {
+    assert(!_heap_dump.prim_array_dumps.contains(id),
+           "object " HDID_FORMAT " duplicated in multiple dump categories: object and primitive array", id);
+    return restore_obj_array(*obj_array_dump, CHECK_NH);
+  }
+
+  const HeapDump::PrimArrayDump *prim_array_dump = _heap_dump.prim_array_dumps.get(id);
+  guarantee(prim_array_dump != nullptr, "object " HDID_FORMAT " not found in the heap dump", id);
+  return restore_prim_array(*prim_array_dump, CHECK_NH);
+}
+
+instanceHandle CracHeapRestorer::restore_instance(const HeapDump::InstanceDump &dump, TRAPS) {
+  assert(!_objects.contains(dump.id), "use restore_object() instead");
+  log_trace(crac)("Restoring instance " HDID_FORMAT, dump.id);
+
+  InstanceKlass &ik = get_instance_class(dump.class_id);
+  guarantee(!ik.is_mirror_instance_klass(), "unrecorded class mirror " HDID_FORMAT, dump.id);
+  guarantee(!ik.should_be_initialized(),
+            "object " HDID_FORMAT " is an instance of uninitialized class %s (" HDID_FORMAT ")",
+            dump.id, ik.external_name(), dump.class_id);
+  ik.check_valid_for_instantiation(true, CHECK_({}));
+
+  const instanceHandle obj = ik.allocate_instance_handle(CHECK_({}));
+  put_object_when_absent(dump.id, obj); // Record first to be able to find in case of circular references
+  restore_instance_fields(obj, dump, CHECK_({}));
+
+  if (log_is_enabled(Trace, crac)) {
+    ResourceMark rm;
+    log_trace(crac)("Restored instance " HDID_FORMAT " of %s", dump.id, ik.external_name());
+  }
+  return obj;
+}
+
+objArrayHandle CracHeapRestorer::restore_obj_array(const HeapDump::ObjArrayDump &dump, TRAPS) {
+  assert(!_objects.contains(dump.id), "use restore_object() instead");
+  log_trace(crac)("Restoring object array " HDID_FORMAT, dump.id);
+
+  ObjArrayKlass *oak;
+  {
+    ArrayKlass &ak = get_array_class(dump.array_class_id);
+    guarantee(ak.is_objArray_klass(), "object array " HDID_FORMAT " has a primitive array class", dump.id);
+    oak = ObjArrayKlass::cast(&ak);
+  }
+
+  guarantee(dump.elem_ids.size() <= INT_MAX, "object array " HDID_FORMAT " is too long: "
+            UINT32_FORMAT " > %i", dump.id, dump.elem_ids.size(), INT_MAX);
+  const int length = checked_cast<int>(dump.elem_ids.size());
+
+  objArrayHandle array;
+  {
+    const objArrayOop o = oak->allocate(length, CHECK_({}));
+    array = objArrayHandle(Thread::current(), o);
+  }
+  put_object_when_absent(dump.id, array); // Record first to be able to find in case of circular references
+
+  for (int i = 0; i < length; i++) {
+    const Handle elem = restore_object(dump.elem_ids[i], CHECK_({}));
+    assert(elem == nullptr || elem->klass()->is_subtype_of(oak->element_klass()),
+           "object array " HDID_FORMAT " is expected to have elements of type %s, "
+           "but its element #%i has class %s which is not a subtype of the element type",
+           dump.id, oak->element_klass()->external_name(), i, elem->klass()->external_name());
+    array->obj_at_put(i, elem());
+  }
+
+  if (log_is_enabled(Trace, crac)) {
+    ResourceMark rm;
+    log_trace(crac)("Restored object array " HDID_FORMAT " of %s", dump.id, oak->external_name());
+  }
+  return array;
+}
+
+typeArrayHandle CracHeapRestorer::restore_prim_array(const HeapDump::PrimArrayDump &dump, TRAPS) {
+  assert(!_objects.contains(dump.id), "use restore_object() instead");
+  log_trace(crac)("Restoring primitive array " HDID_FORMAT, dump.id);
+
+  guarantee(dump.elems_num <= INT_MAX, "primitive array " HDID_FORMAT " is too long: "
+            UINT32_FORMAT " > %i", dump.id, dump.elems_num, INT_MAX);
+  const int length = checked_cast<int>(dump.elems_num);
+  const BasicType elem_type = HeapDump::htype2btype(dump.elem_type);
+
+  typeArrayOop array = oopFactory::new_typeArray_nozero(elem_type, length, CHECK_({}));
+  precond(static_cast<size_t>(length) * type2aelembytes(elem_type) == dump.elems_data.size());
+  if (length > 0) {
+    memcpy(array->base(elem_type), dump.elems_data.mem(), dump.elems_data.size());
+  }
+
+  const typeArrayHandle array_h(Thread::current(), array);
+  put_object_when_absent(dump.id, array_h);
+
+  if (log_is_enabled(Trace, crac)) {
+    ResourceMark rm;
+    log_trace(crac)("Restored primitive array " HDID_FORMAT " of %s", dump.id, array->klass()->external_name());
+  }
+  return array_h;
+}

--- a/src/hotspot/share/runtime/cracHeapRestorer.cpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.cpp
@@ -6,6 +6,7 @@
 #include "logging/log.hpp"
 #include "memory/oopFactory.hpp"
 #include "memory/resourceArea.hpp"
+#include "memory/universe.hpp"
 #include "oops/arrayKlass.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/instanceKlass.inline.hpp"
@@ -560,7 +561,7 @@ void CracHeapRestorer::find_and_record_java_class(const HeapDump::ClassDump &cla
 
       // Primitive mirrors are also recorded here because they don't have a
       // Klass to be dumped with directly but always have a TypeArrayKlass
-      if (ak.is_typeArray_klass()) {
+      if (ak.is_typeArray_klass() && &ak != Universe::fillerArrayKlassObj() /* same as int[] */) {
         const oop prim_mirror_obj = java_lang_Class::component_mirror(mirror());
         assert(prim_mirror_obj != nullptr, "type array's mirror must have a component mirror");
         const instanceHandle prim_mirror(current, static_cast<instanceOop>(prim_mirror_obj));

--- a/src/hotspot/share/runtime/cracHeapRestorer.cpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.cpp
@@ -673,9 +673,15 @@ void CracHeapRestorer::set_field(instanceHandle obj, const FieldStream &fs, cons
 #ifdef ASSERT
       if (restored.not_null()) {
         Klass *const field_type = get_ref_field_type(field_holder, fs.signature());
-        assert(field_type != nullptr, "field's type must be loaded since the field is assigned");
-        assert(restored->klass()->is_subtype_of(field_type), "field of type %s cannot be assigned a value of class %s",
-               fs.signature()->as_klass_external_name(), restored->klass()->external_name());
+        // TODO until restoration of loader constraints is implemented we may get null here
+        // assert(field_type != nullptr, "field's type must be loaded since the field is assigned");
+        if (field_type != nullptr) {
+          assert(restored->klass()->is_subtype_of(field_type), "field of type %s cannot be assigned a value of class %s",
+                 fs.signature()->as_C_string(), restored->klass()->external_name());
+        } else {
+          log_warning(crac, class)("Loader constraint absent: %s should be constrained on loading %s",
+                                   field_holder.class_loader_data()->loader_name_and_id(), fs.signature()->as_C_string());
+        }
       }
 #endif // ASSERT
       obj->obj_field_put(fs.offset(), restored());

--- a/src/hotspot/share/runtime/cracHeapRestorer.hpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.hpp
@@ -52,7 +52,7 @@ class ClassLoaderProvider : public StackObj {
   virtual instanceHandle get_class_loader(HeapDump::ID id, TRAPS) = 0;
 };
 
-struct ClassHeapDeps;
+struct UnfilledClassInfo;
 class StackTrace;
 
 // Restores heap based on an HPROF dump created by HeapDumper (there are some
@@ -74,7 +74,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
 
   instanceHandle get_class_loader(HeapDump::ID id, TRAPS) override;
 
-  void restore_heap(const HeapDumpTable<ClassHeapDeps, AnyObj::C_HEAP> &class_heap_deps,
+  void restore_heap(const HeapDumpTable<UnfilledClassInfo, AnyObj::C_HEAP> &class_infos,
                     const GrowableArrayView<StackTrace *> &stack_traces, TRAPS);
 
  private:

--- a/src/hotspot/share/runtime/cracHeapRestorer.hpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.hpp
@@ -110,7 +110,8 @@ class CracHeapRestorer : public ClassLoaderProvider {
   void record_java_class(instanceHandle mirror, const HeapDump::InstanceDump &mirror_dump, TRAPS);
 
   void set_field(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS);
-  bool set_field_if_special(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS);
+  bool set_instance_field_if_special(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS);
+  static bool set_static_field_if_special(instanceHandle mirror, const FieldStream &fs, const HeapDump::BasicValue &val);
   void restore_instance_fields(instanceHandle obj, const HeapDump::InstanceDump &dump, TRAPS);
   void restore_static_fields(InstanceKlass *ik, const HeapDump::ClassDump &dump, TRAPS);
 

--- a/src/hotspot/share/runtime/cracStackDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.hpp
@@ -1,11 +1,11 @@
-#ifndef SHARE_UTILITIES_STACK_DUMP_PARSER_HPP
-#define SHARE_UTILITIES_STACK_DUMP_PARSER_HPP
+#ifndef SHARE_RUNTIME_CRACSTACKDUMPPARSER_HPP
+#define SHARE_RUNTIME_CRACSTACKDUMPPARSER_HPP
 
 #include "memory/allocation.hpp"
 #include "utilities/extendableArray.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
-#include "utilities/stackDumper.hpp"
+#include "runtime/cracStackDumper.hpp"
 
 // Parsed stack trace.
 class StackTrace : public CHeapObj<mtInternal> {
@@ -79,12 +79,10 @@ class ParsedStackDump : public CHeapObj<mtInternal> {
   GrowableArrayCHeap<StackTrace *, mtInternal> _stack_traces;
 };
 
-struct StackDumpParser : public AllStatic {
+struct CracStackDumpParser : public AllStatic {
   // Parses the stack dump in path filling the out container. Returns nullptr on
   // success or a pointer to a static error message otherwise.
-  //
-  // Stack traces and their frames are resource-allocated.
   static const char *parse(const char *path, ParsedStackDump *out);
 };
 
-#endif // SHARE_UTILITIES_STACK_DUMP_PARSER_HPP
+#endif // SHARE_RUNTIME_CRACSTACKDUMPPARSER_HPP

--- a/src/hotspot/share/runtime/cracStackDumper.hpp
+++ b/src/hotspot/share/runtime/cracStackDumper.hpp
@@ -1,5 +1,5 @@
-#ifndef SHARE_UTILITIES_STACK_DUMPER_HPP
-#define SHARE_UTILITIES_STACK_DUMPER_HPP
+#ifndef SHARE_RUNTIME_CRACSTACKDUMPER_HPP
+#define SHARE_RUNTIME_CRACSTACKDUMPER_HPP
 
 #include "memory/allStatic.hpp"
 #include "runtime/javaThread.hpp"
@@ -8,7 +8,7 @@
 // Thread stack dumping in the big-endian binary format described below.
 //
 // Header:
-//   u1... -- null-termiminated string "JAVA STACK DUMP 0.1"
+//   u1... -- null-termiminated string "CRAC STACK DUMP 0.1"
 //   u2    -- word size in bytes:
 //            4 -- IDs and primitives (PRs) are 4 byte, longs and doubles are
 //                 split in half into their slot pairs with the most significant
@@ -33,6 +33,8 @@
 //     ID -- ID of the method name String object
 //     ID -- ID of the method signature String object
 //     ID -- ID of the Class object of the method's class
+//           TODO JVM TI Redefine/RetransformClass support: add method holder's
+//                redefinition version to select the right one on restore.
 //     u2 -- bytecode index (BCI) of the current bytecode: for the youngest
 //           frame see the BCI meaning in the trace preamble, and for the rest
 //           of the frames this specifies the invoke bytecode being executed
@@ -53,7 +55,7 @@ enum DumpedStackValueType : u1 { PRIMITIVE, REFERENCE };
 
 // Dumps Java frames (until the first CallStub) of non-internal Java threads.
 // Dumped IDs are oops to be compatible with HeapDumper's object IDs.
-struct StackDumper : public AllStatic {
+struct CracStackDumper : public AllStatic {
   class Result {
    public:
     enum class Code {
@@ -82,16 +84,15 @@ struct StackDumper : public AllStatic {
 
    private:
     const Code _code;
-    const char * const _io_error_msg = nullptr;
-    JavaThread * const _problematic_thread = nullptr;
+    const char *const _io_error_msg = nullptr;
+    JavaThread *const _problematic_thread = nullptr;
   };
 
-  // Dumps the stacks to the specified file, possibly overwriting it if the
-  // corresponding parameter is set to true, Returns nullptr on success, or a
-  // pointer to a static error message otherwise.
+  // Dumps the stacks into the specified file, possibly overwriting it if the
+  // corresponding parameter is set to true.
   //
-  // Safepoint is required.
+  // Must be called on safepoint.
   static Result dump(const char *path, bool overwrite = false);
 };
 
-#endif // SHARE_UTILITIES_STACK_DUMPER_HPP
+#endif // SHARE_RUNTIME_CRACSTACKDUMPER_HPP

--- a/src/hotspot/share/runtime/reflectionUtils.cpp
+++ b/src/hotspot/share/runtime/reflectionUtils.cpp
@@ -69,7 +69,7 @@ bool KlassStream::eos() {
   return eos();
 }
 
-int FieldStream::length() { return _klass->java_fields_count(); }
+int FieldStream::length() { return _java_only ? _klass->java_fields_count() : _klass->total_fields_count(); }
 
 GrowableArray<FilteredField*> *FilteredFieldsMap::_filtered_fields =
   new (mtServiceability) GrowableArray<FilteredField*>(3, mtServiceability);

--- a/src/hotspot/share/runtime/reflectionUtils.hpp
+++ b/src/hotspot/share/runtime/reflectionUtils.hpp
@@ -122,11 +122,12 @@ class FieldStream : public KlassStream {
  private:
   int length();
 
+  bool _java_only; // If false, include injected fields
   fieldDescriptor _fd_buf;
 
  public:
-  FieldStream(InstanceKlass* klass, bool local_only, bool classes_only)
-    : KlassStream(klass, local_only, classes_only, false) {
+  FieldStream(InstanceKlass* klass, bool local_only, bool classes_only, bool java_only = true)
+    : KlassStream(klass, local_only, classes_only, false), _java_only(java_only) {
     _index = length();
     next();
   }

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1298,10 +1298,10 @@ void SymbolTableDumper::do_symbol(Symbol** p) {
   ResourceMark rm;
   Symbol* sym = *p;
   int len = sym->utf8_length();
+  char* s = sym->as_utf8();
+  DumperSupport::write_header(writer(), HPROF_UTF8, oopSize + len);
+  writer()->write_symbolID(sym);
   if (len > 0) {
-    char* s = sym->as_utf8();
-    DumperSupport::write_header(writer(), HPROF_UTF8, oopSize + len);
-    writer()->write_symbolID(sym);
     writer()->write_raw(s, len);
   }
 }
@@ -1409,13 +1409,6 @@ class HeapObjectDumper : public ObjectClosure {
 };
 
 void HeapObjectDumper::do_object(oop o) {
-  // skip classes as these emitted as HPROF_GC_CLASS_DUMP records
-  if (o->klass() == vmClasses::Class_klass()) {
-    if (!java_lang_Class::is_primitive(o)) {
-      return;
-    }
-  }
-
   if (DumperSupport::mask_dormant_archived_object(o) == nullptr) {
     log_debug(cds, heap)("skipped dormant archived object " INTPTR_FORMAT " (%s)", p2i(o), o->klass()->external_name());
     return;

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -36,13 +36,13 @@ class HeapDumper : public StackObj {
  private:
   char* _error;
   bool _gc_before_heap_dump;
-  bool _with_injected_fields;
+  bool _extended; // Includes j.l.Class objects of reference types and injected fields
   bool _oome;
   elapsedTimer _t;
 
-  HeapDumper(bool gc_before_heap_dump, bool with_injected_fields, bool oome) :
+  HeapDumper(bool gc_before_heap_dump, bool extended, bool oome) :
     _error(nullptr), _gc_before_heap_dump(gc_before_heap_dump),
-    _with_injected_fields(with_injected_fields), _oome(oome) { }
+    _extended(extended), _oome(oome) { }
 
   // string representation of error
   char* error() const                   { return _error; }

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -36,11 +36,13 @@ class HeapDumper : public StackObj {
  private:
   char* _error;
   bool _gc_before_heap_dump;
+  bool _with_injected_fields;
   bool _oome;
   elapsedTimer _t;
 
-  HeapDumper(bool gc_before_heap_dump, bool oome) :
-    _error(nullptr), _gc_before_heap_dump(gc_before_heap_dump), _oome(oome) { }
+  HeapDumper(bool gc_before_heap_dump, bool with_injected_fields, bool oome) :
+    _error(nullptr), _gc_before_heap_dump(gc_before_heap_dump),
+    _with_injected_fields(with_injected_fields), _oome(oome) { }
 
   // string representation of error
   char* error() const                   { return _error; }
@@ -52,8 +54,8 @@ class HeapDumper : public StackObj {
   static void dump_heap(bool oome);
 
  public:
-  HeapDumper(bool gc_before_heap_dump) :
-    _error(nullptr), _gc_before_heap_dump(gc_before_heap_dump), _oome(false) { }
+  HeapDumper(bool gc_before_heap_dump, bool with_injected_fields = false) :
+    HeapDumper(gc_before_heap_dump, with_injected_fields, false) {}
 
   ~HeapDumper();
 

--- a/src/hotspot/share/utilities/accessFlags.hpp
+++ b/src/hotspot/share/utilities/accessFlags.hpp
@@ -96,6 +96,7 @@ class AccessFlags {
  private:
   friend class Klass;
   friend class ClassFileParser;
+  friend class CracInstanceClassDumpParser;
   // the functions below should only be called on the _access_flags inst var directly,
   // otherwise they are just changing a copy of the flags
 

--- a/src/hotspot/share/utilities/basicTypeWriter.cpp
+++ b/src/hotspot/share/utilities/basicTypeWriter.cpp
@@ -1,0 +1,45 @@
+#include "precompiled.hpp"
+#include "logging/log.hpp"
+#include "runtime/os.hpp"
+#include "utilities/basicTypeWriter.hpp"
+
+bool FileBasicTypeWriter::open(const char *path, bool overwrite) {
+  assert(path != nullptr, "cannot write to null path");
+
+  close();
+  errno = 0; // If close() errored, a warning has already been issued
+
+  if (!overwrite && os::file_exists(path)) {
+    errno = EEXIST;
+    return false;
+  }
+  errno = 0; // os::file_exists() may use functions that set errno
+
+  FILE *file = os::fopen(path, "wb");
+  if (file == nullptr) {
+    guarantee(errno != 0, "fopen should set errno on error");
+    return false;
+  }
+
+  _file = file;
+  return true;
+}
+
+void FileBasicTypeWriter::close() {
+  if (_file == nullptr) {
+    return;
+  }
+  if (log_is_enabled(Warning, data)) {
+    int fd = os::get_fileno(_file);
+    errno = -1; // To get "Unknown error" from os::strerror() if fclose won't set errno
+    if (fclose(_file) != 0) {
+      if (fd != -1) {
+        log_warning(data)("Failed to close file with FD %i after writing: %s", fd, os::strerror(errno));
+      } else {
+        log_warning(data)("Failed to close a file after writing: %s", os::strerror(errno));
+      }
+    }
+  } else {
+    fclose(_file);
+  }
+}

--- a/src/hotspot/share/utilities/basicTypeWriter.hpp
+++ b/src/hotspot/share/utilities/basicTypeWriter.hpp
@@ -1,0 +1,56 @@
+#ifndef SHARE_UTILITIES_BASICTYPEWRITER_HPP
+#define SHARE_UTILITIES_BASICTYPEWRITER_HPP
+
+#include "metaprogramming/enableIf.hpp"
+#include "utilities/bitCast.hpp"
+#include "utilities/bytes.hpp"
+#include "utilities/debug.hpp"
+#include <type_traits>
+
+class BasicTypeWriter {
+ public:
+  // Writes size bytes into buf. Returns true on success.
+  virtual bool write_raw(const void *buf, size_t size) = 0;
+
+  // Writes integral types (and boolean as a byte).
+  template <class T, ENABLE_IF(std::is_integral<T>::value &&
+                               (sizeof(T) == sizeof(u1) || sizeof(T) == sizeof(u2) ||
+                                sizeof(T) == sizeof(u4) || sizeof(T) == sizeof(u8)))>
+  bool write(T value) {
+    T tmp;
+    switch (sizeof(value)) {
+      case sizeof(u1): tmp = value;                                                break;
+      case sizeof(u2): Bytes::put_Java_u2(reinterpret_cast<address>(&tmp), value); break;
+      case sizeof(u4): Bytes::put_Java_u4(reinterpret_cast<address>(&tmp), value); break;
+      case sizeof(u8): Bytes::put_Java_u8(reinterpret_cast<address>(&tmp), value); break;
+    }
+    return write_raw(&tmp, sizeof(tmp));
+  }
+
+  bool write(jfloat value)  { return write(bit_cast<u4>(value)); }
+  bool write(jdouble value) { return write(bit_cast<u8>(value)); }
+
+ protected:
+  ~BasicTypeWriter() = default;
+};
+
+// Writes into a binary file.
+class FileBasicTypeWriter : public BasicTypeWriter {
+ public:
+  ~FileBasicTypeWriter() { close(); };
+
+  bool open(const char *path, bool overwrite = false);
+
+  bool write_raw(const void *buf, size_t size) override {
+    precond(_file != nullptr);
+    precond(buf != nullptr || size == 0);
+    return size == 0 || fwrite(buf, size, 1, _file) == 1;
+  }
+
+ private:
+  FILE *_file = nullptr;
+
+  void close();
+};
+
+#endif // SHARE_UTILITIES_BASICTYPEWRITER_HPP

--- a/src/hotspot/share/utilities/constantTag.cpp
+++ b/src/hotspot/share/utilities/constantTag.cpp
@@ -100,6 +100,22 @@ jbyte constantTag::error_value() const {
   }
 }
 
+jbyte constantTag::external_value() const {
+  if (_tag < JVM_CONSTANT_InternalMin) {
+    return _tag;
+  }
+  switch (_tag) {
+    case JVM_CONSTANT_UnresolvedClass:
+    case JVM_CONSTANT_UnresolvedClassInError:
+    case JVM_CONSTANT_ClassIndex:          return JVM_CONSTANT_Class;
+    case JVM_CONSTANT_StringIndex:         return JVM_CONSTANT_String;
+    case JVM_CONSTANT_MethodHandleInError: return JVM_CONSTANT_MethodHandle;
+    case JVM_CONSTANT_MethodTypeInError:   return JVM_CONSTANT_MethodType;
+    case JVM_CONSTANT_DynamicInError:      return JVM_CONSTANT_Dynamic;
+    default: ShouldNotReachHere();         return JVM_CONSTANT_Invalid;
+  }
+}
+
 const char* constantTag::internal_name() const {
   switch (_tag) {
     case JVM_CONSTANT_Invalid :

--- a/src/hotspot/share/utilities/constantTag.hpp
+++ b/src/hotspot/share/utilities/constantTag.hpp
@@ -151,6 +151,7 @@ class constantTag {
   jbyte value() const                { return _tag; }
   jbyte error_value() const;
   jbyte non_error_value() const;
+  jbyte external_value() const;
 
   BasicType basic_type() const;        // if used with ldc, what kind of value gets pushed?
 

--- a/src/hotspot/share/utilities/heapDumpClasses.cpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.cpp
@@ -200,7 +200,7 @@ void HeapDumpClasses::java_lang_Class::ensure_initialized(const ParsedHeapDump &
   precond(java_lang_Class_id != HeapDump::NULL_ID);
   if (!is_initialized()) {
     const HeapDump::ClassDump &java_lang_Class_dump = heap_dump.get_class_dump(java_lang_Class_id);
-    precond(is_class_loader_class_dump(heap_dump, java_lang_Class_dump));
+    precond(is_class_mirror_class_dump(heap_dump, java_lang_Class_dump));
     INITIALIZE_OFFSETS(java_lang_Class, CLASSMIRROR_DUMP_FIELDS_DO, CLASSMIRROR_DUMP_PTR_FIELDS_DO)
     DEBUG_ONLY(_java_lang_Class_id = java_lang_Class_id);
     _id_size = heap_dump.id_size;

--- a/src/hotspot/share/utilities/heapDumpClasses.cpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.cpp
@@ -1,0 +1,238 @@
+#include "precompiled.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "oops/symbol.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/heapDumpClasses.hpp"
+#include "utilities/heapDumpParser.hpp"
+#include "utilities/macros.hpp"
+#ifdef ASSERT
+#include "memory/resourceArea.hpp"
+#include "utilities/resourceHash.hpp"
+#endif // ASSERT
+
+static bool symbol_equals(const Symbol *actual, const Symbol *expected) {
+  return actual == expected;
+}
+static bool symbol_equals(const Symbol *actual, const char *expected) {
+  return actual->equals(expected);
+}
+
+#define NO_DUMP_FIELDS_DO(...)
+
+#define DEFINE_INSTANCE_DUMP_CHECK(class_name)                                                                        \
+  bool HeapDumpClasses::is_##class_name##_dump(const ParsedHeapDump &heap_dump, const HeapDump::InstanceDump &dump) { \
+    ResourceMark rm;                                                                                                  \
+    ResourceHashtable<HeapDump::ID, bool> visited_classes;                                                            \
+                                                                                                                      \
+    for (const HeapDump::ClassDump *class_dump = &heap_dump.get_class_dump(dump.class_id);                            \
+         class_dump->super_id != HeapDump::NULL_ID; class_dump = &heap_dump.get_class_dump(class_dump->super_id)) {   \
+      bool is_first_visit;                                                                                            \
+      visited_classes.put_if_absent(class_dump->id, &is_first_visit);                                                 \
+      assert(is_first_visit, "circularity detected in class hierarchy of " HDID_FORMAT, dump.class_id);               \
+                                                                                                                      \
+      if (is_##class_name##_class_dump(heap_dump, *class_dump)) {                                                     \
+        return true;                                                                                                  \
+      }                                                                                                               \
+    }                                                                                                                 \
+                                                                                                                      \
+    return false;                                                                                                     \
+  }
+
+STATIC_ASSERT((std::is_same<u4, juint>()));
+#define DEFINE_OFFSET_FROM_START_LOCAL(klass, name, ...) u4 name##_offset_from_start = max_juint;
+
+#define CREATE_FIELD_OFFSET_CASE(klass, name, name_sym, basic_type, ...)                                              \
+  if (symbol_equals(field_name, name_sym)) {                                                                                   \
+    guarantee(name##_offset_from_start == max_juint, "non-static field %s::%s dumped multiple times in " HDID_FORMAT,          \
+              vmSymbols::klass()->as_klass_external_name(), field_name->as_C_string(), klass##_dump.id);                       \
+    guarantee(field_type == (basic_type), "illegal type of non-static field %s::%s (ID " HDID_FORMAT "): expected %s, got %s", \
+              vmSymbols::klass()->as_klass_external_name(), field_name->as_C_string(), klass##_dump.id,                        \
+              type2name(basic_type), type2name(field_type));                                                                   \
+    name##_offset_from_start = total_offset_from_start;                                                                        \
+  } else
+
+#define CREATE_PTR_FIELD_OFFSET_CASE(klass, name, name_sym, ...)                                                           \
+  if (symbol_equals(field_name, name_sym)) {                                                                               \
+    guarantee(name##_offset_from_start == max_juint, "non-static field %s::%s dumped multiple times in " HDID_FORMAT,      \
+              vmSymbols::klass()->as_klass_external_name(), field_name->as_C_string(), klass##_dump.id);                   \
+    const u4 field_size = is_java_primitive(field_type) ? type2aelembytes(field_type) : heap_dump.id_size;                 \
+    name##_offset_from_start = total_offset_from_start;                                                                    \
+    if (_ptr_type == T_ILLEGAL) {                                                                                          \
+      guarantee(field_type == T_INT || field_type == T_LONG,                                                               \
+                "illegal type of non-static raw pointer field %s::%s (ID " HDID_FORMAT "): expected int or long, got %s",  \
+                vmSymbols::klass()->as_klass_external_name(), field_name->as_C_string(), klass##_dump.id,                  \
+                type2name(field_type));                                                                                    \
+      _ptr_type = field_type;                                                                                              \
+    } else {                                                                                                               \
+      precond(_ptr_type == T_INT || _ptr_type == T_LONG);                                                                  \
+      guarantee(field_type == _ptr_type, "%s object " HDID_FORMAT " has non-static raw pointer fields of different types", \
+                vmSymbols::klass()->as_klass_external_name(), klass##_dump.id);                                            \
+    }                                                                                                                      \
+  } else
+
+#define CHECK_FIELD_FOUND(klass, name, ...) name##_offset_from_start < max_juint &&
+
+#define SET_FIELD_OFFSET(klass, name, ...) _##name##_offset = total_offset_from_start - name##_offset_from_start;
+
+#define INITIALIZE_OFFSETS(klass, FIELDS_DO, PTR_FIELDS_DO)                                                     \
+  FIELDS_DO(DEFINE_OFFSET_FROM_START_LOCAL)                                                                     \
+  PTR_FIELDS_DO(DEFINE_OFFSET_FROM_START_LOCAL)                                                                 \
+  u4 total_offset_from_start = 0;                                                                               \
+  for (u2 i = 0; i < klass##_dump.instance_field_infos.size(); i++) {                                           \
+    const HeapDump::ClassDump::Field::Info &field_info = klass##_dump.instance_field_infos[i];                  \
+    const BasicType field_type = HeapDump::htype2btype(field_info.type);                                        \
+    const Symbol *field_name = heap_dump.get_symbol(field_info.name_id);                                        \
+    FIELDS_DO(CREATE_FIELD_OFFSET_CASE)                                                                         \
+    PTR_FIELDS_DO(CREATE_PTR_FIELD_OFFSET_CASE)                                                                 \
+    { /* final else branch */ }                                                                                 \
+    total_offset_from_start += is_java_primitive(field_type) ? type2aelembytes(field_type) : heap_dump.id_size; \
+  }                                                                                                             \
+  guarantee(FIELDS_DO(CHECK_FIELD_FOUND) PTR_FIELDS_DO(CHECK_FIELD_FOUND) /* && */ true,                        \
+            "some non-static fields are missing from %s class dump " HDID_FORMAT,                               \
+            vmSymbols::klass()->as_klass_external_name(), klass##_dump.id);                                     \
+  FIELDS_DO(SET_FIELD_OFFSET)                                                                                   \
+  PTR_FIELDS_DO(SET_FIELD_OFFSET)
+
+#define ASSERT_INITIALIZED_WITH_SAME_ID(klass)                                                             \
+  precond(_##klass##_id != HeapDump::NULL_ID);                                                             \
+  assert(_##klass##_id == klass##_id,                                                                      \
+         "%s class dump already found with different ID: old ID = " HDID_FORMAT ", new ID = " HDID_FORMAT, \
+         vmSymbols::klass()->as_klass_external_name(), _##klass##_id, klass##_id);
+
+#define DEFINE_GET_FIELD_METHOD(klass, name, name_sym, basic_type, c_type, type_name)                                          \
+  c_type HeapDumpClasses::klass::name(const HeapDump::InstanceDump &dump) const {                                              \
+    precond(is_initialized() && _##name##_offset >= (is_java_primitive(basic_type) ? type2aelembytes(basic_type) : _id_size)); \
+    guarantee(dump.fields_data.size() >= _##name##_offset,                                                                     \
+              "%s object " HDID_FORMAT " has not enough non-static field data to store its '" #name "' field",              \
+              vmSymbols::klass()->as_klass_external_name(), dump.id);                                                          \
+    return dump.read_field(dump.fields_data.size() - _##name##_offset, basic_type, _id_size).as_##type_name;                   \
+  }
+
+#define DEFINE_GET_PTR_FIELD_METHOD(klass, name, name_sym)                                                             \
+  jlong HeapDumpClasses::java_lang_Class::name(const HeapDump::InstanceDump &dump) const {                             \
+    precond(is_initialized() && _##name##_offset >= checked_cast<u4>(type2aelembytes(_ptr_type)));                     \
+    guarantee(dump.fields_data.size() >= _##name##_offset,                                                             \
+              "%s object " HDID_FORMAT " has not enough non-static field data to store its '" #name "' field",         \
+              vmSymbols::klass()->as_klass_external_name(), dump.id);                                                  \
+    const HeapDump::BasicValue val = dump.read_field(dump.fields_data.size() - _##name##_offset, _ptr_type, _id_size); \
+    switch (_ptr_type) {                                                                                               \
+      case T_INT:  return val.as_int;                                                                                  \
+      case T_LONG: return val.as_long;                                                                                 \
+      default:                                                                                                         \
+        ShouldNotReachHere();                                                                                          \
+        return 0;                                                                                                      \
+    }                                                                                                                  \
+  }
+
+// java.lang.ClassLoader
+
+#ifdef ASSERT
+static bool is_class_loader_class_dump(const ParsedHeapDump &heap_dump, const HeapDump::ClassDump &dump) {
+  const bool has_right_name_and_loader = heap_dump.get_class_name(dump.id) == vmSymbols::java_lang_ClassLoader() &&
+                                         dump.class_loader_id == HeapDump::NULL_ID;
+  if (!has_right_name_and_loader) {
+    return false;
+  }
+
+  assert(dump.super_id != HeapDump::NULL_ID, "illegal super in %s dump " HDID_FORMAT ": expected %s, got none",
+         vmSymbols::java_lang_ClassLoader()->as_klass_external_name(), dump.id,
+         vmSymbols::java_lang_Object()->as_klass_external_name());
+
+  const HeapDump::ClassDump &super_dump = heap_dump.get_class_dump(dump.super_id);
+  assert(heap_dump.get_class_name(super_dump.id) == vmSymbols::java_lang_Object() &&
+         super_dump.class_loader_id == HeapDump::NULL_ID, "illegal super in %s dump " HDID_FORMAT ": expected %s, got %s",
+         vmSymbols::java_lang_ClassLoader()->as_klass_external_name(), dump.id,
+         heap_dump.get_class_name(super_dump.id)->as_klass_external_name(),
+         vmSymbols::java_lang_Object()->as_klass_external_name());
+
+  return true;
+}
+
+DEFINE_INSTANCE_DUMP_CHECK(class_loader)
+#endif // ASSERT
+
+void HeapDumpClasses::java_lang_ClassLoader::ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_ClassLoader_id) {
+  precond(java_lang_ClassLoader_id != HeapDump::NULL_ID);
+  if (!is_initialized()) {
+    const HeapDump::ClassDump &java_lang_ClassLoader_dump = heap_dump.get_class_dump(java_lang_ClassLoader_id);
+    precond(is_class_loader_class_dump(heap_dump, java_lang_ClassLoader_dump));
+    INITIALIZE_OFFSETS(java_lang_ClassLoader, CLASSLOADER_DUMP_FIELDS_DO, NO_DUMP_FIELDS_DO)
+    DEBUG_ONLY(_java_lang_ClassLoader_id = java_lang_ClassLoader_id);
+    _id_size = heap_dump.id_size;
+  } else {
+    ASSERT_INITIALIZED_WITH_SAME_ID(java_lang_ClassLoader)
+  }
+  postcond(is_initialized());
+}
+
+CLASSLOADER_DUMP_FIELDS_DO(DEFINE_GET_FIELD_METHOD)
+
+
+// java.lang.Class
+
+#ifdef ASSERT
+static bool is_class_mirror_class_dump(const ParsedHeapDump &heap_dump, const HeapDump::ClassDump &dump) {
+  const bool has_right_name_and_loader = heap_dump.get_class_name(dump.id) == vmSymbols::java_lang_Class() &&
+                                         dump.class_loader_id == HeapDump::NULL_ID;
+  if (!has_right_name_and_loader) {
+    return false;
+  }
+
+  assert(dump.super_id != HeapDump::NULL_ID, "illegal super in %s dump " HDID_FORMAT ": expected %s, got none",
+         vmSymbols::java_lang_Class()->as_klass_external_name(), dump.id,
+         vmSymbols::java_lang_Object()->as_klass_external_name());
+
+  const HeapDump::ClassDump &super_dump = heap_dump.get_class_dump(dump.super_id);
+  assert(heap_dump.get_class_name(super_dump.id) == vmSymbols::java_lang_Object() &&
+         super_dump.class_loader_id == HeapDump::NULL_ID, "illegal super in %s dump " HDID_FORMAT ": expected %s, got %s",
+         vmSymbols::java_lang_Class()->as_klass_external_name(), dump.id,
+         heap_dump.get_class_name(super_dump.id)->as_klass_external_name(),
+         vmSymbols::java_lang_Object()->as_klass_external_name());
+
+  return true;
+}
+
+DEFINE_INSTANCE_DUMP_CHECK(class_mirror)
+#endif // ASSERT
+
+void HeapDumpClasses::java_lang_Class::ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_Class_id) {
+  precond(java_lang_Class_id != HeapDump::NULL_ID);
+  if (!is_initialized()) {
+    const HeapDump::ClassDump &java_lang_Class_dump = heap_dump.get_class_dump(java_lang_Class_id);
+    precond(is_class_loader_class_dump(heap_dump, java_lang_Class_dump));
+    INITIALIZE_OFFSETS(java_lang_Class, CLASSMIRROR_DUMP_FIELDS_DO, CLASSMIRROR_DUMP_PTR_FIELDS_DO)
+    DEBUG_ONLY(_java_lang_Class_id = java_lang_Class_id);
+    _id_size = heap_dump.id_size;
+  } else {
+    ASSERT_INITIALIZED_WITH_SAME_ID(java_lang_Class)
+  }
+  postcond(is_initialized());
+}
+
+CLASSMIRROR_DUMP_FIELDS_DO(DEFINE_GET_FIELD_METHOD)
+CLASSMIRROR_DUMP_PTR_FIELDS_DO(DEFINE_GET_PTR_FIELD_METHOD)
+
+HeapDumpClasses::java_lang_Class::Kind HeapDumpClasses::java_lang_Class::kind(const HeapDump::InstanceDump &dump) const {
+  const bool has_klass = klass(dump) != 0;
+  const bool has_component = componentType(dump) != 0;
+  if (has_klass) {
+    return has_component ? Kind::ARRAY : Kind::INSTANCE;
+  }
+  guarantee(!has_component, "%s object " HDID_FORMAT " representing a primitive type cannot have a component type",
+            vmSymbols::java_lang_Class()->as_klass_external_name(), dump.id);
+  return Kind::PRIMITIVE;
+}
+
+
+#undef DEFINE_GET_PTR_FIELD_METHOD
+#undef DEFINE_GET_FIELD_METHOD
+#undef ASSERT_INITIALIZED_WITH_SAME_ID
+#undef INITIALIZE_OFFSETS
+#undef SET_FIELD_OFFSET
+#undef CHECK_FIELD_FOUND
+#undef CREATE_PTR_FIELD_OFFSET_CASE
+#undef CREATE_FIELD_OFFSET_CASE
+#undef DEFINE_OFFSET_FROM_START_LOCAL
+#undef DEFINE_INSTANCE_DUMP_CHECK
+#undef NO_DUMP_FIELDS_DO

--- a/src/hotspot/share/utilities/heapDumpClasses.hpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.hpp
@@ -1,0 +1,84 @@
+#ifndef SHARE_UTILITIES_HEAPDUMPCLASSES_HPP
+#define SHARE_UTILITIES_HEAPDUMPCLASSES_HPP
+
+#include "memory/allStatic.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/heapDumpParser.hpp"
+
+#define DEFINE_OFFSET_FIELD(klass, name, ...) \
+  u4 _##name##_offset;
+#define DECLARE_GET_FIELD_METHOD(klass, name, name_sym, basic_type, c_type, type_name) \
+  c_type name(const HeapDump::InstanceDump &dump) const;
+// "Pointer" fields are internal fields of intptr type: their Java type is
+// either int or long depending on the CPU architecture
+#define DECLARE_GET_PTR_FIELD_METHOD(klass, name, name_sym) \
+  jlong name(const HeapDump::InstanceDump &dump) const;
+
+// Helper classes for parsing HPROF-dumped instance fields of well-known
+// classes and their sub-classes.
+//
+// Classes and fields are to be added on-demand.
+struct HeapDumpClasses : public AllStatic {
+
+  DEBUG_ONLY(static bool is_class_loader_dump(const ParsedHeapDump &heap_dump, const HeapDump::InstanceDump &dump));
+
+#define CLASSLOADER_DUMP_FIELDS_DO(macro)                                      \
+  macro(java_lang_ClassLoader, parent, vmSymbols::parent_name(), T_OBJECT, HeapDump::ID, object_id)   \
+  macro(java_lang_ClassLoader, name, vmSymbols::name_name(), T_OBJECT, HeapDump::ID, object_id)       \
+  macro(java_lang_ClassLoader, nameAndId, "nameAndId", T_OBJECT, HeapDump::ID, object_id)             \
+  macro(java_lang_ClassLoader, unnamedModule, "unnamedModule", T_OBJECT, HeapDump::ID, object_id)     \
+  macro(java_lang_ClassLoader, parallelLockMap, "parallelLockMap", T_OBJECT, HeapDump::ID, object_id)
+
+  class java_lang_ClassLoader {
+   private:
+    u4 _id_size = 0;
+    CLASSLOADER_DUMP_FIELDS_DO(DEFINE_OFFSET_FIELD)
+    DEBUG_ONLY(HeapDump::ID _java_lang_ClassLoader_id = HeapDump::NULL_ID);
+
+   public:
+    void ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_ClassLoader_id);
+    CLASSLOADER_DUMP_FIELDS_DO(DECLARE_GET_FIELD_METHOD)
+
+   private:
+    bool is_initialized() const { return _id_size > 0; }
+  };
+
+
+  DEBUG_ONLY(static bool is_class_mirror_dump(const ParsedHeapDump &heap_dump, const HeapDump::InstanceDump &dump));
+
+#define CLASSMIRROR_DUMP_FIELDS_DO(macro)                                                                   \
+  macro(java_lang_Class, name, vmSymbols::name_name(), T_OBJECT, HeapDump::ID, object_id)                   \
+  macro(java_lang_Class, module, "module", T_OBJECT, HeapDump::ID, object_id)                               \
+  macro(java_lang_Class, componentType, vmSymbols::componentType_name(), T_OBJECT, HeapDump::ID, object_id)
+#define CLASSMIRROR_DUMP_PTR_FIELDS_DO(macro) \
+  macro(java_lang_Class, klass, vmSymbols::klass_name())
+
+  class java_lang_Class {
+   private:
+    u4 _id_size = 0;
+    BasicType _ptr_type = T_ILLEGAL;
+    CLASSMIRROR_DUMP_FIELDS_DO(DEFINE_OFFSET_FIELD)
+    CLASSMIRROR_DUMP_PTR_FIELDS_DO(DEFINE_OFFSET_FIELD)
+    DEBUG_ONLY(HeapDump::ID _java_lang_Class_id = HeapDump::NULL_ID);
+
+   public:
+    void ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_Class_id);
+
+    CLASSMIRROR_DUMP_FIELDS_DO(DECLARE_GET_FIELD_METHOD)
+    CLASSMIRROR_DUMP_PTR_FIELDS_DO(DECLARE_GET_PTR_FIELD_METHOD)
+
+    enum class Kind { INSTANCE, ARRAY, PRIMITIVE };
+    Kind kind(const HeapDump::InstanceDump &dump) const;
+    bool is_instance_kind(const HeapDump::InstanceDump &dump) const  { return kind(dump) == Kind::INSTANCE; }
+    bool is_array_kind(const HeapDump::InstanceDump &dump) const     { return kind(dump) == Kind::ARRAY; }
+    bool is_primitive_kind(const HeapDump::InstanceDump &dump) const { return kind(dump) == Kind::PRIMITIVE; }
+
+   private:
+    bool is_initialized() const { return _id_size > 0; }
+  };
+};
+
+#undef DECLARE_GET_FIELD_METHOD
+#undef DEFINE_OFFSET_FIELD
+
+#endif // SHARE_UTILITIES_HEAPDUMPCLASSES_HPP

--- a/src/hotspot/share/utilities/heapDumpClasses.hpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.hpp
@@ -50,8 +50,9 @@ struct HeapDumpClasses : public AllStatic {
   macro(java_lang_Class, name, vmSymbols::name_name(), T_OBJECT, HeapDump::ID, object_id)                   \
   macro(java_lang_Class, module, "module", T_OBJECT, HeapDump::ID, object_id)                               \
   macro(java_lang_Class, componentType, vmSymbols::componentType_name(), T_OBJECT, HeapDump::ID, object_id)
-#define CLASSMIRROR_DUMP_PTR_FIELDS_DO(macro) \
-  macro(java_lang_Class, klass, vmSymbols::klass_name())
+#define CLASSMIRROR_DUMP_PTR_FIELDS_DO(macro)                        \
+  macro(java_lang_Class, klass, vmSymbols::klass_name())             \
+  macro(java_lang_Class, array_klass, vmSymbols::array_klass_name())
 
   class java_lang_Class {
    private:
@@ -72,6 +73,11 @@ struct HeapDumpClasses : public AllStatic {
     bool is_instance_kind(const HeapDump::InstanceDump &dump) const  { return kind(dump) == Kind::INSTANCE; }
     bool is_array_kind(const HeapDump::InstanceDump &dump) const     { return kind(dump) == Kind::ARRAY; }
     bool is_primitive_kind(const HeapDump::InstanceDump &dump) const { return kind(dump) == Kind::PRIMITIVE; }
+
+    bool mirrors_void(const HeapDump::InstanceDump &dump) const {
+      // Void is the only "primitive type" without an array class
+      return is_primitive_kind(dump) && array_klass(dump) == 0;
+    }
 
    private:
     bool is_initialized() const { return _id_size > 0; }

--- a/src/hotspot/share/utilities/heapDumpParser.hpp
+++ b/src/hotspot/share/utilities/heapDumpParser.hpp
@@ -114,8 +114,7 @@ struct HeapDump : AllStatic {
       case HPROF_INT:           return T_INT;
       case HPROF_LONG:          return T_LONG;
       case HPROF_NORMAL_OBJECT: return T_OBJECT;
-      case HPROF_ARRAY_OBJECT:  return T_ARRAY;
-      default:                  return T_ILLEGAL;
+      default:                  return T_ILLEGAL; // Includes HPROF_ARRAY_OBJECT which is not used
     }
   }
 };

--- a/test/hotspot/gtest/runtime/test_cracStackDumpParser.cpp
+++ b/test/hotspot/gtest/runtime/test_cracStackDumpParser.cpp
@@ -1,7 +1,7 @@
 #include "precompiled.hpp"
 #include "unittest.hpp"
-#include "utilities/stackDumpParser.hpp"
-#include "utilities/stackDumper.hpp"
+#include "runtime/cracStackDumpParser.hpp"
+#include "runtime/cracStackDumper.hpp"
 
 constexpr char TEST_FILENAME[] = "stackDumpParser_test.hprof";
 
@@ -51,16 +51,16 @@ static void check_stack_frames(const StackTrace &expected_trace,
 }
 
 static constexpr char CONTENTS_NO_TRACES[] =
-    "JAVA STACK DUMP 0.1\0" // Header
+    "CRAC STACK DUMP 0.1\0" // Header
     "\x00\x04"              // Word size
     ;
 
-TEST(StackDumpParser, no_stack_traces) {
+TEST(CracStackDumpParser, no_stack_traces) {
   fill_test_file(CONTENTS_NO_TRACES, sizeof(CONTENTS_NO_TRACES) - 1);
   ASSERT_FALSE(testing::Test::HasFatalFailure() || testing::Test::HasNonfatalFailure());
 
   ParsedStackDump stack_dump;
-  const char *err_msg = StackDumpParser::parse(TEST_FILENAME, &stack_dump);
+  const char *err_msg = CracStackDumpParser::parse(TEST_FILENAME, &stack_dump);
   ASSERT_EQ(nullptr, err_msg) << "Parsing error: " << err_msg;
 
   EXPECT_EQ(4U, stack_dump.word_size());
@@ -68,7 +68,7 @@ TEST(StackDumpParser, no_stack_traces) {
 }
 
 static constexpr char CONTENTS_EMPTY_TRACE[] =
-    "JAVA STACK DUMP 0.1\0" // Header
+    "CRAC STACK DUMP 0.1\0" // Header
     "\x00\x04"              // Word size
 
     "\xab\xcd\xef\x95"      // Thread ID
@@ -76,12 +76,12 @@ static constexpr char CONTENTS_EMPTY_TRACE[] =
     "\x00\x00\x00\x00"      // Number of frames
     ;
 
-TEST(StackDumpParser, empty_stack_trace) {
+TEST(CracStackDumpParser, empty_stack_trace) {
   fill_test_file(CONTENTS_EMPTY_TRACE, sizeof(CONTENTS_EMPTY_TRACE) - 1);
   ASSERT_FALSE(testing::Test::HasFatalFailure() || testing::Test::HasNonfatalFailure());
 
   ParsedStackDump stack_dump;
-  const char *err_msg = StackDumpParser::parse(TEST_FILENAME, &stack_dump);
+  const char *err_msg = CracStackDumpParser::parse(TEST_FILENAME, &stack_dump);
   ASSERT_EQ(nullptr, err_msg) << "Parsing error: " << err_msg;
 
   EXPECT_EQ(4U, stack_dump.word_size());
@@ -94,7 +94,7 @@ TEST(StackDumpParser, empty_stack_trace) {
 }
 
 static constexpr char CONTENTS_NO_STACK_VALUES[] =
-    "JAVA STACK DUMP 0.1\0" // Header
+    "CRAC STACK DUMP 0.1\0" // Header
     "\x00\x04"              // Word size
 
     "\xab\xcd\xef\x95"      // Thread ID
@@ -109,12 +109,12 @@ static constexpr char CONTENTS_NO_STACK_VALUES[] =
       "\x00\x00"              // Monitors num
     ;
 
-TEST(StackDumpParser, stack_frame_with_no_stack_values) {
+TEST(CracStackDumpParser, stack_frame_with_no_stack_values) {
   fill_test_file(CONTENTS_NO_STACK_VALUES, sizeof(CONTENTS_NO_STACK_VALUES) - 1);
   ASSERT_FALSE(testing::Test::HasFatalFailure() || testing::Test::HasNonfatalFailure());
 
   ParsedStackDump stack_dump;
-  const char *err_msg = StackDumpParser::parse(TEST_FILENAME, &stack_dump);
+  const char *err_msg = CracStackDumpParser::parse(TEST_FILENAME, &stack_dump);
   ASSERT_EQ(nullptr, err_msg) << "Parsing error: " << err_msg;
 
   EXPECT_EQ(4U, stack_dump.word_size());
@@ -133,7 +133,7 @@ TEST(StackDumpParser, stack_frame_with_no_stack_values) {
 }
 
 static constexpr char CONTENTS_CORRECT_STACK_VALUES[] =
-    "JAVA STACK DUMP 0.1\0"              // Header
+    "CRAC STACK DUMP 0.1\0"              // Header
     "\x00\x08"                           // Word size
 
     "\xab\xcd\xef\x95\xba\xdc\xfe\x96"   // Thread ID
@@ -158,12 +158,12 @@ static constexpr char CONTENTS_CORRECT_STACK_VALUES[] =
       "\x00\x00"                           // Monitors num
     ;
 
-TEST(StackDumpParser, stack_frame_with_correct_stack_values) {
+TEST(CracStackDumpParser, stack_frame_with_correct_stack_values) {
   fill_test_file(CONTENTS_CORRECT_STACK_VALUES, sizeof(CONTENTS_CORRECT_STACK_VALUES) - 1);
   ASSERT_FALSE(testing::Test::HasFatalFailure() || testing::Test::HasNonfatalFailure());
 
   ParsedStackDump stack_dump;
-  const char *err_msg = StackDumpParser::parse(TEST_FILENAME, &stack_dump);
+  const char *err_msg = CracStackDumpParser::parse(TEST_FILENAME, &stack_dump);
   ASSERT_EQ(nullptr, err_msg) << "Parsing error: " << err_msg;
 
   EXPECT_EQ(8U, stack_dump.word_size());
@@ -190,7 +190,7 @@ TEST(StackDumpParser, stack_frame_with_correct_stack_values) {
 }
 
 static constexpr char CONTENTS_MULTIPLE_STACKS[] =
-    "JAVA STACK DUMP 0.1\0" // Header
+    "CRAC STACK DUMP 0.1\0" // Header
     "\x00\x04"              // Word size
 
     "\xab\xcd\xef\x95"      // Thread ID
@@ -230,12 +230,12 @@ static constexpr char CONTENTS_MULTIPLE_STACKS[] =
       "\x00\x00"              // Monitors num
     ;
 
-TEST(StackDumpParser, multiple_stacks_dumped) {
+TEST(CracStackDumpParser, multiple_stacks_dumped) {
   fill_test_file(CONTENTS_MULTIPLE_STACKS, sizeof(CONTENTS_MULTIPLE_STACKS) - 1);
   ASSERT_FALSE(testing::Test::HasFatalFailure() || testing::Test::HasNonfatalFailure());
 
   ParsedStackDump stack_dump;
-  const char *err_msg = StackDumpParser::parse(TEST_FILENAME, &stack_dump);
+  const char *err_msg = CracStackDumpParser::parse(TEST_FILENAME, &stack_dump);
   ASSERT_EQ(nullptr, err_msg) << "Parsing error: " << err_msg;
 
   EXPECT_EQ(4U, stack_dump.word_size());

--- a/test/hotspot/gtest/utilities/test_heapDumpParser.cpp
+++ b/test/hotspot/gtest/utilities/test_heapDumpParser.cpp
@@ -331,28 +331,15 @@ TEST_VM(HeapDumpParser, instance_dump_read_field) {
 
   ASSERT_EQ(expected_field_data_size, record->fields_data.size());
 
-  HeapDump::BasicValue actual_field;
-
-  ASSERT_EQ(sizeof(expected_field1), record->read_field(0, JVM_SIGNATURE_SHORT, expected_id_size, &actual_field));
-  EXPECT_EQ(expected_field1, actual_field.as_short);
-
-  ASSERT_EQ(sizeof(expected_field2),
-            record->read_field(sizeof(expected_field1), JVM_SIGNATURE_INT, expected_id_size, &actual_field));
-  EXPECT_EQ(expected_field2, actual_field.as_int);
-
-  ASSERT_EQ(sizeof(expected_field3), record->read_field(sizeof(expected_field1) + sizeof(expected_field2),
-                                                        JVM_SIGNATURE_BOOLEAN, expected_id_size, &actual_field));
-  EXPECT_EQ(expected_field3, actual_field.as_boolean);
-
-  ASSERT_EQ(sizeof(expected_field4),
-            record->read_field(sizeof(expected_field1) + sizeof(expected_field2) + sizeof(expected_field3),
-                               JVM_SIGNATURE_FLOAT, expected_id_size, &actual_field));
-  EXPECT_EQ(expected_field4, actual_field.as_float);
-
-  ASSERT_EQ(sizeof(expected_field5), record->read_field(sizeof(expected_field1) + sizeof(expected_field2) +
-                                                            sizeof(expected_field3) + sizeof(expected_field4),
-                                                        JVM_SIGNATURE_CLASS, expected_id_size, &actual_field));
-  EXPECT_EQ(expected_field5, actual_field.as_object_id);
+  EXPECT_EQ(expected_field1, record->read_field(0, T_SHORT, expected_id_size).as_short);
+  EXPECT_EQ(expected_field2, record->read_field(sizeof(expected_field1),
+                                                T_INT, expected_id_size).as_int);
+  EXPECT_EQ(expected_field3, record->read_field(sizeof(expected_field1) + sizeof(expected_field2),
+                                                T_BOOLEAN, expected_id_size).as_boolean);
+  EXPECT_EQ(expected_field4, record->read_field(sizeof(expected_field1) + sizeof(expected_field2) + sizeof(expected_field3),
+                                                T_FLOAT, expected_id_size).as_float);
+  EXPECT_EQ(expected_field5, record->read_field(sizeof(expected_field1) + sizeof(expected_field2) + sizeof(expected_field3) + sizeof(expected_field4),
+                                                T_OBJECT, expected_id_size).as_object_id);
 }
 
 static constexpr char CONTENTS_OBJ_ARRAY_DUMP[] =

--- a/test/jdk/jdk/crac/portable/ResourceCallbacks.java
+++ b/test/jdk/jdk/crac/portable/ResourceCallbacks.java
@@ -3,8 +3,9 @@ import jdk.crac.Core;
 import jdk.crac.Resource;
 
 /**
- * NOTE: currently this example DOES NOT WORK because restoration of lambdas is
- * not yet implemented.
+ * NOTE: currently this example DOES NOT WORK because restoration of the thread
+ * initiating the checkpoint is not implemented (the thread runs native code at
+ * the moment of checkpoint).
  *
  * Demonstrates resource callbacks.
  * <p>


### PR DESCRIPTION
Implements loading and defining classes to be restored without invoking their class loaders.

Main parts of the implementation:
1. On checkpoint, [`CracClassDumper`](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassDumper.hpp#L89) creates a class dump — a single file with all `InstanceKlass`es serialized, plus list of all `ArrayKlass`es and some class loading info. The classes are dumped in such order that they can be defined on the fly while parsing the dump (e.g. supers and interfaces of a class are dumped before the class).
2. On [restore](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/crac.cpp#L777):
   1. [`CracClassDumpParser`](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassDumpParser.hpp#L56) [parses the dump and allocates the classes](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassDumpParser.cpp#L1868). It uses [`CracHeapRestorer`](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracHeapRestorer.hpp#L60) to [get prepared class loaders](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracHeapRestorer.cpp#L455) (only several fields essential to class definition are restored in these, all involved objects are recorded as restored for the future heap restoration, such loaders cannot be used for real class loading yet) and [`CracClassStateRestorer`](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassStateRestorer.hpp#L58) to [define the classes](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassStateRestorer.cpp#L187) (the classes are marked so that concurrent threads won't link or initialize them; if a class is already defined the parsed data is partially transferred into it). Array classes are also created at this step.
   2. `CracClassDumpParser` uses `CracClassStateRestorer` to [fill inter-class constant pool references](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassStateRestorer.cpp#L465) among the parsed classes — these cannot be filled when parsing because they may contain cyclic dependencies (e.g. class A refers to class B and B refers to A — we have to parse and define both to fill such reference).
   3. `CracClassDumpParser` [parses and applies information about initiating class loaders](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassDumpParser.cpp#L1897). In the future, class loader constraints should also be parsed and applied here (currently they are not restored).
   4. [Heap restoration starts](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracHeapRestorer.cpp#L478): `CracHeapRestorer` first records java.lang.Class objects of all the created classes and also finds such objects of primitive types, then restores heap references of the classes (resolved references arrays, initialization exceptions, static fields and fields of j.l.Class object), restoration of the previously prepared class loaders also completes at this step.
   5. When each class is restored, `CracClassStateRestorer` is used to [apply its state](https://github.com/TimPushkin/crac/blob/80d98adb1290fffef87f8865fa666f6c7f778001/src/hotspot/share/runtime/cracClassStateRestorer.cpp#L631), i.e. mark the class as loaded, linked or initialized — after that the class is ready to be used as a normal class.

Related stuff left for the future:
1. Pre-defined (defined not by the restoration algorithm) hidden classes are duplicated because there is no way to find out if they are pre-defined or not: multiple hidden classes can be defined from the same class file using the same class loader — the only difference will be the postfix in the name of the resulting class. So, even though we can find the defining class loader of such class, we cannot know if this exact class is already defined or not since there may be multiple hidden classes defined by this loader with everything but the postfix being the same and the postfix itself does not really tell anything.
   The only case I see where this may be a problem is when a pre-defined class (or a pre-existing thread stack value) and a restored class (or a stack value) both reference the same hidden class when being checkpointed. In this case after being restored they will reference different classes since the restored one will be recreated.
2. References from pre-defined classes are duplicated. To fix these we would need to walk these classes and record all their references (and references of these references), matching them with IDs from the heap dump. This is not trivial since the types may not match.
3. Instances of classes well-known to the VM (they are probably all listed in [`javaClasses.hpp`](https://github.com/TimPushkin/crac/blob/portable-cr/class-dump/src/hotspot/share/classfile/javaClasses.hpp)) may need special treatment when being restored (e.g. they may contain platform-dependent fields or VM may rely on them being recorded in some special way).
   1. Related problem: interned `java.lang.String` objects are not interned when being restored — need to add more data to heap dump to support this.
4. Class loading constraints are not restored — this should be easy: on checkpoint, write the constraints into the class dump, on restore, add them back after all classes are defined.
5. Restore more class data:
   1. Resolved virtual call info in the constant pool cache is not restored because vtable indices are not portable (vtable depends on method ordering which, in turn, depends on the order of method names in the symbol table). But there probably is portable data that can be written to help restore these without going through the usual resolution process.
   2. CDS- and JVM TI-related data is not currently restored, e.g. redefined classes are not supported, breakpoints are not saved.