### PR TITLE
Jetty demo

### DIFF
--- a/src/hotspot/share/runtime/cracStackDumper.cpp
+++ b/src/hotspot/share/runtime/cracStackDumper.cpp
@@ -1,5 +1,6 @@
 #include "precompiled.hpp"
 #include "classfile/javaClasses.hpp"
+#include "classfile/vmIntrinsics.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "interpreter/bytecodes.hpp"
 #include "logging/log.hpp"
@@ -149,9 +150,12 @@ class ThreadStackStream : public StackObj {
   static bool is_special_native_method(const Method &m) {
     precond(m.is_native());
     const InstanceKlass &holder = *m.method_holder();
-    return holder.name() == vmSymbols::jdk_crac_Core() &&
-           holder.class_loader_data()->is_the_null_class_loader_data() &&
-           m.name() == vmSymbols::checkpointRestore0_name();
+    return // CRaC's C/R method
+           (holder.name() == vmSymbols::jdk_crac_Core() &&
+            holder.class_loader_data()->is_the_null_class_loader_data() &&
+            m.name() == vmSymbols::checkpointRestore0_name()) ||
+           // Unsafe.park(...)
+           m.intrinsic_id() == vmIntrinsics::_park;
   }
 };
 

--- a/src/hotspot/share/runtime/cracStackDumper.cpp
+++ b/src/hotspot/share/runtime/cracStackDumper.cpp
@@ -211,8 +211,8 @@ class StackDumpWriter : public StackObj {
       //  1. For interpreted frame, is it always right to re-execute?
       //  2. For compiled frame, is exec_mode used by deoptimization to decide
       //     on re-execution also important for us here?
-      if (i == 0 && frame.is_compiled_frame() && !static_cast<const compiledVFrame &>(frame).should_reexecute()) {
-        assert(!frame.method()->is_native(), "native methods are not compiled");
+      if (i == 0 && !frame.method()->is_native() &&
+          frame.is_compiled_frame() && !static_cast<const compiledVFrame &>(frame).should_reexecute()) {
         const int code_len = Bytecodes::length_at(frame.method(), frame.method()->bcp_from(frame.bci()));
         log_trace(crac, stacktrace, dump)("moving BCI: %i -> %i", bci, bci + code_len);
         assert(bci + code_len <= UINT16_MAX, "overflow");

--- a/src/java.base/share/classes/java/net/Inet6Address.java
+++ b/src/java.base/share/classes/java/net/Inet6Address.java
@@ -31,6 +31,12 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
 import java.util.Enumeration;
+
+import jdk.crac.Core;
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.JDKResource;
+
 import java.util.Arrays;
 
 /**
@@ -368,8 +374,23 @@ class Inet6Address extends InetAddress {
     @java.io.Serial
     private static final long serialVersionUID = 6880410070516793377L;
 
+    private static final JDKResource nativeInitResource;
+
     // Perform native initialization
-    static { init(); }
+    static {
+        init();
+        nativeInitResource = new JDKResource() {
+            @Override
+            public void beforeCheckpoint(Context<? extends Resource> context) {
+            };
+
+            @Override
+            public void afterRestore(Context<? extends Resource> context) {
+                init();
+            };
+        };
+        Core.getGlobalContext().register(nativeInitResource);
+    }
 
     Inet6Address() {
         super();

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -414,6 +414,8 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
 
             @Override
             public void afterRestore(Context<? extends Resource> context) throws Exception {
+                jdk.internal.loader.BootLoader.loadLibrary("net");
+                init();
             }
         };
         Core.Priority.NORMAL.getContext().register(checkpointListener);

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -31,6 +31,10 @@ import java.io.FileDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.ref.Reference;
 import java.util.Objects;
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.Core;
+import jdk.internal.crac.JDKResource;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.ScopedMemoryAccess.ScopedAccessError;
 import jdk.internal.misc.VM;
@@ -102,7 +106,7 @@ class Direct$Type$Buffer$RW$$BO$
 
     }
 
-    private final Cleaner cleaner;
+    private Cleaner cleaner;
 
     public Cleaner cleaner() { return cleaner; }
 
@@ -116,11 +120,12 @@ class Direct$Type$Buffer$RW$$BO$
 
 #if[byte]
 
-    // Primary constructor
-    //
-    Direct$Type$Buffer$RW$(int cap) {                   // package-private
 #if[rw]
-        super(-1, 0, cap, cap, null);
+
+    private final JDKResource resource;
+
+    private void allocate() {
+        int cap = capacity();
         boolean pa = VM.isDirectMemoryPageAligned();
         int ps = Bits.pageSize();
         long size = Math.max(1L, (long)cap + (pa ? ps : 0));
@@ -148,7 +153,40 @@ class Direct$Type$Buffer$RW$$BO$
             Bits.unreserveMemory(size, cap);
             throw t;
         }
+    }
+
+#end[rw]
+
+    // Primary constructor
+    //
+    Direct$Type$Buffer$RW$(int cap) {                   // package-private
+#if[rw]
+        super(-1, 0, cap, cap, null);
+        allocate();
         att = null;
+
+        resource = new JDKResource() {
+            private byte[] buf;
+
+            @Override
+            public void beforeCheckpoint(Context<? extends Resource> context) {
+                buf = new byte[cap];
+                getArray(0, buf, 0, cap);
+                cleaner.clean();
+                cleaner = null;
+                address = 0; // Simplifies debugging
+            };
+
+            @Override
+            public void afterRestore(Context<? extends Resource> context) {
+                allocate();
+                putArray(0, buf, 0, cap);
+                buf = null;
+            };
+        };
+        // Must have a priority higher than that of file descriptors because
+        // file descriptor policies are read from such buffer
+        Core.Priority.POST_FILE_DESCRIPTORS.getContext().register(resource);
 #else[rw]
         super(cap);
         this.isReadOnly = true;
@@ -164,6 +202,7 @@ class Direct$Type$Buffer$RW$$BO$
         super(-1, 0, cap, cap, segment);
         address = addr;
         cleaner = null;
+        resource = null;
         att = ob;
     }
 
@@ -174,6 +213,7 @@ class Direct$Type$Buffer$RW$$BO$
         super(-1, 0, cap, cap, fd, isSync, segment);
         address = addr;
         cleaner = null;
+        resource = null;
         att = ob;
     }
 
@@ -184,6 +224,7 @@ class Direct$Type$Buffer$RW$$BO$
         super(-1, 0, checkCapacity(cap), (int)cap, null);
         address = addr;
         cleaner = null;
+        resource = null;
         att = null;
     }
 
@@ -216,6 +257,7 @@ class Direct$Type$Buffer$RW$$BO$
         super(-1, 0, cap, cap, fd, isSync, segment);
         address = addr;
         cleaner = Cleaner.create(this, unmapper);
+        resource = null; // TODO probably also need to do something
         att = null;
 #else[rw]
         super(cap, addr, fd, unmapper, isSync, segment);
@@ -243,6 +285,7 @@ class Direct$Type$Buffer$RW$$BO$
         address = ((Buffer)db).address + off;
 #if[byte]
         cleaner = null;
+        resource = null;
 #end[byte]
         Object attachment = db.attachment();
         att = (attachment == null ? db : attachment);

--- a/src/java.base/share/classes/java/nio/X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/X-Buffer.java.template
@@ -943,7 +943,7 @@ public abstract sealed class $Type$Buffer
         return get(index, dst, 0, dst.length);
     }
 
-    private $Type$Buffer getArray(int index, $type$[] dst, int offset, int length) {
+    $Type$Buffer getArray(int index, $type$[] dst, int offset, int length) {
         if (
 #if[char]
             isAddressable() &&

--- a/src/java.base/share/classes/jdk/internal/crac/Core.java
+++ b/src/java.base/share/classes/jdk/internal/crac/Core.java
@@ -57,6 +57,7 @@ public class Core {
      * Most resources should use priority NORMAL (the lowest priority).
      */
     public enum Priority {
+        POST_FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         PRE_FILE_DESCRIPTORS(new BlockingOrderedContext<>()),
         CLEANERS(new BlockingOrderedContext<>()),

--- a/src/java.base/share/classes/sun/nio/ch/IOVecWrapper.java
+++ b/src/java.base/share/classes/sun/nio/ch/IOVecWrapper.java
@@ -65,9 +65,6 @@ class IOVecWrapper {
     // Shadow buffers for cases when original buffer is substituted
     private final ByteBuffer[] shadow;
 
-    // Base address of this array
-    final long address;
-
     // Address size in bytes
     static int addressSize;
 
@@ -91,7 +88,6 @@ class IOVecWrapper {
         this.remaining = new int[size];
         this.shadow    = new ByteBuffer[size];
         this.vecArray  = new AllocatedNativeObject(size * SIZE_IOVEC, false);
-        this.address   = vecArray.address();
     }
 
     static IOVecWrapper get(int size) {
@@ -107,6 +103,13 @@ class IOVecWrapper {
             cached.set(wrapper);
         }
         return wrapper;
+    }
+
+    /**
+     * Base address of this array.
+     */
+    long address() {
+        return vecArray.address(); // Can change because of checkpoint-restore
     }
 
     void setBuffer(int i, ByteBuffer buf, int pos, int rem) {

--- a/src/java.base/share/classes/sun/nio/ch/NativeObject.java
+++ b/src/java.base/share/classes/sun/nio/ch/NativeObject.java
@@ -49,7 +49,7 @@ class NativeObject {                                    // package-private
 
     // Native base address
     //
-    private final long address;
+    protected long address;
 
     /**
      * Creates a new native object that is based at the given native address.
@@ -70,17 +70,7 @@ class NativeObject {                                    // package-private
 
     // Invoked only by AllocatedNativeObject
     //
-    protected NativeObject(int size, boolean pageAligned) {
-        if (!pageAligned) {
-            this.allocationAddress = unsafe.allocateMemory(size);
-            this.address = this.allocationAddress;
-        } else {
-            int ps = pageSize();
-            long a = unsafe.allocateMemory(size + ps);
-            this.allocationAddress = a;
-            this.address = a + ps - (a & (ps - 1));
-        }
-    }
+    protected NativeObject() {}
 
     /**
      * Returns the native base address of this native object.

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -50,6 +50,10 @@ import java.security.PrivilegedAction;
 import java.util.Enumeration;
 import java.util.Objects;
 
+import jdk.crac.Core;
+import jdk.crac.Context;
+import jdk.crac.Resource;
+import jdk.internal.crac.JDKResource;
 import sun.net.ext.ExtendedSocketOptions;
 import sun.net.util.IPAddressUtil;
 import sun.security.action.GetPropertyAction;
@@ -794,6 +798,8 @@ public class Net {
 
     private static native void initIDs();
 
+    private static final JDKResource nativeInitResource;
+
     /**
      * Event masks for the various poll system calls.
      * They will be set platform dependent in the static initializer below.
@@ -815,6 +821,17 @@ public class Net {
     static {
         IOUtil.load();
         initIDs();
+        nativeInitResource = new JDKResource() {
+            @Override
+            public void beforeCheckpoint(Context<? extends Resource> context) {
+            };
+
+            @Override
+            public void afterRestore(Context<? extends Resource> context) {
+                initIDs();
+            };
+        };
+        Core.getGlobalContext().register(nativeInitResource);
 
         POLLIN     = pollinValue();
         POLLOUT    = polloutValue();


### PR DESCRIPTION
This PR contains fixes needed for [the Jetty example](https://github.com/CRaC/example-jetty) to work in the portable mode.

Two additional changes to the example itself are required:
1. As not all threads are currently restored (e.g. the thread handling `jcmd` is not), checkpoint must be created from a user-started thread or `main`. The easiest solution is to call C/R from `main`:
   ```java
   public static void main( String[] args ) throws Exception {
        serverManager = new ServerManager(8080, new App());
        Thread.sleep(10_000);     // New: allows to use the server before C/R
        Core.checkpointRestore(); // New: call C/R in main
        serverManager.server.join();
    }
   ```
2. Unlike CRIU, portable mode does not re-open any file descriptors, even the ones from the class path, so to achieve behavior similar to CRIU `-Djdk.crac.resource-policies=policies.yaml` should always be passed with `policies.yaml` specifying `reopen` for all files in the class path, e.g.:
   ```yaml
   type: file
   path: **/*.jar
   action: reopen
   ```
   does so for all JARs.