### PR TITLE
Restoration of resources

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -798,6 +798,7 @@ class SerializeClosure;
   template(jdk_crac_Core,                          "jdk/crac/Core")                                               \
   template(checkpointRestoreInternal_name,         "checkpointRestoreInternal")                                   \
   template(checkpointRestoreInternal_signature,    "(J)Ljava/lang/String;")                                       \
+  template(checkpointRestore0_name,                "checkpointRestore0")                                          \
                                                                                                                   \
   /* Thread.dump_to_file jcmd */                                                                                  \
   template(jdk_internal_vm_ThreadDumper,           "jdk/internal/vm/ThreadDumper")                                \

--- a/src/hotspot/share/runtime/cracHeapRestorer.hpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.hpp
@@ -128,7 +128,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
                                        set_instance_field_if_special_ptr_t set_field_if_special, TRAPS);
   void restore_ordinary_instance_fields(instanceHandle obj, const HeapDump::InstanceDump &dump, TRAPS);
   void restore_instance_fields(instanceHandle obj, const HeapDump::InstanceDump &dump, TRAPS);
-  static bool set_static_field_if_special(instanceHandle mirror, const FieldStream &fs, const HeapDump::BasicValue &val);
+  bool set_static_field_if_special(instanceHandle mirror, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS);
   void restore_static_fields(InstanceKlass *ik, const HeapDump::ClassDump &dump, TRAPS);
 
   instanceHandle get_void_mirror(const HeapDump::InstanceDump &dump);

--- a/src/hotspot/share/runtime/cracStackDumpParser.cpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.cpp
@@ -117,8 +117,10 @@ class StackTracesParser : public StackObj {
 
       auto *const trace = new CracStackTrace(preamble.thread_id, preamble.frames_num);
       for (u4 i = 0; i < trace->frames_num(); i++) {
-        log_trace(crac, stacktrace, parser)("Parsing frame " UINT32_FORMAT, i);
-        if (!parse_frame(&trace->frame(i))) {
+        log_trace(crac, stacktrace, parser)("Parsing frame " UINT32_FORMAT " (youngest first)", i);
+        // Frames are dumped from youngest to oldest but we store them in
+        // reverse so that the youngest frame is last (i.e. is actually on top)
+        if (!parse_frame(&trace->frame(trace->frames_num() - 1 - i))) {
           delete trace;
           return ERR_INVAL_FRAME;
         }

--- a/src/hotspot/share/runtime/cracStackDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.hpp
@@ -123,13 +123,15 @@ class CracStackTrace : public CHeapObj<mtInternal> {
 
   // Number of frames in the stack.
   u4 frames_num() const          { return _frames_num; }
-  // Frames from youngest to oldest.
+  // Frames from oldest to youngest.
   const Frame &frame(u4 i) const { precond(i < frames_num()); return _frames[i]; }
   Frame &frame(u4 i)             { precond(i < frames_num()); return _frames[i]; }
+  // Remove the youngest frame.
+  void pop()                     { precond(frames_num() > 0); _frames_num--; }
 
  private:
   const ID _thread_id;
-  const u4 _frames_num;
+  u4 _frames_num;
   Frame *const _frames;
 };
 

--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -25,6 +25,9 @@
 
 package java.util.jar;
 
+import jdk.crac.Context;
+import jdk.crac.Core;
+import jdk.crac.Resource;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.JavaUtilZipFileAccess;
 import jdk.internal.misc.ThreadTracker;
@@ -195,6 +198,24 @@ public class JarFile extends ZipFile {
                 MULTI_RELEASE_FORCED = false;
             }
         }
+    }
+
+    // TODO remove this when portable CRaC becomes able to restore SharedSecrets
+    private static final Resource secretsReinitResource = new Resource() {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+            if (SharedSecrets.javaUtilJarAccess() == null) {
+                SharedSecrets.setJavaUtilJarAccess(new JavaUtilJarAccessImpl());
+            }
+        }
+    };
+
+    static {
+        Core.getGlobalContext().register(secretsReinitResource);
     }
 
     private static final String META_INF = "META-INF/";

--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -30,6 +30,9 @@ import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 import java.util.Objects;
 
+import jdk.crac.Core;
+import jdk.crac.Context;
+import jdk.crac.Resource;
 import jdk.internal.ref.CleanerFactory;
 import jdk.internal.util.Preconditions;
 import sun.nio.ch.DirectBuffer;
