### PR TITLE
Restoration of multiple threads

### DIFF
--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -48,7 +48,7 @@
 #include "prims/methodHandles.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/continuationEntry.inline.hpp"
-#include "runtime/crac.hpp"
+#include "runtime/cracThreadRestorer.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/safepointMechanism.hpp"
@@ -2917,10 +2917,10 @@ void SharedRuntime::generate_restore_blob() {
   // Call C code that will prepare for us the info about the frames to restore.
   // No blocking or GC can happen, frames are not accessed.
   //
-  // void crac::fetch_frame_info(JavaThread* current)
+  // void CracThreadRestorer::fetch_frame_info(JavaThread* current)
 
   __ mov(c_rarg0, r15_thread);
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, crac::fetch_frame_info)));
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, CracThreadRestorer::fetch_frame_info)));
 
   // TODO oop map?
 
@@ -3027,7 +3027,7 @@ void SharedRuntime::generate_restore_blob() {
 
   // Call C code. It should fill the skeletom frames we've pushed.
   //
-  // void crac::fill_in_frames(JavaThread* current)
+  // void CracThreadRestorer::fill_in_frames(JavaThread* current)
 
   // Use rbp because the frames look interpreted now.
   // Don't need the precise return PC here, just precise enough to point into this code blob.
@@ -3035,7 +3035,7 @@ void SharedRuntime::generate_restore_blob() {
 
   __ andptr(rsp, -(StackAlignmentInBytes));  // Fix stack alignment as required by ABI
   __ mov(c_rarg0, r15_thread);
-  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, crac::fill_in_frames)));
+  __ call(RuntimeAddress(CAST_FROM_FN_PTR(address, CracThreadRestorer::fill_in_frames)));
 
   // TODO oop map?
 

--- a/src/hotspot/share/runtime/crac.cpp
+++ b/src/hotspot/share/runtime/crac.cpp
@@ -24,12 +24,10 @@
 #include "precompiled.hpp"
 
 #include "classfile/classLoader.hpp"
+#include "classfile/javaClasses.hpp"
 #include "classfile/symbolTable.hpp"
-#include "classfile/systemDictionary.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
-#include "interpreter/bytecodes.hpp"
-#include "interpreter/interpreter.hpp"
 #include "jni.h"
 #include "jvm.h"
 #include "logging/log.hpp"
@@ -39,7 +37,6 @@
 #include "memory/oopFactory.hpp"
 #include "memory/resourceArea.hpp"
 #include "oops/instanceKlass.hpp"
-#include "oops/method.hpp"
 #include "oops/oopsHierarchy.hpp"
 #include "os.inline.hpp"
 #include "runtime/crac.hpp"
@@ -48,27 +45,19 @@
 #include "runtime/cracHeapRestorer.hpp"
 #include "runtime/cracStackDumpParser.hpp"
 #include "runtime/cracStackDumper.hpp"
+#include "runtime/cracThreadRestorer.hpp"
 #include "runtime/crac_structs.hpp"
-#include "runtime/deoptimization.hpp"
 #include "runtime/handles.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
-#include "runtime/javaCalls.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/jniHandles.hpp"
 #include "runtime/jniHandles.inline.hpp"
-#include "runtime/reflectionUtils.hpp"
-#include "runtime/signature.hpp"
-#include "runtime/stackValue.hpp"
-#include "runtime/stackValueCollection.hpp"
-#include "runtime/stubRoutines.hpp"
 #include "runtime/thread.hpp"
 #include "runtime/threads.hpp"
-#include "runtime/vframeArray.hpp"
 #include "runtime/vmThread.hpp"
 #include "services/heapDumper.hpp"
 #include "services/writeableFlags.hpp"
-#include "utilities/bitCast.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/exceptions.hpp"
@@ -521,7 +510,7 @@ bool crac::prepare_checkpoint() {
   return true;
 }
 
