### PR TITLE
Fixes and improvements

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -4515,6 +4515,7 @@ int  java_lang_ClassLoader::_name_offset;
 int  java_lang_ClassLoader::_nameAndId_offset;
 int  java_lang_ClassLoader::_unnamedModule_offset;
 int  java_lang_ClassLoader::_parent_offset;
+int  java_lang_ClassLoader::_classes_offset;
 
 ClassLoaderData* java_lang_ClassLoader::loader_data_acquire(oop loader) {
   assert(loader != nullptr, "loader must not be null");
@@ -4539,7 +4540,8 @@ void java_lang_ClassLoader::release_set_loader_data(oop loader, ClassLoaderData*
   macro(_name_offset,            k1, vmSymbols::name_name(), string_signature, false); \
   macro(_nameAndId_offset,       k1, "nameAndId",            string_signature, false); \
   macro(_unnamedModule_offset,   k1, "unnamedModule",        module_signature, false); \
-  macro(_parent_offset,          k1, "parent",               classloader_signature, false)
+  macro(_parent_offset,          k1, "parent",               classloader_signature, false); \
+  macro(_classes_offset,         k1, "classes",              arraylist_signature, false)
 
 void java_lang_ClassLoader::compute_offsets() {
   InstanceKlass* k1 = vmClasses::ClassLoader_klass();
@@ -4581,6 +4583,11 @@ oop java_lang_ClassLoader::name(oop loader) {
 oop java_lang_ClassLoader::nameAndId(oop loader) {
   assert(is_instance(loader), "loader must be oop");
   return loader->obj_field(_nameAndId_offset);
+}
+
+oop java_lang_ClassLoader::classes(oop loader) {
+  assert(is_instance(loader), "loader must be oop");
+  return loader->obj_field(_classes_offset);
 }
 
 bool java_lang_ClassLoader::isAncestor(oop loader, oop cl) {

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -1461,6 +1461,7 @@ class java_lang_ClassLoader : AllStatic {
   static int _name_offset;
   static int _nameAndId_offset;
   static int _unnamedModule_offset;
+  static int _classes_offset;
 
   static void compute_offsets();
 
@@ -1475,6 +1476,7 @@ class java_lang_ClassLoader : AllStatic {
   static oop parent_no_keepalive(oop loader);
   static oop name(oop loader);
   static oop nameAndId(oop loader);
+  static oop classes(oop loader);
   static bool isAncestor(oop loader, oop cl);
 
   // Support for parallelCapable field

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1414,7 +1414,9 @@ void SystemDictionary::define_instance_class(InstanceKlass* k, Handle class_load
   // fail with an OutOfMemoryError (if it does, we will *not* put this
   // class in the dictionary and will not update the class hierarchy).
   // JVMTI FollowReferences needs to find the classes this way.
-  if (k->class_loader() != nullptr) {
+  if (k->class_loader() != nullptr &&
+      // ArrayList is null during CRaC's portable restoration, it is restored later
+      java_lang_ClassLoader::classes(class_loader()) != nullptr) {
     methodHandle m(THREAD, Universe::loader_addClass_method());
     JavaValue result(T_VOID);
     JavaCallArguments args(class_loader);

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1565,6 +1565,8 @@ InstanceKlass *SystemDictionary::find_or_define_recreated_class(InstanceKlass *k
       loader_data->add_to_deallocate_list(k);
       return nullptr;
     }
+    postcond(defined != nullptr);
+    return defined;
   }
 
   ObjectLocker ol(loader, thread);

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -530,6 +530,7 @@ class SerializeClosure;
   template(jvmti_is_in_VTMS_transition_name,          "jvmti_is_in_VTMS_transition")              \
   template(module_entry_name,                         "module_entry")                             \
   template(resolved_references_name,                  "<resolved_references>")                    \
+  template(hash_name,                                 "<hash>")                                   \
   template(is_interned_name,                          "<is_interned>")                            \
   template(internal_name_name,                        "<name>")                                   \
   template(internal_signature_name,                   "<signature>")                              \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -530,6 +530,7 @@ class SerializeClosure;
   template(jvmti_is_in_VTMS_transition_name,          "jvmti_is_in_VTMS_transition")              \
   template(module_entry_name,                         "module_entry")                             \
   template(resolved_references_name,                  "<resolved_references>")                    \
+  template(is_interned_name,                          "<is_interned>")                            \
   template(internal_name_name,                        "<name>")                                   \
   template(internal_signature_name,                   "<signature>")                              \
   template(internal_kind_name,                        "<kind>")                                   \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -663,6 +663,7 @@ class SerializeClosure;
   template(executable_signature,                      "Ljava/lang/reflect/Executable;")                           \
   template(module_signature,                          "Ljava/lang/Module;")                                       \
   template(concurrenthashmap_signature,               "Ljava/util/concurrent/ConcurrentHashMap;")                 \
+  template(arraylist_signature,                       "Ljava/util/ArrayList;")                                    \
   template(String_StringBuilder_signature,            "(Ljava/lang/String;)Ljava/lang/StringBuilder;")            \
   template(int_StringBuilder_signature,               "(I)Ljava/lang/StringBuilder;")                             \
   template(char_StringBuilder_signature,              "(C)Ljava/lang/StringBuilder;")                             \

--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -62,6 +62,12 @@ void DependencyContext::init() {
   }
 }
 
+bool DependencyContext::is_unused() const {
+  const nmethodBucket* dependencies = Atomic::load(_dependency_context_addr);
+  const uint64_t last_cleanup = Atomic::load(_last_cleanup_addr);
+  return dependencies == nullptr && last_cleanup == 0;
+}
+
 //
 // Walk the list of dependent nmethods searching for nmethods which
 // are dependent on the changes that were passed in and mark them for

--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -62,11 +62,13 @@ void DependencyContext::init() {
   }
 }
 
+#ifdef ASSERT
 bool DependencyContext::is_unused() const {
   const nmethodBucket* dependencies = Atomic::load(_dependency_context_addr);
   const uint64_t last_cleanup = Atomic::load(_last_cleanup_addr);
   return dependencies == nullptr && last_cleanup == 0;
 }
+#endif // ASSERT
 
 //
 // Walk the list of dependent nmethods searching for nmethods which

--- a/src/hotspot/share/code/dependencyContext.hpp
+++ b/src/hotspot/share/code/dependencyContext.hpp
@@ -129,6 +129,10 @@ class DependencyContext : public StackObj {
   static void cleaning_start();
   static void cleaning_end();
 
+#ifdef ASSERT
+  bool is_unused() const;
+#endif // ASSERT
+
 #ifndef PRODUCT
   void print_dependent_nmethods(bool verbose);
 #endif //PRODUCT

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -1526,7 +1526,13 @@ JRT_LEAF(intptr_t, InterpreterRuntime::trace_bytecode(JavaThread* current, intpt
   LastFrameAccessor last_frame(current);
   assert(last_frame.is_interpreted_frame(), "must be an interpreted frame");
   methodHandle mh(current, last_frame.method());
-  BytecodeTracer::trace_interpreter(mh, last_frame.bcp(), tos, tos2);
+  if (!TraceOperands) {
+    BytecodeTracer::trace_interpreter(mh, last_frame.bcp(), tos, tos2);
+  } else {
+    ttyLocker ttyl;
+    BytecodeTracer::trace_interpreter(mh, last_frame.bcp(), tos, tos2);
+    last_frame.get_frame().interpreter_frame_print_values_on(tty);
+  }
   return preserve_this_value;
 JRT_END
 #endif // !PRODUCT

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -107,10 +107,10 @@ void oopDesc::verify(oopDesc* oop_desc) {
   verify_on(tty, oop_desc);
 }
 
-intptr_t oopDesc::slow_identity_hash() {
+intptr_t oopDesc::slow_identity_hash(intptr_t hash) {
   // slow case; we have to acquire the micro lock in order to locate the header
   Thread* current = Thread::current();
-  return ObjectSynchronizer::FastHashCode(current, this);
+  return ObjectSynchronizer::FastHashCode(current, this, /*suggested_hash=*/hash);
 }
 
 // used only for asserts and guarantees

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -293,9 +293,10 @@ class oopDesc {
 
   inline static bool is_instanceof_or_null(oop obj, Klass* klass);
 
-  // identity hash; returns the identity hash key (computes it if necessary)
-  inline intptr_t identity_hash();
-  intptr_t slow_identity_hash();
+  // identity hash; returns the identity hash key (installs it if necessary)
+  inline intptr_t identity_hash(intptr_t hash = markWord::no_hash /*generate*/);
+  intptr_t slow_identity_hash(intptr_t hash);
+  inline intptr_t read_identity_hash() const;
   inline bool fast_no_hash_check();
 
   // marks are forwarded to stack when object is locked

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -4010,7 +4010,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
 #endif
 
 #ifndef PRODUCT
-  if (TraceBytecodesAt != 0) {
+  if (TraceBytecodesAt != 0 || TraceOperands) {
     TraceBytecodes = true;
   }
   if (CountCompiledCalls) {

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -2,6 +2,7 @@
 #include "classfile/classLoaderData.hpp"
 #include "classfile/dictionary.hpp"
 #include "classfile/systemDictionary.hpp"
+#include "classfile/vmSymbols.hpp"
 #include "logging/log.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/array.hpp"
@@ -30,7 +31,6 @@
 #include "utilities/macros.hpp"
 #ifdef ASSERT
 #include "classfile/vmClasses.hpp"
-#include "classfile/vmSymbols.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "oops/fieldInfo.hpp"
 #include "oops/fieldStreams.hpp"

--- a/src/hotspot/share/runtime/cracClassStateRestorer.cpp
+++ b/src/hotspot/share/runtime/cracClassStateRestorer.cpp
@@ -181,7 +181,39 @@ static void swap_methods(InstanceKlass *ik1, InstanceKlass *ik2) {
            i, ik1->external_name(), method1->name()->as_C_string(), method2->name()->as_C_string());
     method1->set_constants(ik2->constants());
     method2->set_constants(ik1->constants());
+    postcond(method1->method_holder() == ik2);
+    postcond(method2->method_holder() == ik1);
   }
+
+  // Note: if this is an interface, pre-defined implementors may refer to
+  // swapped-out methods via their default methods arrays so those also need to
+  // be updated.
+  //
+  // We assume that we'll visit all implementors later and fix their default
+  // methods arrays then (also by swapping because newly created classes always
+  // have the updated methods since we handle interfaces prior to implementors).
+  //
+  // TODO rewriter has to also handle this somehow, maybe there is a better way?
+}
+
+static void swap_default_methods(InstanceKlass *ik1, InstanceKlass *ik2) {
+  auto *const dmethods1 = ik1->default_methods();
+  auto *const dmethods2 = ik2->default_methods();
+  precond(dmethods1 != nullptr && dmethods2 != nullptr);
+  guarantee(dmethods1->length() == dmethods2->length(), "not the same class");
+
+  ik1->set_default_methods(dmethods2);
+  ik2->set_default_methods(dmethods1);
+
+#ifdef ASSERT
+  for (int i = 0; i < dmethods1->length(); i++) {
+    const Method *dmethod1 = dmethods1->at(i);
+    const Method *dmethod2 = dmethods2->at(i);
+    // Can only compare names because methods with equal names can be reordered
+    assert(dmethod1->name() == dmethod2->name(), "method #%i of %s has different names: %s and %s",
+           i, ik1->external_name(), dmethod1->name()->as_C_string(), dmethod2->name()->as_C_string());
+  }
+#endif // ASSERT
 }
 
 InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *created_ik, InstanceKlass::ClassState target_state, TRAPS) {
@@ -237,8 +269,8 @@ InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *creat
       ResourceMark rm;
       const char *current_state_name = (defined_ik->is_rewritten() && !defined_ik->is_linked())             ? "rewritten" : defined_ik->init_state_name();
       const char *target_state_name =  (created_ik->is_rewritten() && target_state < InstanceKlass::linked) ? "rewritten" : InstanceKlass::state_name(target_state);
-      log_debug(crac, class)("Using pre-defined %s (current state = %s, target state = %s) - defined by %s",
-                             defined_ik->external_name(), current_state_name, target_state_name, defined_ik->class_loader_data()->loader_name_and_id());
+      log_debug(crac, class)("Using pre-defined %s (%p instead of %p): current state = %s, target state = %s - defined by %s",
+                             defined_ik->external_name(), defined_ik, created_ik, current_state_name, target_state_name, defined_ik->class_loader_data()->loader_name_and_id());
     }
     assert(created_ik->access_flags().as_int() == defined_ik->access_flags().as_int(),
            "pre-defined %s has different access flags: " INT32_FORMAT_X " (dumped) != " INT32_FORMAT_X " (pre-defined)",
@@ -261,14 +293,30 @@ InstanceKlass *CracClassStateRestorer::define_created_class(InstanceKlass *creat
       }
     }
 
+    // There may be a super-interface we rewrote so have to update the default
+    // methods to ensure there are no references to methods swapped-out of that
+    // super-interface
+    guarantee((created_ik->default_methods() != nullptr) == (defined_ik->default_methods() != nullptr), "not the same class");
+    if (created_ik->default_methods() != nullptr) {
+      swap_default_methods(created_ik, defined_ik);
+    }
+
     created_ik->class_loader_data()->add_to_deallocate_list(created_ik);
   } else if (log_is_enabled(Debug, crac, class)) {
     ResourceMark rm;
     const char *current_state_name = (defined_ik->is_rewritten() && !defined_ik->is_linked())             ? "rewritten" : defined_ik->init_state_name();
     const char *target_state_name =  (created_ik->is_rewritten() && target_state < InstanceKlass::linked) ? "rewritten" : InstanceKlass::state_name(target_state);
-    log_debug(crac, class)("Using newly defined %s (current state = %s, target state = %s) - defined by %s",
-                           defined_ik->external_name(), current_state_name, target_state_name, defined_ik->class_loader_data()->loader_name_and_id());
+    log_debug(crac, class)("Using newly defined %s (%p): current state = %s, target state = %s - defined by %s",
+                           defined_ik->external_name(), defined_ik, current_state_name, target_state_name, defined_ik->class_loader_data()->loader_name_and_id());
   }
+#ifdef ASSERT
+  if (defined_ik->default_methods() != nullptr) {
+    for (int i = 0; i < defined_ik->default_methods()->length(); i++) {
+      const InstanceKlass *holder = defined_ik->default_methods()->at(i)->method_holder();
+      assert(holder->is_loaded(), "default method %s has unloaded holder %p", holder->external_name(), holder);
+    }
+  }
+#endif // ASSERT
 
   if (target_state < InstanceKlass::linked) {
     assert(target_state != InstanceKlass::being_linked, "not supported, shouldn't be dumped");

--- a/src/hotspot/share/runtime/cracHeapRestorer.cpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.cpp
@@ -406,8 +406,6 @@ instanceHandle CracHeapRestorer::prepare_class_loader(HeapDump::ID id, TRAPS) {
     const instanceHandle parallel_lock_map = get_class_loader_parallel_lock_map(dump, CHECK_({}));
     java_lang_ClassLoader::set_parallelLockMap(loader(), parallel_lock_map());
   }
-  // TODO "classes" field: ArrayList into which mirrors of defined classes are
-  //  put -- must be added here for the whole thing to work
 
   if (java_lang_ClassLoader::parallelCapable(loader())) { // Works because we set parallelLockMap above
     // TODO should add it into ClassLoader$ParallelLoaders::loaderTypes array
@@ -776,8 +774,6 @@ bool CracHeapRestorer::set_class_loader_instance_field_if_special(instanceHandle
     }
     return true;
   }
-
-  // TODO "classes" field: ArrayList into which mirrors of defined classes are put
 
   // The rest of the fields are untouched by the preparation and should be
   // restored as usual

--- a/src/hotspot/share/runtime/cracHeapRestorer.hpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.hpp
@@ -93,6 +93,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
   HeapDumpClasses::java_lang_String _string_dump_reader;
   HeapDumpClasses::java_lang_invoke_ResolvedMethodName _resolved_method_name_dump_reader;
   HeapDumpClasses::java_lang_invoke_MemberName _member_name_dump_reader;
+  HeapDumpClasses::java_lang_invoke_MethodType _method_type_dump_reader;
 
   InstanceKlass &get_instance_class(HeapDump::ID id) const;
   ArrayKlass &get_array_class(HeapDump::ID id) const;
@@ -112,9 +113,6 @@ class CracHeapRestorer : public ClassLoaderProvider {
   void find_and_record_class_mirror(const HeapDump::ClassDump &class_dump, TRAPS);
   void record_class_mirror(instanceHandle mirror, const HeapDump::InstanceDump &mirror_dump, TRAPS);
 
-  instanceHandle intern_if_needed(instanceHandle string, const HeapDump::InstanceDump &dump, TRAPS);
-  methodHandle get_resolved_method(const HeapDump::InstanceDump &resolved_method_name_dump, TRAPS);
-
   void set_field(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS);
 #define set_instance_field_if_special_signature(name) \
   bool name(instanceHandle, const HeapDump::InstanceDump &, const FieldStream &, const DumpedInstanceFieldStream &, TRAPS);
@@ -132,6 +130,11 @@ class CracHeapRestorer : public ClassLoaderProvider {
   void restore_instance_fields(instanceHandle obj, const HeapDump::InstanceDump &dump, TRAPS);
   static bool set_static_field_if_special(instanceHandle mirror, const FieldStream &fs, const HeapDump::BasicValue &val);
   void restore_static_fields(InstanceKlass *ik, const HeapDump::ClassDump &dump, TRAPS);
+
+  instanceHandle get_void_mirror(const HeapDump::InstanceDump &dump);
+  instanceHandle get_string(const HeapDump::InstanceDump &dump, TRAPS);
+  instanceHandle get_resolved_method_name(const HeapDump::InstanceDump &dump, TRAPS);
+  instanceHandle get_method_type(const HeapDump::InstanceDump &dump, TRAPS);
 
   void restore_class_mirror(HeapDump::ID id, TRAPS);
   Handle restore_object(HeapDump::ID id, TRAPS);

--- a/src/hotspot/share/runtime/cracHeapRestorer.hpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.hpp
@@ -124,6 +124,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
   set_instance_field_if_special_signature(set_string_instance_field_if_special);
   set_instance_field_if_special_signature(set_member_name_instance_field_if_special);
   set_instance_field_if_special_signature(set_call_site_instance_field_if_special);
+  set_instance_field_if_special_signature(set_call_site_context_instance_field_if_special);
 #undef set_instance_field_if_special_signature
   void restore_special_instance_fields(instanceHandle obj, const HeapDump::InstanceDump &dump,
                                        set_instance_field_if_special_ptr_t set_field_if_special, TRAPS);

--- a/src/hotspot/share/runtime/cracHeapRestorer.hpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.hpp
@@ -90,6 +90,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
 
   HeapDumpClasses::java_lang_ClassLoader _loader_dump_reader;
   HeapDumpClasses::java_lang_Class _mirror_dump_reader;
+  HeapDumpClasses::java_lang_String _string_dump_reader;
   HeapDumpClasses::java_lang_invoke_ResolvedMethodName _resolved_method_name_dump_reader;
   HeapDumpClasses::java_lang_invoke_MemberName _member_name_dump_reader;
 
@@ -111,6 +112,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
   void find_and_record_class_mirror(const HeapDump::ClassDump &class_dump, TRAPS);
   void record_class_mirror(instanceHandle mirror, const HeapDump::InstanceDump &mirror_dump, TRAPS);
 
+  instanceHandle intern_if_needed(instanceHandle string, const HeapDump::InstanceDump &dump, TRAPS);
   methodHandle get_resolved_method(const HeapDump::InstanceDump &resolved_method_name_dump, TRAPS);
 
   void set_field(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS);

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -421,6 +421,7 @@ class frame {
   void print_value_on(outputStream* st, JavaThread *thread) const;
   void print_on(outputStream* st) const;
   void interpreter_frame_print_on(outputStream* st) const;
+  void interpreter_frame_print_values_on(outputStream* st) const;
   void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;
   static void print_C_frame(outputStream* st, char* buf, int buflen, address pc);
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -857,6 +857,9 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, TraceBytecodes, false,                                      \
           "Trace bytecode execution")                                       \
                                                                             \
+  develop(bool, TraceOperands, false,                                       \
+          "Extend bytecode trace with operand stack dumps")                 \
+                                                                            \
   develop(bool, TraceICs, false,                                            \
           "Trace inline cache changes")                                     \
                                                                             \

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -162,7 +162,7 @@ class ObjectSynchronizer : AllStatic {
 
   // Returns the identity hash value for an oop
   // NOTE: It may cause monitor inflation
-  static intptr_t FastHashCode(Thread* current, oop obj);
+  static intptr_t FastHashCode(Thread* current, oop obj, intptr_t suggested_hash = markWord::no_hash);
 
   // java.lang.Thread support
   static bool current_thread_holds_lock(JavaThread* current, Handle h_obj);

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -705,16 +705,16 @@ class DumperSupport : AllStatic {
   // dumps the definition of the instance fields for a given class
   static void dump_instance_field_descriptors(AbstractDumpWriter* writer, Klass* k, bool with_injected);
   // creates HPROF_GC_INSTANCE_DUMP record for the given object
-  static void dump_instance(AbstractDumpWriter* writer, oop o, bool with_injected_fields);
+  static void dump_instance(AbstractDumpWriter* writer, oop o, bool extended);
   // creates HPROF_GC_CLASS_DUMP record for the given instance class
   static void dump_instance_class(AbstractDumpWriter* writer, Klass* k, bool with_injected_fields);
   // creates HPROF_GC_CLASS_DUMP record for a given array class
   static void dump_array_class(AbstractDumpWriter* writer, Klass* k);
 
   // creates HPROF_GC_OBJ_ARRAY_DUMP record for the given object array
-  static void dump_object_array(AbstractDumpWriter* writer, objArrayOop array);
+  static void dump_object_array(AbstractDumpWriter* writer, objArrayOop array, bool extended);
   // creates HPROF_GC_PRIM_ARRAY_DUMP record for the given type array
-  static void dump_prim_array(AbstractDumpWriter* writer, typeArrayOop array);
+  static void dump_prim_array(AbstractDumpWriter* writer, typeArrayOop array, bool extended);
   // create HPROF_FRAME record for the given method and bci
   static void dump_stack_frame(AbstractDumpWriter* writer, int frame_serial_num, int class_serial_num, Method* m, int bci);
 
@@ -1051,14 +1051,20 @@ void DumperSupport::dump_instance_field_descriptors(AbstractDumpWriter* writer, 
 }
 
 // creates HPROF_GC_INSTANCE_DUMP record for the given object
-void DumperSupport::dump_instance(AbstractDumpWriter* writer, oop o, bool with_injected_fields) {
+void DumperSupport::dump_instance(AbstractDumpWriter* writer, oop o, bool extended) {
   InstanceKlass* ik = InstanceKlass::cast(o->klass());
-  u4 is = instance_size(ik, with_injected_fields);
+  u4 is = instance_size(ik, extended);
   u4 size = 1 + sizeof(address) + 4 + sizeof(address) + 4 + is;
 
   writer->start_sub_record(HPROF_GC_INSTANCE_DUMP, size);
   writer->write_objectID(o);
-  writer->write_u4(STACK_TRACE_ID);
+
+  if (!extended) {
+    writer->write_u4(STACK_TRACE_ID);
+  } else {
+    // Note: this does not adhere to HPROF spec
+    writer->write_u4(checked_cast<jint>(o->read_identity_hash()));
+  }
 
   // class ID
   writer->write_classID(ik);
@@ -1067,7 +1073,7 @@ void DumperSupport::dump_instance(AbstractDumpWriter* writer, oop o, bool with_i
   writer->write_u4(is);
 
   // field values
-  dump_instance_fields(writer, o, with_injected_fields);
+  dump_instance_fields(writer, o, extended);
 
   writer->end_sub_record();
 }
@@ -1193,7 +1199,7 @@ int DumperSupport::calculate_array_max_length(AbstractDumpWriter* writer, arrayO
 }
 
 // creates HPROF_GC_OBJ_ARRAY_DUMP record for the given object array
-void DumperSupport::dump_object_array(AbstractDumpWriter* writer, objArrayOop array) {
+void DumperSupport::dump_object_array(AbstractDumpWriter* writer, objArrayOop array, bool extended) {
   // sizeof(u1) + 2 * sizeof(u4) + sizeof(objectID) + sizeof(classID)
   short header_size = 1 + 2 * 4 + 2 * sizeof(address);
   int length = calculate_array_max_length(writer, array, header_size);
@@ -1201,7 +1207,14 @@ void DumperSupport::dump_object_array(AbstractDumpWriter* writer, objArrayOop ar
 
   writer->start_sub_record(HPROF_GC_OBJ_ARRAY_DUMP, size);
   writer->write_objectID(array);
-  writer->write_u4(STACK_TRACE_ID);
+
+  if (!extended) {
+    writer->write_u4(STACK_TRACE_ID);
+  } else {
+    // Note: this does not adhere to HPROF spec
+    writer->write_u4(checked_cast<jint>(array->read_identity_hash()));
+  }
+
   writer->write_u4(length);
 
   // array class ID
@@ -1227,7 +1240,7 @@ void DumperSupport::dump_object_array(AbstractDumpWriter* writer, objArrayOop ar
   for (int i = 0; i < Length; i++) { writer->write_##Size((Size)Array->Type##_at(i)); }
 
 // creates HPROF_GC_PRIM_ARRAY_DUMP record for the given type array
-void DumperSupport::dump_prim_array(AbstractDumpWriter* writer, typeArrayOop array) {
+void DumperSupport::dump_prim_array(AbstractDumpWriter* writer, typeArrayOop array, bool extended) {
   BasicType type = TypeArrayKlass::cast(array->klass())->element_type();
   // 2 * sizeof(u1) + 2 * sizeof(u4) + sizeof(objectID)
   short header_size = 2 * 1 + 2 * 4 + sizeof(address);
@@ -1239,7 +1252,14 @@ void DumperSupport::dump_prim_array(AbstractDumpWriter* writer, typeArrayOop arr
 
   writer->start_sub_record(HPROF_GC_PRIM_ARRAY_DUMP, size);
   writer->write_objectID(array);
-  writer->write_u4(STACK_TRACE_ID);
+
+  if (!extended) {
+    writer->write_u4(STACK_TRACE_ID);
+  } else {
+    // Note: this does not adhere to HPROF spec
+    writer->write_u4(checked_cast<jint>(array->read_identity_hash()));
+  }
+
   writer->write_u4(length);
   writer->write_u1(type2tag(type));
 
@@ -1508,13 +1528,13 @@ void HeapObjectDumper::do_object(oop o) {
 
   if (o->is_instance()) {
     // create a HPROF_GC_INSTANCE record for each object
-    DumperSupport::dump_instance(writer(), o, /*with_injected_fields=*/_extended);
+    DumperSupport::dump_instance(writer(), o, _extended);
   } else if (o->is_objArray()) {
     // create a HPROF_GC_OBJ_ARRAY_DUMP record for each object array
-    DumperSupport::dump_object_array(writer(), objArrayOop(o));
+    DumperSupport::dump_object_array(writer(), objArrayOop(o), _extended);
   } else if (o->is_typeArray()) {
     // create a HPROF_GC_PRIM_ARRAY_DUMP record for each type array
-    DumperSupport::dump_prim_array(writer(), typeArrayOop(o));
+    DumperSupport::dump_prim_array(writer(), typeArrayOop(o), _extended);
   }
 }
 

--- a/src/hotspot/share/utilities/heapDumpClasses.cpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.cpp
@@ -374,6 +374,48 @@ bool HeapDumpClasses::java_lang_invoke_MemberName::is_field(const HeapDump::Inst
 }
 
 
+// java.lang.invoke.MethodType
+
+#ifdef ASSERT
+static bool is_method_type_class_dump(const ParsedHeapDump &heap_dump, const HeapDump::ClassDump &dump) {
+  const bool has_right_name_and_loader = heap_dump.get_class_name(dump.id) == vmSymbols::java_lang_invoke_MethodType() &&
+                                         dump.class_loader_id == HeapDump::NULL_ID;
+  if (!has_right_name_and_loader) {
+    return false;
+  }
+
+  assert(dump.super_id != HeapDump::NULL_ID, "illegal super in %s dump " HDID_FORMAT ": expected %s, got none",
+         vmSymbols::java_lang_invoke_MethodType()->as_klass_external_name(), dump.id,
+         vmSymbols::java_lang_Object()->as_klass_external_name());
+
+  const HeapDump::ClassDump &super_dump = heap_dump.get_class_dump(dump.super_id);
+  assert(heap_dump.get_class_name(super_dump.id) == vmSymbols::java_lang_Object() &&
+         super_dump.class_loader_id == HeapDump::NULL_ID, "illegal super in %s dump " HDID_FORMAT ": expected %s, got %s",
+         vmSymbols::java_lang_invoke_MethodType()->as_klass_external_name(), dump.id,
+         heap_dump.get_class_name(super_dump.id)->as_klass_external_name(),
+         vmSymbols::java_lang_Object()->as_klass_external_name());
+
+  return true;
+}
+#endif // ASSERT
+
+void HeapDumpClasses::java_lang_invoke_MethodType::ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_invoke_MethodType_id) {
+  precond(java_lang_invoke_MethodType_id != HeapDump::NULL_ID);
+  if (!is_initialized()) {
+    const HeapDump::ClassDump &java_lang_invoke_MethodType_dump = heap_dump.get_class_dump(java_lang_invoke_MethodType_id);
+    precond(is_method_type_class_dump(heap_dump, java_lang_invoke_MethodType_dump));
+    INITIALIZE_OFFSETS(java_lang_invoke_MethodType, METHODTYPE_DUMP_FIELDS_DO, NO_DUMP_FIELDS_DO)
+    DEBUG_ONLY(_java_lang_invoke_MethodType_id = java_lang_invoke_MethodType_id);
+    _id_size = heap_dump.id_size;
+  } else {
+    ASSERT_INITIALIZED_WITH_SAME_ID(java_lang_invoke_MethodType)
+  }
+  postcond(is_initialized());
+}
+
+METHODTYPE_DUMP_FIELDS_DO(DEFINE_GET_FIELD_METHOD)
+
+
 #undef DEFINE_GET_PTR_FIELD_METHOD
 #undef DEFINE_GET_FIELD_METHOD
 #undef ASSERT_INITIALIZED_WITH_SAME_ID

--- a/src/hotspot/share/utilities/heapDumpClasses.hpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.hpp
@@ -34,7 +34,7 @@ struct HeapDumpClasses : public AllStatic {
     DEBUG_ONLY(HeapDump::ID _java_lang_ClassLoader_id = HeapDump::NULL_ID);
 
    public:
-    void ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_ClassLoader_id);
+    void ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID loader_class_id);
     CLASSLOADER_DUMP_FIELDS_DO(DECLARE_GET_FIELD_METHOD)
 
    private:

--- a/src/hotspot/share/utilities/heapDumpClasses.hpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.hpp
@@ -81,6 +81,26 @@ struct HeapDumpClasses : public AllStatic {
   };
 
 
+#define STRING_DUMP_FIELDS_DO(macro)                                                            \
+  macro(java_lang_String, is_interned, vmSymbols::is_interned_name(), T_BOOLEAN, bool, boolean)
+
+  // Requires the heap dump to include injected fields.
+  class java_lang_String {
+   private:
+    u4 _id_size = 0;
+    STRING_DUMP_FIELDS_DO(DEFINE_OFFSET_FIELD)
+    DEBUG_ONLY(HeapDump::ID _java_lang_String_id = HeapDump::NULL_ID);
+
+   public:
+    void ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_String_id);
+
+    STRING_DUMP_FIELDS_DO(DECLARE_GET_FIELD_METHOD)
+
+   private:
+    bool is_initialized() const { return _id_size > 0; }
+  };
+
+
 #define RESOLVEDMETHODNAME_DUMP_FIELDS_DO(macro)                                                                      \
   macro(java_lang_invoke_ResolvedMethodName, vmholder, vmSymbols::vmholder_name(), T_OBJECT, HeapDump::ID, object_id) \
   macro(java_lang_invoke_ResolvedMethodName, method_kind, vmSymbols::internal_kind_name(), T_BYTE, jbyte, byte)

--- a/src/hotspot/share/utilities/heapDumpClasses.hpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.hpp
@@ -161,6 +161,26 @@ struct HeapDumpClasses : public AllStatic {
    private:
     bool is_initialized() const { return _id_size > 0; }
   };
+
+
+#define METHODTYPE_DUMP_FIELDS_DO(macro)                                                  \
+  macro(java_lang_invoke_MethodType, rtype, "rtype", T_OBJECT, HeapDump::ID, object_id)   \
+  macro(java_lang_invoke_MethodType, ptypes, "ptypes", T_OBJECT, HeapDump::ID, object_id)
+
+  class java_lang_invoke_MethodType {
+   private:
+    u4 _id_size = 0;
+    METHODTYPE_DUMP_FIELDS_DO(DEFINE_OFFSET_FIELD)
+    DEBUG_ONLY(HeapDump::ID _java_lang_invoke_MethodType_id = HeapDump::NULL_ID);
+
+   public:
+    void ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID java_lang_invoke_MethodType_id);
+
+    METHODTYPE_DUMP_FIELDS_DO(DECLARE_GET_FIELD_METHOD)
+
+   private:
+    bool is_initialized() const { return _id_size > 0; }
+  };
 };
 
 #undef DECLARE_GET_FIELD_METHOD


### PR DESCRIPTION
Various fixes and improvements of portable C/R. Most notably:
- Interned string are now restored as such
- Restoration of identity hashes is implemented, though for now it's not portable from 64-bit to 32-bit platforms because the former have hashes several bits larger than the latter -- the solution would be to limit the size of hashes generated on 64-bit platforms if a checkpoint is going to be performed, but this should probably only be done if explicitly requested

There are two known bugs this PR does not fix:
1. `MethodType`s are cached on the Java side and if the cache is pre-created (and thus not restored) we have to call into Java to consult it when restoring a `MethodType`, but the fact of pre-creation is not easy to check. The current weak check sometimes falsely claims there is a cache which results into a deadlock (a call into Java attempts to initialize of a class being restored which gets the thread blocked). This is not fixed because the problem will disappear when we start to restore all classes which will result into the cache always being restored.
2. Sometimes a `java.lang.BootstrapMethodError` occurs when using string concatenations via an `invokedynamic` because a wrong `LambdaForm` is being found when generating the concatenation method. I wasn't able to pin down the exact reason of this but since it seems to only occur when some involved classes are pre-initialized and some are restored I assume this will also be resolved when we become able to restore all classes.