### PR TITLE
Thread restoration improvements

### DIFF
--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -966,7 +966,10 @@ class vframeRestoreArray : public vframeArray {
     for (int i = 0; i < frames(); i++) {
       log_trace(crac)("Filling frame %i", i);
       auto *const elem = static_cast<vframeRestoreArrayElement *>(element(i));
-      elem->fill_in(stack.frames(i), i == 0 && stack.should_reexecute_youngest(), classes, objects, symbols);
+      // Note: youngest frame's BCI is always re-executed -- this is important
+      // because otherwise deopt's unpacking code will try to use ToS caching
+      // which we don't account for
+      elem->fill_in(stack.frames(i), i == 0, classes, objects, symbols);
       assert(!elem->method()->is_native(), "native methods are not restored");
     }
   }

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -30,7 +30,6 @@
 #include "runtime/handles.hpp"
 #include "runtime/javaThread.hpp"
 #include "utilities/exceptions.hpp"
-#include "utilities/heapDumpParser.hpp"
 
 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 #define UUID_LENGTH 36
@@ -79,12 +78,8 @@ private:
   static jlong javaTimeNanos_offset;
 
   static JavaValue restore_current_thread(TRAPS);
-  static void clear_restoration_data();
 
-  static ParsedHeapDump  *_heap_dump;
-  static ParsedStackDump *_stack_dump;
-  static HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> *_portable_restored_classes;
-  static HeapDumpTable<jobject, AnyObj::C_HEAP> *_portable_restored_objects;
+  static ParsedCracStackDump *_stack_dump;
 };
 
 #endif //SHARE_RUNTIME_CRAC_HPP

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -26,7 +26,9 @@
 
 #include "memory/allStatic.hpp"
 #include "runtime/cracStackDumpParser.hpp"
+#include "runtime/deoptimization.hpp"
 #include "runtime/handles.hpp"
+#include "runtime/javaThread.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/heapDumpParser.hpp"
 
@@ -63,8 +65,10 @@ public:
   // Restores thread states and launches their execution. Should only be called
   // once, after restore_heap() has been called.
   static void restore_threads(TRAPS);
+  // Called by RestoreStub to prepare information about frames to restore.
+  static Deoptimization::UnrollBlock *fetch_frame_info(JavaThread *current);
   // Called by RestoreStub to fill in the skeletal frames just created.
-  static void fill_in_frames();
+  static void fill_in_frames(JavaThread *current);
 
 private:
   static bool read_bootid(char *dest);