-static Handle ret_cr(int ret, Handle new_args, Handle new_props, Handle err_codes, Handle err_msgs, TRAPS) {
+Handle crac::cr_return(int ret, Handle new_args, Handle new_props, Handle err_codes, Handle err_msgs, TRAPS) {
   objArrayOop bundleObj = oopFactory::new_objectArray(5, CHECK_NH);
   objArrayHandle bundle(THREAD, bundleObj);
   jvalue jval;
@@ -539,12 +528,12 @@ static Handle ret_cr(int ret, Handle new_args, Handle new_props, Handle err_code
  */
 Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong jcmd_stream, TRAPS) {
   if (!CRaCCheckpointTo) {
-    return ret_cr(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
+    return cr_return(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
   }
 
   if (-1 == os::mkdir(CRaCCheckpointTo) && errno != EEXIST) {
     warning("cannot create %s: %s", CRaCCheckpointTo, os::strerror(errno));
-    return ret_cr(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
+    return cr_return(JVM_CHECKPOINT_NONE, Handle(), Handle(), Handle(), Handle(), THREAD);
   }
 
   Universe::heap()->set_cleanup_unused(true);
@@ -610,7 +599,7 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
 
     wakeup_threads_in_timedwait();
 
-    return ret_cr(JVM_CHECKPOINT_OK, Handle(THREAD, new_args), props, Handle(), Handle(), THREAD);
+    return cr_return(JVM_CHECKPOINT_OK, Handle(THREAD, new_args), props, Handle(), Handle(), THREAD);
   }
 
   const GrowableArray<CracFailDep>* failures = cr.failures();
@@ -627,7 +616,7 @@ Handle crac::checkpoint(jarray fd_arr, jobjectArray obj_arr, bool dry_run, jlong
     msgs->obj_at_put(i, msgObj);
   }
 
-  return ret_cr(JVM_CHECKPOINT_ERROR, Handle(), Handle(), codes, msgs, THREAD);
+  return cr_return(JVM_CHECKPOINT_ERROR, Handle(), Handle(), codes, msgs, THREAD);
 }
 
 void crac::restore() {
@@ -772,8 +761,8 @@ void crac::update_javaTimeNanos_offset() {
   }
 }
 
-// Restore in portable mode.
-void crac::restore_heap(TRAPS) {
+// Restore classes and objects in portable mode.
+void crac::restore_data(TRAPS) {
   assert(is_portable_mode(), "Use crac::restore() instead");
   precond(CRaCRestoreFrom != nullptr);
 
@@ -850,423 +839,39 @@ void crac::restore_heap(TRAPS) {
     }
   }
 
+  // Save the stacks for thread restoration
   precond(_stack_dump == nullptr);
   _stack_dump = stack_dump;
-}
-
-class vframeRestoreArrayElement : public vframeArrayElement {
- public:
-  void fill_in(const CracStackTrace::Frame &snapshot, bool reexecute) {
-    _method = snapshot.method();
-
-    _bci = snapshot.bci();
-    guarantee(_method->validate_bci(_bci) == _bci, "invalid bytecode index %i", _bci);
-
-    _reexecute = reexecute;
-
-    _locals = stack_values_from_frame(snapshot.locals());
-    _expressions = stack_values_from_frame(snapshot.operands());
-
-    // TODO add monitor info into the snapshot; for now assuming no monitors
-    _monitors = nullptr;
-    DEBUG_ONLY(_removed_monitors = false;)
-  }
-
- private:
-  static StackValueCollection *stack_values_from_frame(const GrowableArrayCHeap<CracStackTrace::Frame::Value, mtInternal> &src) {
-    auto *const stack_values = new StackValueCollection(src.length()); // size == 0 until we actually add the values
-    // Cannot use the array iterator as it creates copies and we cannot copy
-    // resolved reference values in this scope (it requires a Handle allocation)
-    for (int i = 0; i < src.length(); i++) {
-      const auto &src_value = *src.adr_at(i);
-      switch (src_value.type()) {
-        // At checkpoint this was either a T_INT or a T_CONFLICT StackValue,
-        // in the later case it should have been dumped as 0 for us
-        case CracStackTrace::Frame::Value::Type::PRIM: {
-          // We've checked that stack slot size of the dump equals ours (right
-          // after parsing), so the cast is safe
-          LP64_ONLY(const u8 val = src_value.as_primitive());  // Take the whole u8
-          NOT_LP64(const u4 val = src_value.as_primitive());   // Take the low half
-          const auto int_stack_slot = bit_cast<intptr_t>(val); // 4 or 8 byte slot depending on the platform
-          stack_values->add(new StackValue(int_stack_slot));
-          break;
-        }
-        // At checkpoint this was a T_OBJECT StackValue
-        case CracStackTrace::Frame::Value::Type::OBJ: {
-          const oop o = JNIHandles::resolve(src_value.as_obj());
-          // Unpacking code of vframeArrayElement expects a raw oop
-          stack_values->add(new StackValue(cast_from_oop<intptr_t>(o), T_OBJECT));
-          break;
-        }
-        default:
-          ShouldNotReachHere();
-      }
-    }
-    return stack_values;
-  }
-};
-
-class vframeRestoreArray : public vframeArray {
- public:
-  static vframeRestoreArray *allocate(const CracStackTrace &stack) {
-    guarantee(stack.frames_num() <= INT_MAX, "stack trace of thread " SDID_FORMAT " is too long: " UINT32_FORMAT " > %i",
-              stack.thread_id(), stack.frames_num(), INT_MAX);
-    auto *const result = reinterpret_cast<vframeRestoreArray *>(AllocateHeap(sizeof(vframeRestoreArray) + // fixed part
-                                                                             sizeof(vframeRestoreArrayElement) * (stack.frames_num() - 1), // variable part
-                                                                             mtInternal));
-    result->_frames = static_cast<int>(stack.frames_num());
-    result->set_unroll_block(nullptr); // The actual value should be set by the caller later
-
-    // We don't use these
-    result->_owner_thread = nullptr; // Would have been JavaThread::current()
-    result->_sender = frame();       // Will be the CallStub frame called before the restored frames
-    result->_caller = frame();       // Seems to be the same as _sender
-    result->_original = frame();     // Deoptimized frame which we don't have
-
-    result->fill_in(stack);
-    return result;
-  }
-
- private:
-  void fill_in(const CracStackTrace &stack) {
-    _frame_size = 0; // Unused (no frame is being deoptimized)
-
-    // vframeRestoreArray: the first frame is the youngest, the last is the oldest
-    // CracStackTrace:     the first frame is the oldest, the last is the youngest
-    log_trace(crac)("Filling stack trace for thread " SDID_FORMAT, stack.thread_id());
-    precond(frames() == checked_cast<int>(stack.frames_num()));
-    for (int i = 0; i < frames(); i++) {
-      log_trace(crac)("Filling frame %i", i);
-      auto *const elem = static_cast<vframeRestoreArrayElement *>(element(i));
-      // Note: youngest frame's BCI is always re-executed -- this is important
-      // because otherwise deopt's unpacking code will try to use ToS caching
-      // which we don't account for
-      elem->fill_in(stack.frame(frames() - 1 - i), /*reexecute when youngest*/ i == 0);
-      assert(!elem->method()->is_native(), "native methods are not restored");
-    }
-  }
-};
-
-// Called by RestoreBlob to get the info about the frames to restore. This is
-// analogous to Deoptimization::fetch_unroll_info() except that we fetch the
-// info from the stack snapshot instead of a deoptee frame. This is also a leaf
-// (in contrast with fetch_unroll_info) since no reallocation is needed (see the
-// comment before fetch_unroll_info).
-JRT_LEAF(Deoptimization::UnrollBlock *, crac::fetch_frame_info(JavaThread *current))
-  precond(current == JavaThread::current());
-  log_debug(crac)("Thread " UINTX_FORMAT ": fetching frame info", cast_from_oop<uintptr_t>(current->threadObj()));
-
-  // Heap-allocated resource mark to use resource-allocated StackValues
-  // and free them before starting executing the restored code
-  guarantee(current->deopt_mark() == nullptr, "No deopt should be pending");
-  current->set_deopt_mark(new DeoptResourceMark(current));
-
-  // Create vframe descriptions based on the stack snapshot -- no safepoint
-  // should happen after this array is filled until we're done with it
-  vframeRestoreArray *array;
-  {
-    const CracStackTrace *stack = _stack_dump->stack_traces().pop();
-    assert(stack->frames_num() > 0, "should be checked when just starting");
-    if (_stack_dump->stack_traces().is_empty()) {
-      delete _stack_dump;
-      _stack_dump = nullptr;
-    }
-
-    array = vframeRestoreArray::allocate(*stack);
-    postcond(array->frames() == static_cast<int>(stack->frames_num()));
-
-    delete stack;
-  }
-  postcond(array->frames() > 0);
-  log_debug(crac)("Thread " UINTX_FORMAT ": filled frame array (%i frames)",
-                  cast_from_oop<uintptr_t>(current->threadObj()), array->frames());
-
-  // Determine sizes and return pcs of the constructed frames.
-  //
-  // The order of frames is the reverse of the array above:
-  // frame_sizes and frame_pcs: 0th -- the oldest frame,   nth -- the youngest.
-  // vframeRestoreArray *array: 0th -- the youngest frame, nth -- the oldest.
-  auto *const frame_sizes = NEW_C_HEAP_ARRAY(intptr_t, array->frames(), mtInternal);
-  // +1 because the last element is an address to jump into the interpreter
-  auto *const frame_pcs = NEW_C_HEAP_ARRAY(address, array->frames() + 1, mtInternal);
-  // Create an interpreter return address for the assembly code to use as its
-  // return address so the skeletal frames are perfectly walkable
-  frame_pcs[array->frames()] = Interpreter::deopt_entry(vtos, 0);
-
-  // We start from the youngest frame, which has no callee
-  int callee_params = 0;
-  int callee_locals = 0;
-  for (int i = 0; i < array->frames(); i++) {
-    // Deopt code uses this to account for possible JVMTI's PopFrame function
-    // usage which is irrelevant in our case
-    static constexpr int popframe_extra_args = 0;
-
-    // i == 0 is the youngest frame, i == array->frames() - 1 is the oldest
-    frame_sizes[array->frames() - i - 1] =
-        BytesPerWord * array->element(i)->on_stack_size(callee_params, callee_locals, i == 0, popframe_extra_args);
-
-    frame_pcs[array->frames() - i - 1] = i < array->frames() - 1 ?
-    // Setting the pcs the same way as the deopt code does. It is needed to
-    // identify the skeleton frames as interpreted and make them walkable. The
-    // correct pcs will be patched later when filling the frames.
-                                         Interpreter::deopt_entry(vtos, 0) - frame::pc_return_offset :
-    // The oldest frame always returns to CallStub
-                                         StubRoutines::call_stub_return_address();
-
-    callee_params = array->element(i)->method()->size_of_parameters();
-    callee_locals = array->element(i)->method()->max_locals();
-  }
-
-  // Adjustment of the CallStub to accomodate the locals of the oldest restored
-  // frame, if any
-  const int caller_adjustment = Deoptimization::last_frame_adjust(callee_params, callee_locals);
-
-  auto *const info = new Deoptimization::UnrollBlock(
-    0,                           // Deoptimized frame size, unused (no frame is being deoptimized)
-    caller_adjustment * BytesPerWord,
-    0,                           // Amount of params in the CallStub frame, unused (known via the oldest frame's method)
-    array->frames(),
-    frame_sizes,
-    frame_pcs,
-    BasicType::T_ILLEGAL,        // Return type, unused (we are not in the process of returning a value)
-    Deoptimization::Unpack_deopt // fill_in_frames() always specifies Unpack_deopt, regardless of what's set here
-  );
-  array->set_unroll_block(info);
-
-  guarantee(current->vframe_array_head() == nullptr, "no deopt should be pending");
-  current->set_vframe_array_head(array);
-
-  return info;
-JRT_END
-
-// Called by RestoreBlob after skeleton frames have been pushed on stack to fill
-// them. This is analogous to Deoptimization::unpack_frames().
-JRT_LEAF(void, crac::fill_in_frames(JavaThread *current))
-  precond(current == JavaThread::current());
-  log_debug(crac)("Thread " UINTX_FORMAT ": filling skeletal frames", cast_from_oop<uintptr_t>(current->threadObj()));
-
-  // Reset NoHandleMark created by JRT_LEAF (see related comments in
-  // Deoptimization::unpack_frames() on why this is ok). Handles are used e.g.
-  // in trace printing.
-  ResetNoHandleMark rnhm;
-  HandleMark hm(current);
-
-  // Array created by crac::restore_thread_state()
-  vframeArray* array = current->vframe_array_head();
-  // Java frame between the skeleton frames and the frame of this function
-  frame unpack_frame = current->last_frame();
-  // Amount of parameters in the CallStub frame = amount of parameters of the
-  // oldest skeleton frame
-  int initial_caller_parameters = array->element(array->frames() - 1)->method()->size_of_parameters();
-
-  // TODO save, clear, restore last Java sp like the deopt code does?
-
-  assert(current->deopt_compiled_method() == nullptr, "no method is being deoptimized");
-  guarantee(current->frames_to_pop_failed_realloc() == 0,
-            "we don't deoptimize, so no reallocations of scalar replaced objects can happen and fail");
-  array->unpack_to_stack(unpack_frame, Deoptimization::Unpack_deopt /* TODO this or reexecute? */, initial_caller_parameters);
-  log_debug(crac)("Thread " UINTX_FORMAT": skeletal frames filled", cast_from_oop<uintptr_t>(current->threadObj()));
-
-  // Cleanup, analogous to Deoptimization::cleanup_deopt_info()
-  current->set_vframe_array_head(nullptr);
-  delete array->unroll_block(); // Also deletes frame_sizes and frame_pcs
-  delete array;
-  delete current->deopt_mark();
-  current->set_deopt_mark(nullptr);
-
-  // TODO more verifications, like the ones Deoptimization::unpack_frames() does
-  DEBUG_ONLY(current->validate_frame_layout();)
-JRT_END
-
-// Make this second-youngest frame the youngest faking the result of the
-// callee (i.e. the current youngest) frame.
-static void transform_to_youngest(CracStackTrace::Frame *frame, Handle callee_result) {
-  const Bytecodes::Code code = frame->method()->code_at(frame->bci());
-  assert(Bytecodes::is_invoke(code), "non-youngest frames stay must be invoking, got %s", Bytecodes::name(code));
-
-  // Push the result onto the operand stack
-  if (callee_result.not_null()) {
-    const auto operands_num = frame->operands().length();
-    assert(operands_num < frame->method()->max_stack(), "cannot push return value: all %i slots taken",
-           frame->method()->max_stack());
-    frame->operands().reserve(operands_num + 1); // Not bare append because it may allocate more than one slot
-    // FIXME append() creates a copy but accepts a reference so no copy elision can occur
-    frame->operands().append({}); // Cheap empty->empty copy, empty->empty swap
-    *frame->operands().adr_at(operands_num) = CracStackTrace::Frame::Value::of_obj(callee_result); // Cheap resolved->empty swap
-  }
-
-  // Increment the BCI past the invoke bytecode
-  const int code_len = Bytecodes::length_for(code);
-  assert(code_len > 0, "invoke codes don't need special length calculation");
-  frame->set_bci(frame->bci() + code_len);
-  assert(frame->method()->validate_bci(frame->bci()) >= 0, "transformed to invalid BCI %i", frame->bci());
-}
-
-// If the youngest frame represents special method requiring a fixup, applies
-// the fixup. If all frames get popped, the return value is returned.
-static JavaValue fixup_youngest_frame_if_special(CracStackTrace *stack, TRAPS) {
-  precond(stack->frames_num() > 0);
-
-  const Method &youngest_m = *stack->frame(stack->frames_num() - 1).method();
-  if (!youngest_m.is_native()) { // Only native methods are special
-    return {};
-  }
-  const InstanceKlass &holder = *youngest_m.method_holder();
-
-  if (holder.name() == vmSymbols::jdk_crac_Core() && holder.class_loader_data()->is_the_null_class_loader_data() &&
-      youngest_m.name() == vmSymbols::checkpointRestore0_name()) { // Checkpoint initiation method
-    // Pop the native frame
-    stack->pop();
-
-    // Create the return value indicating the successful restoration
-    HandleMark hm(Thread::current()); // The handle will either become an oop or a JNI handle
-    const Handle bundle_h = ret_cr(JVM_CHECKPOINT_OK, Handle(), Handle(), Handle(), Handle(), CHECK_({}));
-
-    if (stack->frames_num() == 0) {
-      // No Java caller (e.g. called from JNI), return the value directly
-      precond(bundle_h->is_array());
-      JavaValue bundle_jv(T_ARRAY);
-      bundle_jv.set_oop(bundle_h());
-      return bundle_jv;
-    }
-
-    // Push the return value onto the caller's operand stack
-    CracStackTrace::Frame &caller = stack->frame(stack->frames_num() - 1);
-    transform_to_youngest(&caller, bundle_h);
-  } else {
-    assert(!youngest_m.is_native(), "only special native methods can be restored");
-  }
-
-  return {};
-}
-
-// Fills the provided arguments with null-values according to the provided
-// signature.
-class NullArgumentsFiller : public SignatureIterator {
- public:
-  NullArgumentsFiller(Symbol *signature, JavaCallArguments *args) : SignatureIterator(signature), _args(args) {
-    precond(args->size_of_parameters() == 0);
-    do_parameters_on(this);
-  }
-
- private:
-  JavaCallArguments *_args;
-
-  friend class SignatureIterator;  // so do_parameters_on can call do_type
-
-  void do_type(BasicType type) {
-    switch (type) {
-      case T_BYTE:
-      case T_BOOLEAN:
-      case T_CHAR:
-      case T_SHORT:
-      case T_INT:    _args->push_int(0);        break;
-      case T_FLOAT:  _args->push_float(0);      break;
-      case T_LONG:   _args->push_long(0);       break;
-      case T_DOUBLE: _args->push_double(0);     break;
-      case T_ARRAY:
-      case T_OBJECT: _args->push_oop(Handle()); break;
-      default:       ShouldNotReachHere();
-    }
-  }
-};
-
-
-// Initiates thread restoration and won't return until the restored execution
-// completes. Returns the result of the execution. If the stack was empty, the
-// result will have type T_ILLEGAL.
-//
-// The process of thread restoration is as follows:
-// 1. This method is called to make a Java-call to the initial method (the
-// oldest one in the stack) with the snapshotted arguments, replacing its entry
-// point with an entry into assembly restoration code (RestoreBlob).
-// 2. Java-call places a CallStub frame for the initial method and calls
-// RestoreBlob.
-// 3. RestoreBlob calls crac::fetch_frame_info() which prepares restoration info
-// based on the stack snapshot. This cannot be perfomed directly in step 1:
-// a safepoint can occur on step 2 which the prepared data won't survive.
-// 4. RestoreBlob reads the prepared restoration info and creates so-called
-// skeletal frames which are walkable interpreter frames of proper sizes but
-// with monitors, locals, expression stacks, etc. unfilled.
-// 5. RestoreBlob calls crac::fill_in_frames() which also reads the prepared
-// restoration info and fills the skeletal frames.
-// 6. RestoreBlob jumps into the interpreter to start executing the youngest
-// restored stack frame.
-JavaValue crac::restore_current_thread(TRAPS) {
-  precond(!_stack_dump->stack_traces().is_empty());
-  JavaThread *const current = JavaThread::current();
-  if (log_is_enabled(Info, crac)) {
-    ResourceMark rm;
-    log_info(crac)("Thread " UINTX_FORMAT " (%s): starting the restoration",
-                   cast_from_oop<uintptr_t>(current->threadObj()), current->name());
-  }
-
-  // If the stack is empty there is nothing to restore
-  // TODO should this be considered an error?
-  CracStackTrace *const stack = _stack_dump->stack_traces().last();
-  if (stack->frames_num() == 0) {
-    log_info(crac)("Thread " UINTX_FORMAT ": no frames in stack snapshot (ID " SDID_FORMAT ")",
-                    cast_from_oop<uintptr_t>(current->threadObj()), stack->thread_id());
-    _stack_dump->stack_traces().pop();
-    if (_stack_dump->stack_traces().is_empty()) {
-      delete _stack_dump;
-      _stack_dump = nullptr;
-    }
-    delete stack;
-    return {};
-  }
-
-  { // Check if there are special frames requiring fixup, this may pop some frames
-    const JavaValue result = fixup_youngest_frame_if_special(stack, CHECK_({}));
-    if (stack->frames_num() == 0) {
-      assert(result.get_type() != T_ILLEGAL, "return value must be initialized");
-      log_info(crac)("Thread " UINTX_FORMAT ": all frames have been popped as special",
-                     cast_from_oop<uintptr_t>(current->threadObj()));
-      delete stack;
-      return result;
-    }
-  }
-
-  const CracStackTrace::Frame &oldest_frame = stack->frame(0);
-  Method *const method = oldest_frame.method();
-
-  JavaCallArguments args;
-  // The actual values will be filled by the RestoreStub, we just need the Java
-  // call code to allocate the right amount of space
-  // TODO tell Java call the required size directly without generating the
-  // actual arguments like this
-  NullArgumentsFiller(method->signature(), &args);
-  // Make the CallStub call RestoreStub instead of the actual method entry
-  args.set_use_restore_stub(true);
-
-  if (log_is_enabled(Info, crac)) {
-    ResourceMark rm;
-    log_debug(crac)("Thread " UINTX_FORMAT ": restoration starts from %s",
-                    cast_from_oop<uintptr_t>(current->threadObj()), method->external_name());
-  }
-  JavaValue result(method->result_type());
-  JavaCalls::call(&result, methodHandle(current, method), &args, CHECK_({}));
-  // The stack snapshot has been freed already by now
-
-  log_info(crac)("Thread " UINTX_FORMAT ": restored execution completed",
-                 cast_from_oop<uintptr_t>(current->threadObj()));
-  return result;
 }
 
 void crac::restore_threads(TRAPS) {
   assert(is_portable_mode(), "use crac::restore() instead");
   precond(CRaCRestoreFrom != nullptr);
   assert(_stack_dump != nullptr, "call crac::restore_heap() first");
+  assert(java_lang_Thread::thread_id(JavaThread::current()->threadObj()) == 1, "must be called on the main thread");
 
-  // TODO for now we only restore the main thread
-  assert(_stack_dump->stack_traces().length() == 1, "expected only a single (main) thread to be dumped");
-#ifdef ASSERT
-  {
-    ResourceMark rm; // Thread name
-    assert(java_lang_Thread::threadGroup(JavaThread::current()->threadObj()) == Universe::main_thread_group() &&
-           strcmp(JavaThread::current()->name(), "main") == 0, "must be called on the main thread");
+  // The main thread is the first one in the dump (if it's there at all)
+  CracStackTrace *main_stack_trace = nullptr;
+  if (_stack_dump->stack_traces().is_nonempty()) {
+    CracStackTrace *const first_stack_trace = _stack_dump->stack_traces().first();
+    const oop first_thread_obj = JNIHandles::resolve_non_null(first_stack_trace->thread());
+    if (first_thread_obj == JavaThread::current()->threadObj()) {
+      main_stack_trace = first_stack_trace;
+      _stack_dump->stack_traces().delete_at(0); // Efficient but changes the order of stack traces
+    }
   }
-#endif // ASSERT
-  JavaValue result = restore_current_thread(CHECK);
-  log_info(crac)("main thread execution resulted in type: %s", type2name(result.get_type()));
+
+  while (_stack_dump->stack_traces().is_nonempty()) {
+    CracStackTrace *const stack_trace = _stack_dump->stack_traces().pop();
+    CracThreadRestorer::prepare_thread(stack_trace, CHECK);
+  }
+
+  delete _stack_dump; // Is empty by now
+  _stack_dump = nullptr;
+
+  CracThreadRestorer::start_prepared_threads();
+
+  if (main_stack_trace != nullptr) {
+    CracThreadRestorer::restore_current_thread(main_stack_trace, CHECK);
+  }
 }

--- a/src/hotspot/share/runtime/crac.hpp
+++ b/src/hotspot/share/runtime/crac.hpp
@@ -26,9 +26,7 @@
 
 #include "memory/allStatic.hpp"
 #include "runtime/cracStackDumpParser.hpp"
-#include "runtime/deoptimization.hpp"
 #include "runtime/handles.hpp"
-#include "runtime/javaThread.hpp"
 #include "utilities/exceptions.hpp"
 
 // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -45,6 +43,9 @@ public:
   // Restore in the classic mode.
   static void restore();
 
+  static Handle cr_return(int ret, Handle new_args, Handle new_props,
+                          Handle err_codes, Handle err_msgs, TRAPS);
+
   static jlong restore_start_time();
   static jlong uptime_since_restore();
 
@@ -60,14 +61,10 @@ public:
   // Portable mode
 
   // Restores classes and objects.
-  static void restore_heap(TRAPS);
-  // Restores thread states and launches their execution. Should only be called
-  // once, after restore_heap() has been called.
+  static void restore_data(TRAPS);
+  // Launches execution of all threads, returns when the current thread finishes
+  // its restored execution (if any).
   static void restore_threads(TRAPS);
-  // Called by RestoreStub to prepare information about frames to restore.
-  static Deoptimization::UnrollBlock *fetch_frame_info(JavaThread *current);
-  // Called by RestoreStub to fill in the skeletal frames just created.
-  static void fill_in_frames(JavaThread *current);
 
 private:
   static bool read_bootid(char *dest);
@@ -76,8 +73,6 @@ private:
   static jlong checkpoint_nanos;
   static char checkpoint_bootid[UUID_LENGTH];
   static jlong javaTimeNanos_offset;
-
-  static JavaValue restore_current_thread(TRAPS);
 
   static ParsedCracStackDump *_stack_dump;
 };

--- a/src/hotspot/share/runtime/cracHeapRestorer.hpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.hpp
@@ -112,6 +112,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
 
   void find_and_record_class_mirror(const HeapDump::ClassDump &class_dump, TRAPS);
   void record_class_mirror(instanceHandle mirror, const HeapDump::InstanceDump &mirror_dump, TRAPS);
+  void record_main_thread(const GrowableArrayView<CracStackTrace *> &stack_traces);
 
   void set_field(instanceHandle obj, const FieldStream &fs, const HeapDump::BasicValue &val, TRAPS);
 #define set_instance_field_if_special_signature(name) \
@@ -119,6 +120,7 @@ class CracHeapRestorer : public ClassLoaderProvider {
   using set_instance_field_if_special_ptr_t = set_instance_field_if_special_signature((CracHeapRestorer::*));
   set_instance_field_if_special_signature(set_class_loader_instance_field_if_special);
   set_instance_field_if_special_signature(set_class_mirror_instance_field_if_special);
+  set_instance_field_if_special_signature(set_thread_instance_field_if_special);
   set_instance_field_if_special_signature(set_string_instance_field_if_special);
   set_instance_field_if_special_signature(set_member_name_instance_field_if_special);
   set_instance_field_if_special_signature(set_call_site_instance_field_if_special);

--- a/src/hotspot/share/runtime/cracStackDumper.hpp
+++ b/src/hotspot/share/runtime/cracStackDumper.hpp
@@ -53,7 +53,8 @@
 enum DumpedStackValueType : u1 { PRIMITIVE, REFERENCE };
 
 // Dumps Java frames (until the first CallStub) of non-internal Java threads.
-// Dumped IDs are oops to be compatible with HeapDumper's object IDs.
+// Threads are dumped in the order they were created (oldest first), dumped IDs
+// are oops to be compatible with HeapDumper's object IDs.
 struct CracStackDumper : public AllStatic {
   class Result {
    public:

--- a/src/hotspot/share/runtime/cracThreadRestorer.cpp
+++ b/src/hotspot/share/runtime/cracThreadRestorer.cpp
@@ -1,0 +1,487 @@
+#include "precompiled.hpp"
+#include "classfile/javaClasses.hpp"
+#include "classfile/vmSymbols.hpp"
+#include "interpreter/interpreter.hpp"
+#include "jvm.h"
+#include "logging/log.hpp"
+#include "memory/allocation.hpp"
+#include "memory/resourceArea.hpp"
+#include "oops/instanceKlass.hpp"
+#include "oops/method.hpp"
+#include "oops/symbol.hpp"
+#include "runtime/crac.hpp"
+#include "runtime/cracStackDumpParser.hpp"
+#include "runtime/cracThreadRestorer.hpp"
+#include "runtime/deoptimization.hpp"
+#include "runtime/frame.hpp"
+#include "runtime/handles.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/javaCalls.hpp"
+#include "runtime/jniHandles.hpp"
+#include "runtime/jniHandles.inline.hpp"
+#include "runtime/mutexLocker.hpp"
+#include "runtime/semaphore.hpp"
+#include "runtime/signature.hpp"
+#include "runtime/stackValue.hpp"
+#include "runtime/stackValueCollection.hpp"
+#include "runtime/stubRoutines.hpp"
+#include "runtime/vframeArray.hpp"
+#include "utilities/bitCast.hpp"
+#include "utilities/debug.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/growableArray.hpp"
+#include "utilities/macros.hpp"
+
+uint CracThreadRestorer::_prepared_threads_num = 0;
+Semaphore *CracThreadRestorer::_start_semaphore = nullptr;
+
+static jlong log_tid(const JavaThread *thread) {
+  return java_lang_Thread::thread_id(thread->threadObj());
+}
+
+void CracThreadRestorer::start_prepared_threads() {
+  if (_prepared_threads_num == 0) {
+    return; // No threads to start
+  }
+  assert(_start_semaphore != nullptr, "must be");
+  _start_semaphore->signal(_prepared_threads_num);
+  _prepared_threads_num = 0;
+}
+
+// Same jlong -> size_t conversion as JVM_StartThread performs.
+static size_t get_stack_size(oop thread_obj) {
+  const jlong raw_stack_size = java_lang_Thread::stackSize(thread_obj);
+  if (raw_stack_size <= 0) {
+    return 0;
+  }
+#ifndef  _LP64
+  if (raw_stack_size > SIZE_MAX) {
+    return SIZE_MAX;
+  }
+#endif // _LP64
+  return checked_cast<size_t>(raw_stack_size);
+}
+
+void CracThreadRestorer::prepare_thread(CracStackTrace *stack, TRAPS) {
+  if (_start_semaphore == nullptr) {
+    assert(_prepared_threads_num == 0, "must be");
+    _start_semaphore = new Semaphore(0);
+  }
+
+  const jobject thread_obj = stack->thread();
+
+  // Prepare a JavaThread in the same fashion as JVM_StartThread does
+  JavaThread *thread;
+  {
+    MutexLocker ml(Threads_lock);
+    const size_t stack_size = get_stack_size(JNIHandles::resolve_non_null(thread_obj));
+    thread = new JavaThread(&prepared_thread_entry, stack_size);
+    if (thread->osthread() != nullptr) {
+      HandleMark hm(JavaThread::current());
+      thread->prepare(thread_obj);
+    }
+  }
+  if (thread->osthread() == nullptr) {
+    thread->smr_delete();
+    THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), os::native_thread_creation_failed_msg());
+  }
+
+  _prepared_threads_num++;
+
+  // Make the stack available to the restoration code (the thread now owns it)
+  thread->set_crac_stack(stack);
+
+  // The thread will wait for the start signal
+  Thread::start(thread);
+}
+
+// Wait for the start signal from the creator thread before starting.
+void CracThreadRestorer::prepared_thread_entry(JavaThread *current, TRAPS) {
+  log_debug(crac)("Thread " JLONG_FORMAT ": waiting for start signal", log_tid(current));
+  _start_semaphore->wait();
+  restore_current_thread_impl(current, CHECK);
+}
+
+void CracThreadRestorer::restore_current_thread(CracStackTrace *stack, TRAPS) {
+  JavaThread *const current = JavaThread::current();
+  assert(JNIHandles::resolve_non_null(stack->thread()) == current->threadObj(), "wrong stack trace");
+  current->set_crac_stack(stack); // Restoration code expects it there
+  restore_current_thread_impl(current, CHECK);
+}
+
+// Make this second-youngest frame the youngest faking the result of the
+// callee (i.e. the current youngest) frame.
+static void transform_to_youngest(CracStackTrace::Frame *frame, Handle callee_result) {
+  const Bytecodes::Code code = frame->method()->code_at(frame->bci());
+  assert(Bytecodes::is_invoke(code), "non-youngest frames stay must be invoking, got %s", Bytecodes::name(code));
+
+  // Push the result onto the operand stack
+  if (callee_result.not_null()) {
+    const auto operands_num = frame->operands().length();
+    assert(operands_num < frame->method()->max_stack(), "cannot push return value: all %i slots taken",
+           frame->method()->max_stack());
+    frame->operands().reserve(operands_num + 1); // Not bare append because it may allocate more than one slot
+    // FIXME append() creates a copy but accepts a reference so no copy elision can occur
+    frame->operands().append({}); // Cheap empty->empty copy, empty->empty swap
+    *frame->operands().adr_at(operands_num) = CracStackTrace::Frame::Value::of_obj(callee_result); // Cheap resolved->empty swap
+  }
+
+  // Increment the BCI past the invoke bytecode
+  const int code_len = Bytecodes::length_for(code);
+  assert(code_len > 0, "invoke codes don't need special length calculation");
+  frame->set_bci(frame->bci() + code_len);
+  assert(frame->method()->validate_bci(frame->bci()) >= 0, "transformed to invalid BCI %i", frame->bci());
+}
+
+// If the youngest frame represents special method requiring a fixup, applies
+// the fixup.
+static void fixup_youngest_frame_if_special(CracStackTrace *stack, TRAPS) {
+  if (stack->frames_num() == 0) {
+    return;
+  }
+
+  const Method &youngest_m = *stack->frame(stack->frames_num() - 1).method();
+  if (!youngest_m.is_native()) { // Only native methods are special
+    return;
+  }
+  const InstanceKlass &holder = *youngest_m.method_holder();
+
+  if (holder.name() == vmSymbols::jdk_crac_Core() && holder.class_loader_data()->is_the_null_class_loader_data() &&
+      youngest_m.name() == vmSymbols::checkpointRestore0_name()) { // Checkpoint initiation method
+    // Pop the native frame
+    stack->pop();
+
+    if (stack->frames_num() == 0) {
+      return; // No Java caller (e.g. called from JNI)
+    }
+
+    // Create the return value indicating the successful restoration
+    HandleMark hm(Thread::current()); // The handle will either become an oop or a JNI handle
+    const Handle bundle_h = crac::cr_return(JVM_CHECKPOINT_OK, {}, {}, {}, {}, CHECK);
+
+    // Push the return value onto the caller's operand stack
+    CracStackTrace::Frame &caller = stack->frame(stack->frames_num() - 1);
+    transform_to_youngest(&caller, bundle_h);
+  } else {
+    assert(!youngest_m.is_native(), "only special native methods can be restored");
+  }
+}
+
+// Fills the provided arguments with null-values according to the provided
+// signature.
+class NullArgumentsFiller : public SignatureIterator {
+  friend class SignatureIterator;  // so do_parameters_on can call do_type
+ public:
+  NullArgumentsFiller(Symbol *signature, JavaCallArguments *args) : SignatureIterator(signature), _args(args) {
+    do_parameters_on(this);
+  }
+
+ private:
+  JavaCallArguments *_args;
+
+  void do_type(BasicType type) {
+    switch (type) {
+      case T_BYTE:
+      case T_BOOLEAN:
+      case T_CHAR:
+      case T_SHORT:
+      case T_INT:    _args->push_int(0);        break;
+      case T_FLOAT:  _args->push_float(0);      break;
+      case T_LONG:   _args->push_long(0);       break;
+      case T_DOUBLE: _args->push_double(0);     break;
+      case T_ARRAY:
+      case T_OBJECT: _args->push_oop(Handle()); break;
+      default:       ShouldNotReachHere();
+    }
+  }
+};
+
+// Initiates thread restoration and won't return until the restored execution
+// completes.
+//
+// The process of thread restoration is as follows:
+// 1. This method is called to make a Java-call to the initial method (the
+// oldest one in the stack) with the snapshotted arguments, replacing its entry
+// point with an entry into assembly restoration code (RestoreBlob).
+// 2. Java-call places a CallStub frame for the initial method and calls
+// RestoreBlob.
+// 3. RestoreBlob calls fetch_frame_info() which prepares restoration info based
+// on the stack snapshot. This cannot be perfomed directly in step 1: a
+// safepoint can occur on step 2 which the prepared data won't survive.
+// 4. RestoreBlob reads the prepared restoration info and creates so-called
+// skeletal frames which are walkable interpreter frames of proper sizes but
+// with monitors, locals, expression stacks, etc. unfilled.
+// 5. RestoreBlob calls fill_in_frames() which also reads the prepared
+// restoration info and fills the skeletal frames.
+// 6. RestoreBlob jumps into the interpreter to start executing the youngest
+// restored stack frame.
+void CracThreadRestorer::restore_current_thread_impl(JavaThread *current, TRAPS) {
+  assert(current == JavaThread::current(), "must be");
+  if (log_is_enabled(Info, crac)) {
+    ResourceMark rm;
+    log_info(crac)("Thread " JLONG_FORMAT " (%s): starting restoration", log_tid(current), current->name());
+  }
+
+  // Get the stack trace to restore
+  CracStackTrace *stack = current->crac_stack();
+  assert(stack != nullptr, "no stack to restore");
+
+  // Check if there are special frames requiring fixup, this may pop some frames
+  fixup_youngest_frame_if_special(stack, CHECK);
+
+  // Early return if empty: stack restoration does not account for this corner case
+  if (stack->frames_num() == 0) {
+    log_info(crac)("Thread " JLONG_FORMAT ": no frames to restore", log_tid(current));
+    delete stack;
+    current->set_crac_stack(nullptr);
+    return;
+  }
+
+  const CracStackTrace::Frame &oldest_frame = stack->frame(0);
+  Method *const method = oldest_frame.method();
+
+  JavaCallArguments args;
+  // Need to set the receiver (if any): it will be read during the Java call
+  if (!method->is_static()) {
+    guarantee(oldest_frame.locals().is_nonempty(), "must have 'this' as the first local");
+    const CracStackTrace::Frame::Value &receiver = oldest_frame.locals().first();
+    args.set_receiver(Handle(current, JNIHandles::resolve_non_null(receiver.as_obj())));
+  }
+  // The actual values will be filled by the RestoreStub, we just need the Java
+  // call code to allocate the right amount of space
+  NullArgumentsFiller(method->signature(), &args);
+  // Make the CallStub call RestoreStub instead of the actual method entry
+  args.set_use_restore_stub(true);
+
+  if (log_is_enabled(Info, crac)) {
+    ResourceMark rm;
+    log_debug(crac)("Thread " JLONG_FORMAT ": calling %s", log_tid(current), method->external_name());
+  }
+  JavaValue result(method->result_type());
+  JavaCalls::call(&result, methodHandle(current, method), &args, CHECK);
+  // The stack snapshot has been freed already by now
+
+  log_info(crac)("Thread " JLONG_FORMAT ": restored execution completed", log_tid(current));
+}
+
+class vframeRestoreArrayElement : public vframeArrayElement {
+ public:
+  void fill_in(const CracStackTrace::Frame &snapshot, bool reexecute) {
+    _method = snapshot.method();
+
+    _bci = snapshot.bci();
+    guarantee(_method->validate_bci(_bci) == _bci, "invalid bytecode index %i", _bci);
+
+    _reexecute = reexecute;
+
+    _locals = stack_values_from_frame(snapshot.locals());
+    _expressions = stack_values_from_frame(snapshot.operands());
+
+    // TODO add monitor info into the snapshot; for now assuming no monitors
+    _monitors = nullptr;
+    DEBUG_ONLY(_removed_monitors = false;)
+  }
+
+ private:
+  static StackValueCollection *stack_values_from_frame(const GrowableArrayCHeap<CracStackTrace::Frame::Value, mtInternal> &src) {
+    auto *const stack_values = new StackValueCollection(src.length()); // size == 0 until we actually add the values
+    // Cannot use the array iterator as it creates copies and we cannot copy
+    // resolved reference values in this scope (it requires a Handle allocation)
+    for (int i = 0; i < src.length(); i++) {
+      const auto &src_value = *src.adr_at(i);
+      switch (src_value.type()) {
+        // At checkpoint this was either a T_INT or a T_CONFLICT StackValue,
+        // in the later case it should have been dumped as 0 for us
+        case CracStackTrace::Frame::Value::Type::PRIM: {
+          // We've checked that stack slot size of the dump equals ours (right
+          // after parsing), so the cast is safe
+          LP64_ONLY(const u8 val = src_value.as_primitive());  // Take the whole u8
+          NOT_LP64(const u4 val = src_value.as_primitive());   // Take the low half
+          const auto int_stack_slot = bit_cast<intptr_t>(val); // 4 or 8 byte slot depending on the platform
+          stack_values->add(new StackValue(int_stack_slot));
+          break;
+        }
+        // At checkpoint this was a T_OBJECT StackValue
+        case CracStackTrace::Frame::Value::Type::OBJ: {
+          const oop o = JNIHandles::resolve(src_value.as_obj()); // May be null
+          // Unpacking code of vframeArrayElement expects a raw oop
+          stack_values->add(new StackValue(cast_from_oop<intptr_t>(o), T_OBJECT));
+          break;
+        }
+        default:
+          ShouldNotReachHere();
+      }
+    }
+    return stack_values;
+  }
+};
+
+class vframeRestoreArray : public vframeArray {
+ public:
+  static vframeRestoreArray *allocate(const CracStackTrace &stack) {
+    guarantee(stack.frames_num() <= INT_MAX, "stack trace of thread " SDID_FORMAT " is too long: " UINT32_FORMAT " > %i",
+              stack.thread_id(), stack.frames_num(), INT_MAX);
+    auto *const result = reinterpret_cast<vframeRestoreArray *>(AllocateHeap(sizeof(vframeRestoreArray) + // fixed part
+                                                                             sizeof(vframeRestoreArrayElement) * (stack.frames_num() - 1), // variable part
+                                                                             mtInternal));
+    result->_frames = static_cast<int>(stack.frames_num());
+    result->set_unroll_block(nullptr); // The actual value should be set by the caller later
+
+    // We don't use these
+    result->_owner_thread = nullptr; // Would have been JavaThread::current()
+    result->_sender = frame();       // Will be the CallStub frame called before the restored frames
+    result->_caller = frame();       // Seems to be the same as _sender
+    result->_original = frame();     // Deoptimized frame which we don't have
+
+    result->fill_in(stack);
+    return result;
+  }
+
+ private:
+  void fill_in(const CracStackTrace &stack) {
+    _frame_size = 0; // Unused (no frame is being deoptimized)
+    const JavaThread *current = log_is_enabled(Trace, crac) ? JavaThread::current() : nullptr;
+
+    // vframeRestoreArray: the first frame is the youngest, the last is the oldest
+    // CracStackTrace:     the first frame is the oldest, the last is the youngest
+    log_trace(crac)("Thread " JLONG_FORMAT ": filling stack trace " SDID_FORMAT, log_tid(current), stack.thread_id());
+    precond(frames() == checked_cast<int>(stack.frames_num()));
+    for (int i = 0; i < frames(); i++) {
+      log_trace(crac)("Thread " JLONG_FORMAT ": filling frame %i", log_tid(current), i);
+      auto *const elem = static_cast<vframeRestoreArrayElement *>(element(i));
+      // Note: youngest frame's BCI is always re-executed -- this is important
+      // because otherwise deopt's unpacking code will try to use ToS caching
+      // which we don't account for
+      elem->fill_in(stack.frame(frames() - 1 - i), /*reexecute when youngest*/ i == 0);
+      assert(!elem->method()->is_native(), "native methods are not restored");
+    }
+  }
+};
+
+// Called by RestoreBlob to get the info about the frames to restore. This is
+// analogous to Deoptimization::fetch_unroll_info() except that we fetch the
+// info from the stack snapshot instead of a deoptee frame. This is also a leaf
+// (in contrast with fetch_unroll_info) since no reallocation is needed (see the
+// comment before fetch_unroll_info).
+JRT_LEAF(Deoptimization::UnrollBlock *, CracThreadRestorer::fetch_frame_info(JavaThread *current))
+  precond(current == JavaThread::current());
+  log_debug(crac)("Thread " JLONG_FORMAT ": fetching frame info", log_tid(current));
+
+  // Heap-allocated resource mark to use resource-allocated StackValues
+  // and free them before starting executing the restored code
+  guarantee(current->deopt_mark() == nullptr, "No deopt should be pending");
+  current->set_deopt_mark(new DeoptResourceMark(current));
+
+  // Create vframe descriptions based on the stack snapshot -- no safepoint
+  // should happen after this array is filled until we're done with it
+  vframeRestoreArray *array;
+  {
+    const CracStackTrace *stack = current->crac_stack();
+    assert(stack->frames_num() > 0, "should be checked when starting");
+
+    array = vframeRestoreArray::allocate(*stack);
+    postcond(array->frames() == static_cast<int>(stack->frames_num()));
+
+    delete stack;
+    current->set_crac_stack(nullptr);
+  }
+  postcond(array->frames() > 0);
+  log_trace(crac)("Thread " JLONG_FORMAT ": filled frame array (%i frames)", log_tid(current), array->frames());
+
+  // Determine sizes and return pcs of the constructed frames.
+  //
+  // The order of frames is the reverse of the array above:
+  // frame_sizes and frame_pcs: 0th -- the oldest frame,   nth -- the youngest.
+  // vframeRestoreArray *array: 0th -- the youngest frame, nth -- the oldest.
+  auto *const frame_sizes = NEW_C_HEAP_ARRAY(intptr_t, array->frames(), mtInternal);
+  // +1 because the last element is an address to jump into the interpreter
+  auto *const frame_pcs = NEW_C_HEAP_ARRAY(address, array->frames() + 1, mtInternal);
+  // Create an interpreter return address for the assembly code to use as its
+  // return address so the skeletal frames are perfectly walkable
+  frame_pcs[array->frames()] = Interpreter::deopt_entry(vtos, 0);
+
+  // We start from the youngest frame, which has no callee
+  int callee_params = 0;
+  int callee_locals = 0;
+  for (int i = 0; i < array->frames(); i++) {
+    // Deopt code uses this to account for possible JVMTI's PopFrame function
+    // usage which is irrelevant in our case
+    static constexpr int popframe_extra_args = 0;
+
+    // i == 0 is the youngest frame, i == array->frames() - 1 is the oldest
+    frame_sizes[array->frames() - i - 1] =
+        BytesPerWord * array->element(i)->on_stack_size(callee_params, callee_locals, i == 0, popframe_extra_args);
+
+    frame_pcs[array->frames() - i - 1] = i < array->frames() - 1 ?
+    // Setting the pcs the same way as the deopt code does. It is needed to
+    // identify the skeleton frames as interpreted and make them walkable. The
+    // correct pcs will be patched later when filling the frames.
+                                         Interpreter::deopt_entry(vtos, 0) - frame::pc_return_offset :
+    // The oldest frame always returns to CallStub
+                                         StubRoutines::call_stub_return_address();
+
+    callee_params = array->element(i)->method()->size_of_parameters();
+    callee_locals = array->element(i)->method()->max_locals();
+  }
+
+  // Adjustment of the CallStub to accomodate the locals of the oldest restored
+  // frame, if any
+  const int caller_adjustment = Deoptimization::last_frame_adjust(callee_params, callee_locals);
+
+  auto *const info = new Deoptimization::UnrollBlock(
+    0,                           // Deoptimized frame size, unused (no frame is being deoptimized)
+    caller_adjustment * BytesPerWord,
+    0,                           // Amount of params in the CallStub frame, unused (known via the oldest frame's method)
+    array->frames(),
+    frame_sizes,
+    frame_pcs,
+    BasicType::T_ILLEGAL,        // Return type, unused (we are not in the process of returning a value)
+    Deoptimization::Unpack_deopt // fill_in_frames() always specifies Unpack_deopt, regardless of what's set here
+  );
+  array->set_unroll_block(info);
+
+  guarantee(current->vframe_array_head() == nullptr, "no deopt should be pending");
+  current->set_vframe_array_head(array);
+
+  log_debug(crac)("Thread " JLONG_FORMAT ": frame info fetched", log_tid(current));
+  return info;
+JRT_END
+
+// Called by RestoreBlob after skeleton frames have been pushed on stack to fill
+// them. This is analogous to Deoptimization::unpack_frames().
+JRT_LEAF(void, CracThreadRestorer::fill_in_frames(JavaThread *current))
+  precond(current == JavaThread::current());
+  log_debug(crac)("Thread " JLONG_FORMAT ": filling skeletal frames", log_tid(current));
+
+  // Reset NoHandleMark created by JRT_LEAF (see related comments in
+  // Deoptimization::unpack_frames() on why this is ok). Handles are used e.g.
+  // in trace printing.
+  ResetNoHandleMark rnhm;
+  HandleMark hm(current);
+
+  // Array created by fetch_frame_info()
+  vframeArray *const array = current->vframe_array_head();
+  // Java frame between the skeleton frames and the frame of this function
+  const frame unpack_frame = current->last_frame();
+  // Amount of parameters in the CallStub frame = amount of parameters of the
+  // oldest skeleton frame
+  const int initial_caller_parameters = array->element(array->frames() - 1)->method()->size_of_parameters();
+
+  // TODO save, clear, restore last Java sp like the deopt code does?
+
+  assert(current->deopt_compiled_method() == nullptr, "no method is being deoptimized");
+  guarantee(current->frames_to_pop_failed_realloc() == 0,
+            "we don't deoptimize, so no reallocations of scalar replaced objects can happen and fail");
+  array->unpack_to_stack(unpack_frame, Deoptimization::Unpack_deopt /* TODO this or reexecute? */, initial_caller_parameters);
+  log_debug(crac)("Thread " JLONG_FORMAT ": skeletal frames filled", log_tid(current));
+
+  // Cleanup, analogous to Deoptimization::cleanup_deopt_info()
+  current->set_vframe_array_head(nullptr);
+  delete array->unroll_block(); // Also deletes frame_sizes and frame_pcs
+  delete array;
+  delete current->deopt_mark();
+  current->set_deopt_mark(nullptr);
+
+  // TODO more verifications, like the ones Deoptimization::unpack_frames() does
+  DEBUG_ONLY(current->validate_frame_layout();)
+JRT_END

--- a/src/hotspot/share/runtime/cracThreadRestorer.hpp
+++ b/src/hotspot/share/runtime/cracThreadRestorer.hpp
@@ -1,0 +1,40 @@
+#ifndef SHARE_RUNTIME_CRACTHREADRESTORER_HPP
+#define SHARE_RUNTIME_CRACTHREADRESTORER_HPP
+
+#include "memory/allStatic.hpp"
+#include "runtime/cracStackDumpParser.hpp"
+#include "runtime/deoptimization.hpp"
+#include "runtime/javaThread.hpp"
+#include "runtime/semaphore.hpp"
+#include "utilities/exceptions.hpp"
+
+// Thread restoration for CRaC's portable mode.
+//
+// It is intended to be used as follows:
+// 1. A pre-existing Java thread (typically the main thread) initiates
+//    restoration of other threads.
+// 2. The pre-existing thread restores its own execution.
+class CracThreadRestorer : public AllStatic {
+ public:
+  // Creates a new JavaThread and prepares it to restore its saved execution.
+  static void prepare_thread(CracStackTrace *stack, TRAPS);
+  // Starts execution of all threads that have been prepared.
+  static void start_prepared_threads();
+
+  // Restores the provided execution on the current thread.
+  static void restore_current_thread(CracStackTrace *stack, TRAPS);
+
+  // Called by RestoreStub to prepare information about frames to restore.
+  static Deoptimization::UnrollBlock *fetch_frame_info(JavaThread *current);
+  // Called by RestoreStub to fill in the skeletal frames just created.
+  static void fill_in_frames(JavaThread *current);
+
+ private:
+  static uint _prepared_threads_num;
+  static Semaphore *_start_semaphore;
+
+  static void prepared_thread_entry(JavaThread *current, TRAPS);
+  static void restore_current_thread_impl(JavaThread *current, TRAPS);
+};
+
+#endif // SHARE_RUNTIME_CRACTHREADRESTORER_HPP

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -413,6 +413,7 @@ JavaThread::JavaThread() :
   _callee_target(nullptr),
   _vm_result(nullptr),
   _vm_result_2(nullptr),
+  _crac_stack(nullptr),
 
   _current_pending_monitor(nullptr),
   _current_pending_monitor_is_from_java(true),

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -73,6 +73,8 @@ class vframeArray;
 class vframe;
 class javaVFrame;
 
+class CracStackTrace;
+
 class JavaThread;
 typedef void (*ThreadFunction)(JavaThread*, TRAPS);
 
@@ -142,6 +144,9 @@ class JavaThread: public Thread {
   // Used to pass back results to the interpreter or generated code running Java code.
   oop           _vm_result;    // oop result is GC-preserved
   Metadata*     _vm_result_2;  // non-oop result
+
+  // Portable CRaC support
+  CracStackTrace *_crac_stack; // Stack trace to be restored on this thread
 
   // See ReduceInitialCardMarks: this holds the precise space interval of
   // the most recent slow path allocation for which compiled code has
@@ -699,6 +704,9 @@ private:
   void set_vm_result  (oop x)                    { _vm_result   = x; }
 
   void set_vm_result_2  (Metadata* x)            { _vm_result_2   = x; }
+
+  CracStackTrace *crac_stack()                   { return _crac_stack; }
+  void set_crac_stack(CracStackTrace *stack)     { precond(_crac_stack == nullptr || stack == nullptr); _crac_stack = stack; }
 
   MemRegion deferred_card_mark() const           { return _deferred_card_mark; }
   void set_deferred_card_mark(MemRegion mr)      { _deferred_card_mark = mr;   }

--- a/src/hotspot/share/runtime/notificationThread.hpp
+++ b/src/hotspot/share/runtime/notificationThread.hpp
@@ -41,7 +41,7 @@ class NotificationThread : public JavaThread {
 
  public:
   static void initialize();
-
+  bool is_Notification_thread() const override { return true; }
 };
 
 #endif // SHARE_RUNTIME_NOTIFICATIONTHREAD_HPP

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -323,6 +323,7 @@ class Thread: public ThreadShadow {
   virtual bool is_JfrSampler_thread() const          { return false; }
   virtual bool is_AttachListener_thread() const      { return false; }
   virtual bool is_monitor_deflation_thread() const   { return false; }
+  virtual bool is_Notification_thread() const        { return false; }
 
   // Can this thread make Java upcalls
   virtual bool can_call_java() const                 { return false; }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -838,16 +838,11 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   }
 
   // Perform portable CRaC restore if requested
-  // TODO do this somewhere earlier?
-  // - Cannot do before initPhase2 because can only load java.base classes until
-  //   then (but a dump can occure until then because AttachListener::init() can
-  //   be called and listen for jcmd commands)
-  // - Integrate into initPhase3 to restore system class loader and
-  //   security manager (currently we rely on them to be created for us)
+  // TODO do this before any Java code is executed
   if (CRaCRestoreFrom != nullptr && crac::is_portable_mode()) {
     // TODO honor CRaCIgnoreRestoreIfUnavailable (will have to differentiate
     // between errors and exceptions)
-    crac::restore_heap(CHECK_JNI_ERR);
+    crac::restore_data(CHECK_JNI_ERR);
   }
 
   return JNI_OK;

--- a/src/hotspot/share/utilities/heapDumpClasses.hpp
+++ b/src/hotspot/share/utilities/heapDumpClasses.hpp
@@ -81,6 +81,28 @@ struct HeapDumpClasses : public AllStatic {
   };
 
 
+#define THREAD_DUMP_FIELDS_DO(macro)                                                                                                         \
+  macro(java_lang_Thread, tid, "tid", T_LONG, jlong, long)                                                                                   \
+  macro(java_lang_Thread, name, vmSymbols::name_name(), T_OBJECT, HeapDump::ID, object_id)                                                   \
+  macro(java_lang_Thread, holder, "holder", T_OBJECT, HeapDump::ID, object_id)                                                               \
+  macro(java_lang_Thread, inheritedAccessControlContext, vmSymbols::inheritedAccessControlContext_name(), T_OBJECT, HeapDump::ID, object_id)
+
+  class java_lang_Thread {
+   private:
+    u4 _id_size = 0;
+    THREAD_DUMP_FIELDS_DO(DEFINE_OFFSET_FIELD)
+    DEBUG_ONLY(HeapDump::ID _java_lang_Thread_id = HeapDump::NULL_ID);
+
+   public:
+    void ensure_initialized(const ParsedHeapDump &heap_dump, HeapDump::ID thread_class_id);
+
+    THREAD_DUMP_FIELDS_DO(DECLARE_GET_FIELD_METHOD)
+
+   private:
+    bool is_initialized() const { return _id_size > 0; }
+  };
+
+
 #define STRING_DUMP_FIELDS_DO(macro)                                                            \
   macro(java_lang_String, is_interned, vmSymbols::is_interned_name(), T_BOOLEAN, bool, boolean)
 

--- a/test/jdk/jdk/crac/portable/Threads.java
+++ b/test/jdk/jdk/crac/portable/Threads.java
@@ -1,0 +1,93 @@
+import jdk.crac.Core;
+
+import java.util.Random;
+
+/**
+ * Demonstrates threads restoration.
+ * <p>
+ * How to run:
+ * <pre>
+ * {@code
+ * $ java -XX:CREngine= -XX:CRaCCheckpointTo=cr Threads.java
+ * > My thread #2: in initial state
+ * > ...
+ * > My thread #9: in initial state
+ * > Checkpointing
+ * > ...
+ *
+ * $ java -XX:CREngine= -XX:CRaCRestoreFrom=cr
+ * > Restored
+ * > My thread #4: in initial state
+ * > ...
+ * > My thread #3: in initial state
+ * > Changing states
+ * > Changed state of My thread #0
+ * > ...
+ * > Changed state of My thread #9
+ * > My thread #2: in new state (2)
+ * > ...
+ * > My thread #3: in new state (3)
+ * }
+ * </pre>
+ */
+public class Threads {
+    static final Random random = new Random();
+
+    // TODO replace with wait() when it's supported
+    static String work(double period) {
+        double x = random.nextDouble();
+        for (double y = -period / 2; y < period / 2; y++) {
+            x += (y / 2) % x;
+        }
+        return x % 2 == 0 ? "" : " "; // Blackhole
+    }
+
+    public static void main(String[] args) throws Exception {
+        String blackhole;
+
+        // Start some threads
+        final var threads = new MyThread[10];
+        for (int i = 0; i < threads.length; i++) {
+            final var t = new MyThread(i);
+            t.start();
+            threads[i] = t;
+        }
+
+        // Waste some time to let the threads print something concurrently
+        blackhole = work(70_000_000);
+
+        System.out.println("Checkpointing" + blackhole);
+        Core.checkpointRestore();
+        System.out.println("Restored");
+
+        // Waste some time to let the threads print something concurrently again
+        blackhole = work(70_000_000);
+        System.out.println("Changing states" + blackhole);
+
+        // Change threads' state to check the objects we have are the actual
+        // handles to the restored threads
+        for (int i = 0; i < threads.length; i++) {
+            final MyThread t = threads[i];
+            t.strToPrint = "in new state (" + i + ")";
+            System.out.println("Changed state of " + t.getName());
+        }
+        work(70_000_000);
+    }
+}
+
+class MyThread extends Thread {
+    String strToPrint = "in initial state";
+
+    MyThread(int num) {
+        super("My thread #" + num);
+        setDaemon(true);
+    }
+
+    @Override
+    public void run() {
+      while (true) {
+        Threads.work(50_000_000);
+        System.out.println(getName() + ": " + strToPrint);
+      }
+    }
+}


### PR DESCRIPTION
Implements restoration of multiple threads (until now only `main` was being restored).

Limitations (they are all caused by the fact that for now classes and objects created early by the VM are not restored):
- Main (aka primordial) thread is treated specially: its Java object is pre-created by the VM so it is not restored (but recorded as such together with some of its fields so that they aren't duplicated), it is also the thread that performs the restoration
- Threads created early by the VM are not restored even if they are visible from Java (e.g. `Finalizer` and `Reference Handler`) because they are also pre-created, additionally, they are not recorded since they are harder to identify so if they are referenced from a restored object they will be duplicated as non-alive Java thread objects

These limitations should be lifted when restoration of all Java classes and objects gets implemented.