@@ -114,9 +117,25 @@ public class Inflater {
     private int inputConsumed;
     private int outputConsumed;
 
-    static {
+    private static void initNatives() {
         ZipUtils.loadLibrary();
         initIDs();
+    }
+
+    private static final Resource nativeInitResource = new Resource() {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+            initNatives();
+        }
+    };
+
+    static {
+        initNatives();
+        Core.getGlobalContext().register(nativeInitResource);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -284,7 +284,8 @@ public class Core {
             RestoreException {
         // checkpointRestoreLock protects against the simultaneous
         // call of checkpointRestore from different threads.
-        synchronized (checkpointRestoreLock) {
+        // TODO uncomment when portable CRaC becomes able to restore monitors
+        // synchronized (checkpointRestoreLock) {
             // checkpointInProgress protects against recursive
             // checkpointRestore from resource's
             // beforeCheckpoint/afterRestore methods
@@ -303,7 +304,7 @@ public class Core {
                 }
                 checkpointInProgress = false;
             }
-        }
+        // }
     }
 
     /* called by VM */

--- a/src/java.base/share/classes/jdk/internal/perf/Perf.java
+++ b/src/java.base/share/classes/jdk/internal/perf/Perf.java
@@ -30,7 +30,9 @@ import java.security.PrivilegedAction;
 import java.io.IOException;
 
 import sun.nio.cs.UTF_8;
-
+import jdk.crac.Context;
+import jdk.crac.Core;
+import jdk.crac.Resource;
 import jdk.internal.ref.CleanerFactory;
 
 /**
@@ -431,8 +433,20 @@ public final class Perf {
 
     private static native void registerNatives();
 
+    private static final Resource nativeInitResource = new Resource() {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+            registerNatives();
+        }
+    };
+
     static {
         registerNatives();
+        Core.getGlobalContext().register(nativeInitResource);
         instance = new Perf();
     }
 }

--- a/src/java.base/share/classes/jdk/internal/perf/PerfCounter.java
+++ b/src/java.base/share/classes/jdk/internal/perf/PerfCounter.java
@@ -30,6 +30,10 @@ import java.nio.ByteOrder;
 import java.nio.LongBuffer;
 import java.security.AccessController;
 
+import jdk.crac.Context;
+import jdk.crac.Core;
+import jdk.crac.Resource;
+
 /**
  * Performance counter support for internal JRE classes.
  * This class defines a fixed list of counters for the platform
@@ -59,13 +63,47 @@ public class PerfCounter {
     private static final int U_None      = 1;
 
     private final String name;
-    private final LongBuffer lb;
+    private LongBuffer lb;
+
+    // Portable CRaC cannot restore perf buffers
+    private final class BufferResource implements Resource {
+        private final int type; // TODO retrieve from native Perf?
+        private long savedValue;
+
+        BufferResource(int type) {
+            this.type = type;
+        }
+
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+            savedValue = get();
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+            ByteBuffer bb;
+            try {
+                bb = perf.createLong(name, type, U_None, 0L);
+            } catch (IllegalArgumentException ignored) {
+                // This C/R implementation can restore perf state
+                assert get() == savedValue;
+                return;
+            }
+            bb.order(ByteOrder.nativeOrder());
+            lb = bb.asLongBuffer();
+            set(savedValue);
+        }
+    }
+
+    private final BufferResource bufferResource;
 
     private PerfCounter(String name, int type) {
         this.name = name;
         ByteBuffer bb = perf.createLong(name, type, U_None, 0L);
         bb.order(ByteOrder.nativeOrder());
         this.lb = bb.asLongBuffer();
+        bufferResource = new BufferResource(type);
+        Core.getGlobalContext().register(bufferResource);
     }
 
     public static PerfCounter newPerfCounter(String name) {

--- a/src/java.management/share/classes/java/lang/management/ManagementFactory.java
+++ b/src/java.management/share/classes/java/lang/management/ManagementFactory.java
@@ -56,6 +56,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.management.JMX;
+import jdk.crac.Context;
+import jdk.crac.Core;
+import jdk.crac.Resource;
 import sun.management.Util;
 import sun.management.spi.PlatformMBeanProvider;
 import sun.management.spi.PlatformMBeanProvider.PlatformComponent;
@@ -1016,8 +1019,20 @@ public class ManagementFactory {
         }
     }
 
+    private static final Resource nativeInitResource = new Resource() {
+        @Override
+        public void beforeCheckpoint(Context<? extends Resource> context) {
+        }
+
+        @Override
+        public void afterRestore(Context<? extends Resource> context) {
+            loadNativeLib();
+        }
+    };
+
     static {
         loadNativeLib();
+        Core.getGlobalContext().register(nativeInitResource);
     }
 
     @SuppressWarnings("removal")

--- a/test/hotspot/gtest/runtime/test_cracStackDumpParser.cpp
+++ b/test/hotspot/gtest/runtime/test_cracStackDumpParser.cpp
@@ -243,20 +243,22 @@ TEST(CracStackDumpParser, multiple_stacks_dumped) {
   EXPECT_EQ(4U, stack_dump.word_size());
   ASSERT_EQ(2, stack_dump.stack_traces().length());
 
+  // Frames are dumped from youngest to oldest but stored in reverse (so that
+  // the youngest is on top), so the frame indices are reversed here
   CracStackTrace expected_trace_1(/* thread ID */ 0xabcdef95, /* frames num */ 2);
-
-  expected_trace_1.frame(0).set_method_name_id(0xabacabaa);
-  expected_trace_1.frame(0).set_method_sig_id(0xbabafeda);
-  expected_trace_1.frame(0).set_method_kind(MethodKind::Enum::STATIC);
-  expected_trace_1.frame(0).set_method_holder_id(0x87654321);
-  expected_trace_1.frame(0).set_bci(5);
-  expected_trace_1.frame(0).locals().append(CracStackTrace::Frame::Value::of_primitive(0xabcdefab));
-
-  expected_trace_1.frame(1).set_method_name_id(0xbacabaca);
-  expected_trace_1.frame(1).set_method_sig_id(0xccddbbaf);
-  expected_trace_1.frame(1).set_method_kind(MethodKind::Enum::INSTANCE);
-  expected_trace_1.frame(1).set_method_holder_id(0x01237832);
-  expected_trace_1.frame(1).set_bci(0x10);
+  // First in the dump, last in the parsed array
+  expected_trace_1.frame(1).set_method_name_id(0xabacabaa);
+  expected_trace_1.frame(1).set_method_sig_id(0xbabafeda);
+  expected_trace_1.frame(1).set_method_kind(MethodKind::Enum::STATIC);
+  expected_trace_1.frame(1).set_method_holder_id(0x87654321);
+  expected_trace_1.frame(1).set_bci(5);
+  expected_trace_1.frame(1).locals().append(CracStackTrace::Frame::Value::of_primitive(0xabcdefab));
+  // Last in the dump, first in the parsed array
+  expected_trace_1.frame(0).set_method_name_id(0xbacabaca);
+  expected_trace_1.frame(0).set_method_sig_id(0xccddbbaf);
+  expected_trace_1.frame(0).set_method_kind(MethodKind::Enum::INSTANCE);
+  expected_trace_1.frame(0).set_method_holder_id(0x01237832);
+  expected_trace_1.frame(0).set_bci(0x10);
 
   check_stack_frames(expected_trace_1, *stack_dump.stack_traces().at(0));
   ASSERT_FALSE(testing::Test::HasFatalFailure() || testing::Test::HasNonfatalFailure()) << "Wrong parsing of trace #1";

--- a/test/jdk/jdk/crac/portable/Hashcodes.java
+++ b/test/jdk/jdk/crac/portable/Hashcodes.java
@@ -1,0 +1,61 @@
+import java.util.HashMap;
+import jdk.crac.Core;
+
+/**
+ * Demonstrates restoration of identity hash codes.
+ * <p>
+ * How to run:
+ * <pre>
+ * {@code
+ * $ java -XX:CREngine= -XX:CRaCCheckpointTo=cr Hashcodes.java
+ * > Right x hash: 1204088028
+ * > Right key1 value
+ * > Right key2 value
+ *
+ * $ java -XX:CREngine= -XX:CRaCRestoreFrom=cr
+ * > Right x hash: 1204088028
+ * > Right key1 value
+ * > Right key2 value
+ * }
+ * </pre>
+ */
+public class Hashcodes {
+    private static class Key {}
+
+    public static void main(String[] args) throws Exception {
+        var hashtable = new HashMap<Key, String>();
+
+        Key key1 = new Key();
+        String val1 = "value 1";
+        hashtable.put(key1, val1);
+
+        Key key2 = new Key();
+        String val2 = "value 2";
+        hashtable.put(key2, val2);
+
+        var x = new Key();
+        int xHash = x.hashCode();
+
+        Core.checkpointRestore();
+
+        if (x.hashCode() != xHash) {
+            System.out.println("WRONG x hash: expected " + xHash + ", got " + x.hashCode());
+        } else {
+            System.out.println("Right x hash: " + xHash);
+        }
+
+        String valFromKey1 = hashtable.get(key1);
+        if (valFromKey1 != val1) {
+            System.out.println("WRONG key1 value");
+        } else {
+            System.out.println("Right key1 value");
+        }
+
+        String valFromKey2 = hashtable.get(key2);
+        if (valFromKey2 != val2) {
+            System.out.println("WRONG key2 value");
+        } else {
+            System.out.println("Right key2 value");
+        }
+    }
+}

--- a/test/jdk/jdk/crac/portable/RecursionCounter.java
+++ b/test/jdk/jdk/crac/portable/RecursionCounter.java
@@ -5,40 +5,34 @@
  * <pre>
  * {@code
  * // Shell 1
- * // You must compile the class separately or restore will fail because CDS won't create
- * // the built-in class loaders
- * javac RecursionCounter.java
- * java -XX:CREngine= -XX:CRaCCheckpointTo=cr RecursionCounter
- * // Output:
- * // -
- * // --
- * // ---
- * // --- 0
- * // ---
- * // --
- * // -
- * // -
- * // --
- * // ---
- * // --- 1
- * // ---
- * // ...
+ * $ java -XX:CREngine= -XX:CRaCCheckpointTo=cr RecursionCounter.java
+ * > -
+ * > --
+ * > ---
+ * > --- 0
+ * > ---
+ * > --
+ * > -
+ * > -
+ * > --
+ * > ---
+ * > --- 1
+ * > ---
+ * > --
+ * > ...
  *
- * // Shell 2
- * jcmd RecursionCounter JDK.checkpoint
+ * // Shell 2 (specify "RecursionCounter" instead of the launcher in case of a
+ * // pre-compiled version)
+ * $ jcmd jdk.compiler/com.sun.tools.javac.launcher.Main JDK.checkpoint
  *
- * // Shell 1
- * // <Press Ctrl-C to stop the previous Java process>
- * // You have to specify the main class again for VM to find it and run it
- * java -XX:CREngine= -XX:CRaCRestoreFrom=cr RecursionCounter
- * // Output:
- * // --
- * // -
- * // -
- * // --
- * // ---
- * // --- 2
- * // ...
+ * // Shell 1 (stop the previous Java process with Ctrl-C)
+ * $ java -XX:CREngine= -XX:CRaCRestoreFrom=cr
+ * > -
+ * > -
+ * > --
+ * > ---
+ * > --- 2
+ * > ...
  * }
  * </pre>
  */

--- a/test/jdk/jdk/crac/portable/ResourceCallbacks.java
+++ b/test/jdk/jdk/crac/portable/ResourceCallbacks.java
@@ -3,31 +3,20 @@ import jdk.crac.Core;
 import jdk.crac.Resource;
 
 /**
- * NOTE: currently this example DOES NOT WORK because restoration of the thread
- * initiating the checkpoint is not implemented (the thread runs native code at
- * the moment of checkpoint).
- *
  * Demonstrates resource callbacks.
  * <p>
  * How to run:
  * <pre>
  * {@code
- * // You must compile the class separately or restore will fail because CDS won't create aaaa
- * // the built-in class loaders
- * javac ResourceCallbacks.java
+ * $ java -XX:CREngine= -XX:CRaCCheckpointTo=cr ResourceCallbacks.java
+ * > Resource creation time: 1700914709741
+ * > Time before checkpoint: 1700914710112
+ * > Time after restore: 1700914711393
+ * > Resource creation time: 1700914709741
  *
- * java -XX:CREngine= -XX:CRaCCheckpointTo=cr ResourceCallbacks
- * // Output:
- * // Resource creation time: 1700914709741
- * // Time before checkpoint: 1700914710112
- * // Time after restore: 1700914711393
- * // Resource creation time: 1700914709741
- *
- * // You have to specify the main class again for VM to find it and run it
- * java -XX:CREngine= -XX:CRaCRestoreFrom=cr ResourceCallbacks
- * // Output:
- * // Time after restore: 1700914712000
- * // Resource creation time: 1700914709741
+ * $ java -XX:CREngine= -XX:CRaCRestoreFrom=cr
+ * > Time after restore: 1700914712000
+ * > Resource creation time: 1700914709741
  * }
  * </pre>
  */


### PR DESCRIPTION
Changes necessary for resources to get restored:
- Thread executing native `jdk.crac.Core::checkpointRestore0` can be checkpointed, that frame will be popped upon restoration with a result indicating success placed on caller's stack
- Global resource context (stored in `jdk.crac.Core`) is now restored replacing the newly created one --- the latter won't be necessary when the portable mode becomes able to restore all classes (currently `jdk.crac.Core` is pre-defined but treated specially)
- Some additional resources are added into JDK classes to support the portable mode --- this has been done very selectively, more classes need to be extended in the same way (e.g. all classes with native methods should re-register them / re-load native libraries on restore)
  - Note: to make classes from class-path JARs loadable after portable restore [`reopen`](https://github.com/CRaC/docs/blob/master/fd-policies.md) policy has to be specified for them, e.g. the following will do this for all opened JARs:
    ```yaml
    type: file
    path: **/*.jar
    action: reopen
    ```
- C/R-synchronizing monitor has been temporarily removed, it should be brought back when the portable mode becomes able to restore monitors