--- a/src/hotspot/share/runtime/cracClassDumpParser.cpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.cpp
@@ -1868,7 +1868,6 @@ InstanceKlass *CracClassDumpParser::parse_and_define_instance_class(const HeapDu
 }
 
 GrowableArray<Pair<HeapDump::ID, InterclassRefs>> CracClassDumpParser::parse_instance_and_obj_array_classes(TRAPS) {
-  HandleMark hm(Thread::current()); // Class loader handles
   GrowableArray<Pair<HeapDump::ID, InterclassRefs>> interclass_refs;
   for (ClassPreamble preamble = parse_instance_class_preamble(THREAD);
        !HAS_PENDING_EXCEPTION && preamble.class_id != HeapDump::NULL_ID;

--- a/src/hotspot/share/runtime/cracClassDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.hpp
@@ -4,12 +4,12 @@
 #include "memory/allocation.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/oopsHierarchy.hpp"
-#include "runtime/cracClassDumper.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/basicTypeReader.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/heapDumpParser.hpp"
+#include "utilities/methodKind.hpp"
 #include "utilities/pair.hpp"
 
 // Parsed class info that cannot be applied when parsing the dump.
@@ -61,8 +61,9 @@ class CracClassDumpParser: public ClassDumpReader {
                     HeapDumpTable<UnfilledClassInfo, AnyObj::C_HEAP> *unfilled_infos, TRAPS);
 
   // Finds a normal or a non-generic signature polymorphic method.
+  // TODO find a better place for this
   static Method *find_method(InstanceKlass *holder,
-                             Symbol *name, Symbol *signature, CracClassDump::MethodKind kind,
+                             Symbol *name, Symbol *signature, MethodKind::Enum kind,
                              bool lookup_signature_polymorphic, TRAPS);
 
  private:

--- a/src/hotspot/share/runtime/cracClassDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracClassDumpParser.hpp
@@ -70,6 +70,7 @@ class CracClassDumpParser: public ClassDumpReader {
   const ParsedHeapDump &_heap_dump;
   ClassLoaderProvider *const _loader_provider;
 
+  // Not resource-allocated because that would limit parser's usage of resource area
   HeapDumpTable<InstanceKlass *,   AnyObj::C_HEAP> *const _iks;
   HeapDumpTable<ArrayKlass *,      AnyObj::C_HEAP> *const _aks;
   HeapDumpTable<UnfilledClassInfo, AnyObj::C_HEAP> *const _unfilled_infos;

--- a/src/hotspot/share/runtime/cracClassDumper.cpp
+++ b/src/hotspot/share/runtime/cracClassDumper.cpp
@@ -50,6 +50,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/heapDumpParser.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/methodKind.hpp"
 #include "utilities/resizeableResourceHash.hpp"
 #include <cstdint>
 #include <limits>
@@ -159,16 +160,7 @@ class ClassDumpWriter : public KlassClosure, public CLDClosure {
     WRITE_CLASS_ID(*m.method_holder());
     WRITE_SYMBOL_ID(m.name());
     WRITE_SYMBOL_ID(m.signature());
-    CracClassDump::MethodKind kind;
-    if (m.is_static()) {
-      assert(!m.is_overpass(), "overpass methods are not static");
-      kind = CracClassDump::MethodKind::STATIC;
-    } else if (m.is_overpass()) {
-      kind = CracClassDump::MethodKind::OVERPASS;
-    } else {
-      kind = CracClassDump::MethodKind::INSTANCE;
-    }
-    WRITE(checked_cast<u1>(kind));
+    WRITE(checked_cast<u1>(MethodKind::of_method(m)));
   }
 
   // ###########################################################################

--- a/src/hotspot/share/runtime/cracClassDumper.hpp
+++ b/src/hotspot/share/runtime/cracClassDumper.hpp
@@ -2,8 +2,6 @@
 #define SHARE_RUNTIME_CRACCLASSDUMPER_HPP
 
 #include "memory/allStatic.hpp"
-#include "oops/klass.hpp"
-#include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 // Constants used in class dumps.
@@ -16,30 +14,6 @@ struct CracClassDump : public AllStatic {
   };
 
   static constexpr bool is_class_loading_kind(u1 val) { return val <= static_cast<u1>(ClassLoadingKind::STRONG_HIDDEN); }
-
-  // Kinds of methods. According to InstanceKlass::find_local_method(), a class
-  // can have separate methods with the same name and signature for each kind.
-  enum class MethodKind : u1 {
-    STATIC   = 0,
-    INSTANCE = 1, // Non-static, non-overpass
-    OVERPASS = 2,
-  };
-
-  static constexpr bool is_method_kind(u1 val) { return val <= static_cast<u1>(MethodKind::OVERPASS); }
-  static constexpr Klass::StaticLookupMode as_static_lookup_mode(MethodKind kind) {
-    return kind == MethodKind::STATIC ? Klass::StaticLookupMode::find : Klass::StaticLookupMode::skip;
-  }
-  static constexpr Klass::OverpassLookupMode as_overpass_lookup_mode(MethodKind kind) {
-    return kind == MethodKind::OVERPASS ? Klass::OverpassLookupMode::find : Klass::OverpassLookupMode::skip;
-  }
-  static constexpr const char *method_kind_name(MethodKind kind) {
-    switch (kind) {
-      case MethodKind::STATIC:   return "static";
-      case MethodKind::OVERPASS: return "overpass";
-      case MethodKind::INSTANCE: return "non-static non-overpass";
-      default: ShouldNotReachHere(); return nullptr;
-    }
-  }
 
   // Bit positions in compressed VM options.
   enum VMOptionShift : u1 {

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -548,7 +548,7 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
         Symbol *const sig = heap_dump.get_symbol(method_ref.f1_method_desc.sig_id);
         Method *const method = CracClassDumpParser::find_method(*klass, name, sig, method_ref.f1_method_desc.kind, true, CHECK);
         guarantee(method != nullptr, "class %s has a resolved method entry #%i with f1 referencing %s method %s that cannot be found",
-                  ik->external_name(), method_ref.cache_index, CracClassDump::method_kind_name(method_ref.f1_method_desc.kind),
+                  ik->external_name(), method_ref.cache_index, MethodKind::name(method_ref.f1_method_desc.kind),
                   Method::name_and_sig_as_C_string(*klass, name, sig));
         cache_entry.set_f1(method);
         postcond(cache_entry.f1_as_method() == method);
@@ -566,7 +566,7 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
       Symbol *const sig = heap_dump.get_symbol(method_ref.f2_method_desc.sig_id);
       Method *const method = CracClassDumpParser::find_method(*holder, name, sig, method_ref.f2_method_desc.kind, false, CHECK);
       guarantee(method != nullptr, "class %s has a resolved method entry #%i with f2 referencing %s method %s that cannot be found",
-                ik->external_name(), method_ref.cache_index, CracClassDump::method_kind_name(method_ref.f2_method_desc.kind),
+                ik->external_name(), method_ref.cache_index, MethodKind::name(method_ref.f2_method_desc.kind),
                 Method::name_and_sig_as_C_string(*holder, name, sig));
 
 #ifdef ASSERT
@@ -597,7 +597,7 @@ void CracClassStateRestorer::fill_interclass_references(InstanceKlass *ik,
     Symbol *const sig = heap_dump.get_symbol(indy_ref.method_desc.sig_id);
     Method *const method = CracClassDumpParser::find_method(*holder, name, sig, indy_ref.method_desc.kind, false, CHECK);
     guarantee(method != nullptr, "class %s has a resolved invokedynamic entry #%i referencing %s method %s that cannot be found",
-              ik->external_name(), indy_ref.indy_index, CracClassDump::method_kind_name(indy_ref.method_desc.kind),
+              ik->external_name(), indy_ref.indy_index, MethodKind::name(indy_ref.method_desc.kind),
               Method::name_and_sig_as_C_string(*holder, name, sig));
 
     indy_entry.adjust_method_entry(method);

--- a/src/hotspot/share/runtime/cracClassStateRestorer.hpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.hpp
@@ -5,12 +5,12 @@
 #include "memory/allocation.hpp"
 #include "oops/arrayKlass.hpp"
 #include "oops/instanceKlass.hpp"
-#include "runtime/cracClassDumper.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/heapDumpParser.hpp"
+#include "utilities/methodKind.hpp"
 
 // Class may reference other classes and while the class dump format guarantees
 // that some of such references (class loader class, super class, etc.) will be
@@ -29,7 +29,7 @@ struct InterclassRefs : public ResourceObj {
   struct MethodDescription {
     HeapDump::ID name_id;
     HeapDump::ID sig_id;
-    CracClassDump::MethodKind kind;
+    MethodKind::Enum kind;
   };
   struct MethodRef {
     int cache_index;

--- a/src/hotspot/share/runtime/cracStackDumpParser.cpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.cpp
@@ -39,8 +39,8 @@ class StackTracesParser : public StackObj {
       if (preamble.finish) {
         break;
       }
-      log_debug(crac, stacktrace, parser)("Parsing " UINT32_FORMAT " frame(s) of thread " UINT64_FORMAT,
-                                  preamble.frames_num, preamble.thread_id);
+      log_debug(crac, stacktrace, parser)("Parsing " UINT32_FORMAT " frame(s) of thread " SDID_FORMAT,
+                                          preamble.frames_num, preamble.thread_id);
 
       auto *trace = new StackTrace(preamble.thread_id, preamble.should_reexecute_youngest, preamble.frames_num);
       for (u4 i = 0; i < trace->frames_num(); i++) {
@@ -97,27 +97,27 @@ class StackTracesParser : public StackObj {
     // Should re-execute youngest
     u1 should_reexecute_youngest;
     if (!_reader->read(&should_reexecute_youngest)) {
-      log_error(crac, stacktrace, parser)("Failed to read the meaning of the youngest BCI of thread " UINT64_FORMAT,
-                                  preamble->thread_id);
+      log_error(crac, stacktrace, parser)("Failed to read the meaning of the youngest BCI of thread " SDID_FORMAT,
+                                          preamble->thread_id);
       return false;
     }
     if (should_reexecute_youngest >= 2U) {
-      log_error(crac, stacktrace, parser)("Illegal meaning of the youngest BCI of thread " UINT64_FORMAT ": %i",
-                                  preamble->thread_id, should_reexecute_youngest);
+      log_error(crac, stacktrace, parser)("Illegal meaning of the youngest BCI of thread " SDID_FORMAT ": %i",
+                                          preamble->thread_id, should_reexecute_youngest);
       return false;
     }
     preamble->should_reexecute_youngest = (should_reexecute_youngest == 1U);
 
     // Number of frames dumped
     if (!_reader->read(&preamble->frames_num)) {
-      log_error(crac, stacktrace, parser)("Failed to read number of frames in stack of thread " UINT64_FORMAT,
-                                  preamble->thread_id);
+      log_error(crac, stacktrace, parser)("Failed to read number of frames in stack of thread " SDID_FORMAT,
+                                          preamble->thread_id);
       return false;
     }
     if (preamble->frames_num == 0U && preamble->should_reexecute_youngest) {
-      log_error(crac, stacktrace, parser)("Thread " UINT64_FORMAT " is specified as having no frames specified, "
-                                  "but with the current bytecode of its youngest frame to be re-executed",
-                                  preamble->thread_id);
+      log_error(crac, stacktrace, parser)("Thread " SDID_FORMAT " is specified as having no frames "
+                                          "but with the current bytecode of its youngest frame to be re-executed",
+                                          preamble->thread_id);
       return false;
     }
 
@@ -236,8 +236,8 @@ static const char *parse_header(BasicTypeReader *reader, u2 *word_size) {
 }
 
 const char *CracStackDumpParser::parse(const char *path, ParsedStackDump *out) {
-  guarantee(path != nullptr, "cannot parse from null path");
-  guarantee(out != nullptr, "cannot save results into null container");
+  precond(path != nullptr);
+  precond(out != nullptr);
 
   log_info(crac, stacktrace, parser)("Started parsing %s", path);
 

--- a/src/hotspot/share/runtime/cracStackDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.hpp
@@ -1,62 +1,102 @@
 #ifndef SHARE_RUNTIME_CRACSTACKDUMPPARSER_HPP
 #define SHARE_RUNTIME_CRACSTACKDUMPPARSER_HPP
 
+#include "jni.h"
 #include "memory/allocation.hpp"
 #include "oops/instanceKlass.hpp"
+#include "runtime/handles.hpp"
+#include "runtime/jniHandles.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/exceptions.hpp"
-#include "utilities/extendableArray.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
-#include "runtime/cracStackDumper.hpp"
 #include "utilities/heapDumpParser.hpp"
 #include "utilities/methodKind.hpp"
+#include <type_traits>
+
+// Note: stack info parsing and usage happen in different resource and handle
+// scopes -- that is why everything here is heap-allocated and JNI handles are
+// used for OOPs
 
 // Format for stack dump IDs.
 #define SDID_FORMAT UINT64_FORMAT
 
 // Parsed stack trace.
-class StackTrace : public CHeapObj<mtInternal> {
+class CracStackTrace : public CHeapObj<mtInternal> {
  public:
   using ID = u8; // ID type always fits into 8 bytes
 
   class Frame : public CHeapObj<mtInternal> {
    public:
-    struct Value {
-      DumpedStackValueType type;
-      union {
-        u8 prim; // Primitive stack slots are either 4 or 8 bytes
-        ID obj_id;
+    class Value {
+     public:
+      enum class Type : u1 {
+        EMPTY, // Unfilled
+        PRIM,  // Primitive stack value
+        REF,   // Unresolved reference ID
+        OBJ    // Resolved reference (JNI handle owned by this value)
       };
+
+      Value() = default;
+      inline static Value of_primitive(u8 val) { return {Type::PRIM, val}; }
+      inline static Value of_obj_id(ID id)     { return {Type::REF, id}; }
+      inline static Value of_obj(Handle obj)   { return {JNIHandles::make_global(obj)}; }
+
+      // Copying: creates a new JNI handle if resolved.
+      Value(const Value &other);
+      Value &operator=(Value other);
+
+      ~Value() {
+        if (type() == Type::OBJ) {
+          JNIHandles::destroy_global(as_obj());
+        }
+      }
+
+      inline Type type() const       { return _type; }
+
+      inline u8 as_primitive() const { precond(type() == Type::PRIM); return _prim; }
+      inline ID as_obj_id() const    { precond(type() == Type::REF);  return _obj_id; }
+      inline jobject as_obj() const  { precond(type() == Type::OBJ);  return _obj; }
+
+     private:
+      Type _type = Type::EMPTY;
+      union {
+        u8 _prim;     // If the stack slot is 4 bytes only the low half of u8 is used
+        ID _obj_id;
+        jobject _obj; // JNI handle
+      };
+
+      Value(jobject obj) : _type(Type::OBJ), _obj(obj) {} // Implicit for no-copy return in of_obj()
+      Value(Type type, u8 value) : _type(type), _prim(value) {
+        STATIC_ASSERT((std::is_same<decltype(_prim), decltype(_obj_id)>::value));
+        assert(type == Type::PRIM || type == Type::REF, "use the other constructors");
+      }
     };
 
     Method *resolve_method(const HeapDumpTable<InstanceKlass *, AnyObj::C_HEAP> &classes,
                            const ParsedHeapDump::RecordTable<HeapDump::UTF8> &symbols, TRAPS);
     Method *method() const { assert(_resolved_method != nullptr, "unresolved"); return _resolved_method; }
 
-    // ID of method name string.
-    ID method_name_id() const { return _method_name_id; };
-    void set_method_name_id(ID id) { _method_name_id = id; }
-    // ID of method signature string.
-    ID method_sig_id() const { return _method_sig_id; };
-    void set_method_sig_id(ID id) { _method_sig_id = id; }
-    // Kind of the method.
-    MethodKind::Enum method_kind() const { return _method_kind; };
+    ID method_name_id() const                   { return _method_name_id; };
+    void set_method_name_id(ID id)              { _method_name_id = id; }
+
+    ID method_sig_id() const                    { return _method_sig_id; };
+    void set_method_sig_id(ID id)               { _method_sig_id = id; }
+
+    MethodKind::Enum method_kind() const        { return _method_kind; };
     void set_method_kind(MethodKind::Enum kind) { _method_kind = kind; }
-    // ID of the class containing the method.
-    ID method_holder_id() const { return _method_holder_id; };
-    void set_method_holder_id(ID id) { _method_holder_id = id; }
 
-    // Index of the current bytecode
-    u2 bci() const { return _bci; }
-    void set_bci(u2 bci) { _bci = bci;  }
+    ID method_holder_id() const                 { return _method_holder_id; };
+    void set_method_holder_id(ID id)            { _method_holder_id = id; }
 
-    // Local variables
-    const ExtendableArray<Value, u2> &locals() const { return _locals; }
-    ExtendableArray<Value, u2> &locals() { return _locals; }
+    u2 bci() const                              { return _bci; }
+    void set_bci(u2 bci)                        { _bci = bci;  }
 
-    // Operand/expression stack
-    const ExtendableArray<Value, u2> &operands() const { return _operands; }
-    ExtendableArray<Value, u2> &operands() { return _operands; }
+    const GrowableArrayCHeap<Value, mtInternal> &locals() const   { return _locals; }
+    GrowableArrayCHeap<Value, mtInternal> &locals()               { return _locals; }
+
+    const GrowableArrayCHeap<Value, mtInternal> &operands() const { return _operands; }
+    GrowableArrayCHeap<Value, mtInternal> &operands()             { return _operands; }
 
    private:
     ID _method_name_id;
@@ -67,20 +107,23 @@ class StackTrace : public CHeapObj<mtInternal> {
 
     u2 _bci;
 
-    ExtendableArray<Value, u2> _locals;
-    ExtendableArray<Value, u2> _operands;
+    GrowableArrayCHeap<Value, mtInternal> _locals;
+    GrowableArrayCHeap<Value, mtInternal> _operands;
   };
 
-  StackTrace(ID thread_id, u4 frames_num)
+  CracStackTrace(ID thread_id, u4 frames_num)
       : _thread_id(thread_id),  _frames_num(frames_num), _frames(new Frame[_frames_num]) {}
 
-  ~StackTrace() { delete[] _frames; }
+  NONCOPYABLE(CracStackTrace);
+
+  ~CracStackTrace() { delete[] _frames; }
 
   // ID of the thread whose stack this is.
   ID thread_id() const           { return _thread_id; }
+
   // Number of frames in the stack.
   u4 frames_num() const          { return _frames_num; }
-  // Stack frames from youngest to oldest.
+  // Frames from youngest to oldest.
   const Frame &frame(u4 i) const { precond(i < frames_num()); return _frames[i]; }
   Frame &frame(u4 i)             { precond(i < frames_num()); return _frames[i]; }
 
@@ -90,9 +133,9 @@ class StackTrace : public CHeapObj<mtInternal> {
   Frame *const _frames;
 };
 
-class ParsedStackDump : public CHeapObj<mtInternal> {
+class ParsedCracStackDump : public CHeapObj<mtInternal> {
  public:
-  ~ParsedStackDump() {
+  ~ParsedCracStackDump() {
     for (auto *_stack_trace : _stack_traces) {
       delete _stack_trace;
     }
@@ -102,18 +145,18 @@ class ParsedStackDump : public CHeapObj<mtInternal> {
   u2 word_size() const                                         { return _word_size; }
   void set_word_size(u2 value)                                 { _word_size = value; }
   // Parsed stack traces.
-  const GrowableArrayView<StackTrace *> &stack_traces() const  { return _stack_traces; }
-  GrowableArrayCHeap<StackTrace *, mtInternal> &stack_traces() { return _stack_traces; }
+  const GrowableArrayView<CracStackTrace *> &stack_traces() const  { return _stack_traces; }
+  GrowableArrayCHeap<CracStackTrace *, mtInternal> &stack_traces() { return _stack_traces; }
 
  private:
   u2 _word_size = 0;
-  GrowableArrayCHeap<StackTrace *, mtInternal> _stack_traces;
+  GrowableArrayCHeap<CracStackTrace *, mtInternal> _stack_traces;
 };
 
 struct CracStackDumpParser : public AllStatic {
   // Parses the stack dump in path filling the out container. Returns nullptr on
   // success or a pointer to a static error message otherwise.
-  static const char *parse(const char *path, ParsedStackDump *out);
+  static const char *parse(const char *path, ParsedCracStackDump *out);
 };
 
 #endif // SHARE_RUNTIME_CRACSTACKDUMPPARSER_HPP

--- a/src/hotspot/share/runtime/cracStackDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.hpp
@@ -7,6 +7,9 @@
 #include "utilities/growableArray.hpp"
 #include "runtime/cracStackDumper.hpp"
 
+// Format for stack dump IDs.
+#define SDID_FORMAT UINT64_FORMAT
+
 // Parsed stack trace.
 class StackTrace : public CHeapObj<mtInternal> {
  public:

--- a/src/hotspot/share/runtime/cracStackDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.hpp
@@ -33,11 +33,8 @@ class StackTrace : public CHeapObj<mtInternal> {
     // TODO monitors
   };
 
-  StackTrace(ID thread_id, bool should_reexecute_youngest, u4 frames_num)
-      : _thread_id(thread_id), _should_reexecute_youngest(should_reexecute_youngest),
-        _frames_num(frames_num), _frames(new Frame[_frames_num]) {
-    assert(_frames_num > 0 || !_should_reexecute_youngest, "should_reexecute_youngest must be false for empty trace");
-  }
+  StackTrace(ID thread_id, u4 frames_num)
+      : _thread_id(thread_id),  _frames_num(frames_num), _frames(new Frame[_frames_num]) {}
 
   ~StackTrace() { delete[] _frames; }
 
@@ -50,14 +47,9 @@ class StackTrace : public CHeapObj<mtInternal> {
   // Stack frames from youngest to oldest.
   const Frame &frames(u4 i) const        { precond(i < frames_num()); return _frames[i]; }
   Frame &frames(u4 i)                    { precond(i < frames_num()); return _frames[i]; }
-  // For the youngest frame, whether BCI specifies the bytecode to be executed
-  // or already executed. For the other frames such info is not needed because
-  // their BCIs should always specify the invoke bytecode being executed.
-  bool should_reexecute_youngest() const { return _should_reexecute_youngest; };
 
  private:
   const ID _thread_id;
-  const bool _should_reexecute_youngest;
   const u4 _frames_num;
   Frame *const _frames;
 };

--- a/src/hotspot/share/runtime/cracStackDumper.cpp
+++ b/src/hotspot/share/runtime/cracStackDumper.cpp
@@ -19,6 +19,7 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
+#include "utilities/methodKind.hpp"
 
 static uintptr_t oop2uint(oop o) {
   STATIC_ASSERT(sizeof(uintptr_t) == sizeof(intptr_t)); // Primitive stack slots
@@ -224,6 +225,10 @@ class StackDumpWriter : public StackObj {
       log_trace(crac, stacktrace, dump)("Method signature: " UINTX_FORMAT " - %s", reinterpret_cast<uintptr_t>(signature), signature->as_C_string());
     }
     WRITE(reinterpret_cast<uintptr_t>(signature));
+
+    const MethodKind::Enum kind = MethodKind::of_method(*method);
+    log_trace(crac, stacktrace, dump)("Method kind: %s", MethodKind::name(kind));
+    WRITE(checked_cast<u1>(kind));
 
     InstanceKlass *holder = method->method_holder();
     if (log_is_enabled(Trace, crac, stacktrace, dump)) {

--- a/src/hotspot/share/runtime/cracStackDumper.hpp
+++ b/src/hotspot/share/runtime/cracStackDumper.hpp
@@ -27,6 +27,10 @@
 //   Frames, from youngest to oldest:
 //     ID -- ID of the method name String object
 //     ID -- ID of the method signature String object
+//     u1 -- method kind:
+//           0 -- static method
+//           1 -- non-static, non-overpass method
+//           2 -- overpass method
 //     ID -- ID of the Class object of the method's class
 //           TODO JVM TI Redefine/RetransformClass support: add method holder's
 //                redefinition version to select the right one on restore.

--- a/src/hotspot/share/runtime/cracStackDumper.hpp
+++ b/src/hotspot/share/runtime/cracStackDumper.hpp
@@ -23,11 +23,6 @@
 //    StackValues for compiled frames), but not for interpreted ones.
 // Stack traces:
 //   ID -- ID of the Thread object
-//   u1 -- meaning of the bytecode index (BCI) for the youngest frame:
-//         0 -- either the BCI of the youngest frame specifies a bytecode which
-//              has been executed or there are no frames in the trace
-//         1 -- the BCI of the youngest frame specifies a bytecode to be
-//              executed next
 //   u4 -- number of frames that follow
 //   Frames, from youngest to oldest:
 //     ID -- ID of the method name String object
@@ -36,7 +31,7 @@
 //           TODO JVM TI Redefine/RetransformClass support: add method holder's
 //                redefinition version to select the right one on restore.
 //     u2 -- bytecode index (BCI) of the current bytecode: for the youngest
-//           frame see the BCI meaning in the trace preamble, and for the rest
+//           frame this specifies the bytecode to be executed, and for the rest
 //           of the frames this specifies the invoke bytecode being executed
 //     u2 -- number of locals that follow
 //     Locals array:

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1454,25 +1454,9 @@ void JavaThread::metadata_do(MetadataClosure* f) {
 }
 
 // Printing
-const char* _get_thread_state_name(JavaThreadState _thread_state) {
-  switch (_thread_state) {
-  case _thread_uninitialized:     return "_thread_uninitialized";
-  case _thread_new:               return "_thread_new";
-  case _thread_new_trans:         return "_thread_new_trans";
-  case _thread_in_native:         return "_thread_in_native";
-  case _thread_in_native_trans:   return "_thread_in_native_trans";
-  case _thread_in_vm:             return "_thread_in_vm";
-  case _thread_in_vm_trans:       return "_thread_in_vm_trans";
-  case _thread_in_Java:           return "_thread_in_Java";
-  case _thread_in_Java_trans:     return "_thread_in_Java_trans";
-  case _thread_blocked:           return "_thread_blocked";
-  case _thread_blocked_trans:     return "_thread_blocked_trans";
-  default:                        return "unknown thread state";
-  }
-}
 
 void JavaThread::print_thread_state_on(outputStream *st) const {
-  st->print_cr("   JavaThread state: %s", _get_thread_state_name(_thread_state));
+  st->print_cr("   JavaThread state: %s", thread_state_name());
 }
 
 // Called by Threads::print() for VM_PrintThreads operation
@@ -1535,7 +1519,7 @@ void JavaThread::print_on_error(outputStream* st, char *buf, int buflen) const {
     }
   }
   st->print(" [");
-  st->print("%s", _get_thread_state_name(_thread_state));
+  st->print("%s", thread_state_name());
   if (osthread()) {
     st->print(", id=%d", osthread()->thread_id());
   }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -557,6 +557,7 @@ private:
   inline JavaThreadState thread_state() const;
   inline void set_thread_state(JavaThreadState s);
   inline void set_thread_state_fence(JavaThreadState s);  // fence after setting thread state
+  inline const char *thread_state_name() const;
   inline ThreadSafepointState* safepoint_state() const;
   inline void set_safepoint_state(ThreadSafepointState* state);
   inline bool is_at_poll_safepoint();

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -164,6 +164,10 @@ inline void JavaThread::set_thread_state_fence(JavaThreadState s) {
   OrderAccess::fence();
 }
 
+inline const char *JavaThread::thread_state_name() const {
+  return ::thread_state_name(_thread_state);
+}
+
 ThreadSafepointState* JavaThread::safepoint_state() const  {
   return _safepoint_state;
 }

--- a/src/hotspot/share/runtime/vframeArray.hpp
+++ b/src/hotspot/share/runtime/vframeArray.hpp
@@ -189,8 +189,6 @@ class vframeArray: public CHeapObj<mtCompiler> {
   // Accessors for unroll block
   Deoptimization::UnrollBlock* unroll_block() const         { return _unroll_block; }
   void set_unroll_block(Deoptimization::UnrollBlock* block) { _unroll_block = block; }
-  // For assembly stub generation
-  static ByteSize unroll_block_offset()                     { return byte_offset_of(vframeArray, _unroll_block); }
 
   // Returns the size of the frame that got deoptimized
   int frame_size() const { return _frame_size; }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1023,6 +1023,23 @@ enum JavaThreadState {
   _thread_max_state         = 12  // maximum thread state+1 - used for statistics allocation
 };
 
+constexpr const char* thread_state_name(JavaThreadState state) {
+  switch (state) {
+    case _thread_uninitialized:     return "_thread_uninitialized";
+    case _thread_new:               return "_thread_new";
+    case _thread_new_trans:         return "_thread_new_trans";
+    case _thread_in_native:         return "_thread_in_native";
+    case _thread_in_native_trans:   return "_thread_in_native_trans";
+    case _thread_in_vm:             return "_thread_in_vm";
+    case _thread_in_vm_trans:       return "_thread_in_vm_trans";
+    case _thread_in_Java:           return "_thread_in_Java";
+    case _thread_in_Java_trans:     return "_thread_in_Java_trans";
+    case _thread_blocked:           return "_thread_blocked";
+    case _thread_blocked_trans:     return "_thread_blocked_trans";
+    default:                        return "unknown thread state";
+  }
+}
+
 enum LockingMode {
   // Use only heavy monitors for locking
   LM_MONITOR     = 0,

--- a/src/hotspot/share/utilities/heapDumpParser.hpp
+++ b/src/hotspot/share/utilities/heapDumpParser.hpp
@@ -129,7 +129,7 @@ using HeapDumpTable = ResizeableResourceHashtable<HeapDump::ID, V, ALLOC_TYPE>;
 
 struct ParsedHeapDump : public CHeapObj<mtInternal> {
   template <class V>
-  using RecordTable = HeapDumpTable<V, AnyObj::C_HEAP>; // TODO use resource area
+  using RecordTable = HeapDumpTable<V, AnyObj::C_HEAP /*for destructors to be called*/>;
 
   // Actual size of IDs in the dump.
   u4 id_size;

--- a/src/hotspot/share/utilities/methodKind.hpp
+++ b/src/hotspot/share/utilities/methodKind.hpp
@@ -1,0 +1,45 @@
+#ifndef SHARE_UTILITIES_METHODKIND_HPP
+#define SHARE_UTILITIES_METHODKIND_HPP
+
+#include "memory/allStatic.hpp"
+#include "oops/klass.hpp"
+#include "oops/method.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Kinds of methods.
+//
+// According to InstanceKlass::find_local_method(), a class can have separate
+// methods with the same name and signature for each of these kinds.
+struct MethodKind : public AllStatic {
+  enum class Enum: u1 {
+    STATIC   = 0,
+    INSTANCE = 1, // Non-static, non-overpass
+    OVERPASS = 2,
+  };
+
+  static Enum of_method(const Method &m) {
+    assert(!(m.is_static() && m.is_overpass()), "overpass cannot be static");
+    return m.is_static() ? Enum::STATIC : (m.is_overpass() ? Enum::OVERPASS : Enum::INSTANCE);
+  }
+
+  static constexpr bool is_method_kind(u1 val) { return val <= static_cast<u1>(Enum::OVERPASS); }
+
+  static constexpr Klass::StaticLookupMode as_static_lookup_mode(MethodKind::Enum kind) {
+    return kind == Enum::STATIC ? Klass::StaticLookupMode::find : Klass::StaticLookupMode::skip;
+  }
+  static constexpr Klass::OverpassLookupMode as_overpass_lookup_mode(MethodKind::Enum kind) {
+    return kind == Enum::OVERPASS ? Klass::OverpassLookupMode::find : Klass::OverpassLookupMode::skip;
+  }
+
+  static constexpr const char *name(MethodKind::Enum kind) {
+    switch (kind) {
+      case Enum::STATIC:   return "static";
+      case Enum::OVERPASS: return "overpass";
+      case Enum::INSTANCE: return "non-static non-overpass";
+      default: ShouldNotReachHere(); return nullptr;
+    }
+  }
+};
+
+#endif // SHARE_UTILITIES_METHODKIND_HPP


### PR DESCRIPTION
Various fixes and improvements of thread restoration code:
1. Dumped bytecode of the youngest thread is now always the one to be executed next. This is so because the deoptimization code used to fill the stack frames being restored tries to use ToS caching otherwise which is not accounted for by the restoration code.
2. Preparation of frame data to be used by the assembly and deoptimization code now happens after the Java-call to ensure there is no safepoint between the preparation and usage of the data as it contains raw `oop`s.
3. Signature polymorphic methods are now treated specially (as they should) while searching for them during the stack restoration. Static/instance/overpass methods are now differentiated when performing the search.
4. Stack data (methods and reference values) is now resolved in the scope of heap dump so that the heap/class dump data does not have to leave that scope.

It would also be great to factor out thread restoration into a separate class but I figured it will be easier to do when implementing support of restoration of multiple threads.