### PR TITLE
Restoration of monitors

### DIFF
--- a/src/hotspot/share/runtime/cracHeapRestorer.cpp
+++ b/src/hotspot/share/runtime/cracHeapRestorer.cpp
@@ -531,6 +531,8 @@ void CracHeapRestorer::restore_heap(const HeapDumpTable<UnfilledClassInfo, AnyOb
       const u2 num_locals = frame.locals().length();
       for (u2 loc_i = 0; loc_i < num_locals; loc_i++) {
         CracStackTrace::Frame::Value &value = *frame.locals().adr_at(loc_i);
+        assert(value.type() == CracStackTrace::Frame::Value::Type::PRIM ||
+               value.type() == CracStackTrace::Frame::Value::Type::REF, "must be");
         if (value.type() == CracStackTrace::Frame::Value::Type::REF) {
           const Handle obj = restore_object(value.as_obj_id(), CHECK);
           value = CracStackTrace::Frame::Value::of_obj(obj);
@@ -539,10 +541,19 @@ void CracHeapRestorer::restore_heap(const HeapDumpTable<UnfilledClassInfo, AnyOb
       const u2 num_operands = frame.operands().length();
       for (u2 op_i = 0; op_i < num_operands; op_i++) {
         CracStackTrace::Frame::Value &value = *frame.operands().adr_at(op_i);
+        assert(value.type() == CracStackTrace::Frame::Value::Type::PRIM ||
+               value.type() == CracStackTrace::Frame::Value::Type::REF, "must be");
         if (value.type() == CracStackTrace::Frame::Value::Type::REF) {
           const Handle obj = restore_object(value.as_obj_id(), CHECK);
           value = CracStackTrace::Frame::Value::of_obj(obj);
         }
+      }
+      const int num_monitors = frame.monitor_owners().length();
+      for (int mon_i = 0; mon_i < num_monitors; mon_i++) {
+        CracStackTrace::Frame::Value &monitor_owner = *frame.monitor_owners().adr_at(mon_i);
+        assert(monitor_owner.type() == CracStackTrace::Frame::Value::Type::REF, "must be");
+        const Handle obj = restore_object(monitor_owner.as_obj_id(), CHECK);
+        monitor_owner = CracStackTrace::Frame::Value::of_obj(obj);
       }
     }
   }

--- a/src/hotspot/share/runtime/cracStackDumpParser.hpp
+++ b/src/hotspot/share/runtime/cracStackDumpParser.hpp
@@ -92,11 +92,14 @@ class CracStackTrace : public CHeapObj<mtInternal> {
     u2 bci() const                              { return _bci; }
     void set_bci(u2 bci)                        { _bci = bci;  }
 
-    const GrowableArrayCHeap<Value, mtInternal> &locals() const   { return _locals; }
-    GrowableArrayCHeap<Value, mtInternal> &locals()               { return _locals; }
+    const GrowableArrayCHeap<Value, mtInternal> &locals() const         { return _locals; }
+    GrowableArrayCHeap<Value, mtInternal> &locals()                     { return _locals; }
 
-    const GrowableArrayCHeap<Value, mtInternal> &operands() const { return _operands; }
-    GrowableArrayCHeap<Value, mtInternal> &operands()             { return _operands; }
+    const GrowableArrayCHeap<Value, mtInternal> &operands() const       { return _operands; }
+    GrowableArrayCHeap<Value, mtInternal> &operands()                   { return _operands; }
+
+    const GrowableArrayCHeap<Value, mtInternal> &monitor_owners() const { return _monitor_owners; }
+    GrowableArrayCHeap<Value, mtInternal> &monitor_owners()             { return _monitor_owners; }
 
    private:
     ID _method_name_id;
@@ -109,6 +112,7 @@ class CracStackTrace : public CHeapObj<mtInternal> {
 
     GrowableArrayCHeap<Value, mtInternal> _locals;
     GrowableArrayCHeap<Value, mtInternal> _operands;
+    GrowableArrayCHeap<Value, mtInternal> _monitor_owners;
   };
 
   CracStackTrace(ID thread_id, u4 frames_num)

--- a/src/hotspot/share/runtime/cracStackDumper.hpp
+++ b/src/hotspot/share/runtime/cracStackDumper.hpp
@@ -45,9 +45,9 @@
 //     Operand stack, from oldest to youngest:
 //       u1    -- type (same as for locals)
 //       u1... -- value (same as for locals)
-//     u2 -- number of monitors that follow
-//     Monitor infos:
-//       TODO describe the monitor info format
+//     u4 -- number of monitors that follow
+//     Monitors:
+//       ID    -- ID of the object owning the monitor
 
 // Types of dumped locals and operands.
 enum DumpedStackValueType : u1 { PRIMITIVE, REFERENCE };

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -120,7 +120,7 @@ javaVFrame* vframe::java_sender() const {
 
 // ------------- javaVFrame --------------
 
-GrowableArray<MonitorInfo*>* javaVFrame::locked_monitors() {
+GrowableArray<MonitorInfo*>* javaVFrame::locked_monitors() const {
   assert(SafepointSynchronize::is_at_safepoint() || JavaThread::current() == thread(),
          "must be at safepoint or it's a java frame of the current thread");
 

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -135,7 +135,7 @@ class javaVFrame: public vframe {
   }
 
   // Return an array of monitors locked by this frame in the youngest to oldest order
-  GrowableArray<MonitorInfo*>* locked_monitors();
+  GrowableArray<MonitorInfo*>* locked_monitors() const;
 
   // printing used during stack dumps and diagnostics
   static void print_locked_object_class_name(outputStream* st, Handle obj, const char* lock_state);

--- a/src/hotspot/share/utilities/barrier.cpp
+++ b/src/hotspot/share/utilities/barrier.cpp
@@ -1,0 +1,22 @@
+#include "precompiled.hpp"
+#include "runtime/atomic.hpp"
+#include "utilities/barrier.hpp"
+
+void Barrier::arrive() {
+  // Increment the number of threads arrived
+  Atomic::inc(&_num_threads_ready);
+
+  assert(_num_threads_ready <= _num_threads_total,
+         "too many threads arrived: " UINT32_FORMAT " > " UINT32_FORMAT,
+         _num_threads_ready, _num_threads_total);
+
+  if (_num_threads_ready == _num_threads_total) {
+    // All threads have arrived, wake up the waiting ones.
+    // Note: this code can be called by multiple threads, not only the last one,
+    // so the semaphore counter can reach up to num_threads_total^2.
+    _sem.signal(_num_threads_total);
+  } else {
+    // Wait for more threads to arrive
+    _sem.wait();
+  }
+}

--- a/src/hotspot/share/utilities/barrier.hpp
+++ b/src/hotspot/share/utilities/barrier.hpp
@@ -1,0 +1,27 @@
+#ifndef SHARE_UTILITIES_BARRIER_HPP
+#define SHARE_UTILITIES_BARRIER_HPP
+
+#include "memory/allocation.hpp"
+#include "runtime/semaphore.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+// Allows an arbitrary amount of threads to wait for each other before
+// proceeding past the barrier.
+//
+// The barrier is not reusable: once the specified number of threads have
+// arrived it should not be used anymore.
+//
+// Before deleting the barrier make sure all threads have left its methods.
+class Barrier : public CHeapObj<mtInternal> {
+ public:
+  explicit Barrier(uint num_threads) : _num_threads_total(num_threads) {};
+
+  void arrive();
+
+ private:
+  const uint _num_threads_total;
+  volatile uint _num_threads_ready = 0;
+  Semaphore _sem{0};
+};
+
+#endif // SHARE_UTILITIES_BARRIER_HPP

--- a/src/java.base/share/classes/jdk/crac/Core.java
+++ b/src/java.base/share/classes/jdk/crac/Core.java
@@ -284,8 +284,7 @@ public class Core {
             RestoreException {
         // checkpointRestoreLock protects against the simultaneous
         // call of checkpointRestore from different threads.
-        // TODO uncomment when portable CRaC becomes able to restore monitors
-        // synchronized (checkpointRestoreLock) {
+        synchronized (checkpointRestoreLock) {
             // checkpointInProgress protects against recursive
             // checkpointRestore from resource's
             // beforeCheckpoint/afterRestore methods
@@ -304,7 +303,7 @@ public class Core {
                 }
                 checkpointInProgress = false;
             }
-        // }
+        }
     }
 
     /* called by VM */

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -491,6 +491,7 @@ jdk/crac/java/lang/System/NanoTimeTest.java               14 linux-i586
 jdk/crac/java/lang/System/TimedWaitingTest.java           14 linux-i586
 jdk/crac/java/lang/Thread/JoinSleepWaitOnCRPauseTest.java 14 linux-i586
 jdk/crac/java/net/InetAddress/ResolveTest.java            14 linux-i586
+jdk/crac/recursiveCheckpoint/Test.java                    14 macosx-x64
 jdk/crac/SecureRandom/InterlockTest.java                  14 linux-i586
 jdk/crac/SecureRandom/ReseedTest.java                     14 linux-i586
 jdk/crac/Selector/interruptedSelection/Test.java          14 linux-i586

--- a/test/jdk/jdk/crac/portable/Monitors.java
+++ b/test/jdk/jdk/crac/portable/Monitors.java
@@ -1,0 +1,79 @@
+import jdk.crac.Core;
+
+/**
+ * Restoration of monitor states.
+ *
+ * <p> Creates a monitor shared between two threads. The main thread enters the
+ * monitor and initiates C/R while the secondary thread is blocked. After the
+ * restoration it remains blocked until the main thread exits the monitor.
+ *
+ * <p> How to run:
+ * <pre> {@code
+ * $ java -XX:CREngine= -XX:CRaCCheckpointTo=cr Monitors.java
+ * > Thread[#1,main,5,main]: before synchronized
+ * > Thread[#1,main,5,main]: inside synchronized
+ * > Thread[#25,secondary,5,main]: before synchronized
+ * > Thread[#1,main,5,main]: checkpointing
+ * > # Checkpoint occurs
+ * > # ... (the rest of the output omitted)
+ *
+ * $ java -XX:CREngine= -XX:CRaCRestoreFrom=cr
+ * > Thread[#1,main,5,main]: restored
+ * > Thread[#1,main,5,main]: deeply synchronized
+ * > Thread[#1,main,5,main]: leaving synchronized
+ * > Thread[#1,main,5,main]: after synchronized
+ * > Thread[#25,secondary,5,main]: inside synchronized
+ * > Thread[#25,secondary,5,main]: deeply synchronized
+ * > Thread[#25,secondary,5,main]: leaving synchronized
+ * > Thread[#25,secondary,5,main]: after synchronized
+ * } </pre>
+ */
+public class Monitors {
+    private static final Object sharedMonitor = new Object();
+
+    private static void primaryThreadEntry() throws Exception {
+        final Thread secondary = new Thread(Monitors::secondaryThreadEntry, "secondary");
+
+        final String threadStr = Thread.currentThread().toString();
+        System.out.println(threadStr + ": before synchronized");
+        synchronized(sharedMonitor) {
+            System.out.println(threadStr + ": inside synchronized");
+            secondary.start();
+            synchronized(sharedMonitor) {
+                System.out.println(threadStr + ": checkpointing");
+                Core.checkpointRestore();
+                System.out.println(threadStr + ": restored");
+                Thread.sleep(1000); // Let the secondary thread wake up
+                synchronized(sharedMonitor) {
+                    System.out.println(threadStr + ": deeply synchronized");
+                }
+            }
+            System.out.println(threadStr + ": leaving synchronized");
+        }
+        System.out.println(threadStr + ": after synchronized");
+
+        // TODO currently when the restored main thread dies the whole VM dies
+        secondary.join();
+    }
+
+    private static void secondaryThreadEntry() {
+        final String threadStr = Thread.currentThread().toString();
+        System.out.println(threadStr + ": before synchronized");
+        synchronized(sharedMonitor) {
+            System.out.println(threadStr + ": inside synchronized");
+            synchronized(sharedMonitor) {
+                synchronized(sharedMonitor) {
+                    synchronized(sharedMonitor) {
+                        System.out.println(threadStr + ": deeply synchronized");
+                    }
+                }
+            }
+            System.out.println(threadStr + ": leaving synchronized");
+        }
+        System.out.println(threadStr + ": after synchronized");
+    }
+
+    public static void main(String[] args) throws Exception {
+        primaryThreadEntry();
+    }
+}

--- a/test/jdk/jdk/crac/recursiveCheckpoint/Test.java
+++ b/test/jdk/jdk/crac/recursiveCheckpoint/Test.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @library /test/lib
  * @build Test
  * @run driver/timeout=60 jdk.test.lib.crac.CracTest 10
- * @ignore C/R monitor guarding from recursive checkpoints is temporarily removed due to absence of support in portable mode.
  */
 public class Test implements Resource, CracTest {
     private static final AtomicInteger counter = new AtomicInteger(0);


### PR DESCRIPTION
Adds support for monitors to portable C/R.

Entered monitors are saved to stack dump. At restore time each thread enters all monitors from its stack snapshot, then threads wait for each other to finish restoring before starting executing Java code.

Things left for later:
1. Threads blocked trying to enter a synchronized method cannot currently be restored. This requires a special feature from the deoptimization code which is currently only enabled when JVM CI is used. Should be easy to fix by removing the corresponding `#if INCLUDE_JVMCI`, `if (EnableJVMCI)`, etc.
2. `Object.wait()` is not supported yet. Waiting is implemented in a native method where the monitor is temporarily exited in a special way that is not reflected in the thread's stack state. Will need to extend the image to be able to differentiate between waiting/non-waiting thread states (by saving either the state to thread dump or monitor owners to HPROF).
3. Currently monitors are always restored as heavyweight even if lightweight would be sufficient. It is actually a limitation of the deoptimization code which needs to be changed.